### PR TITLE
feat: cache quantifier regexes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ base64 = "0.22"
 url = "2.5"
 sha2 = "0.10"
 futures = "0.3"
+once_cell = "1.19"
 
 [profile.release]
 lto = true

--- a/crates/helix-embeddings/Cargo.toml
+++ b/crates/helix-embeddings/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 license = "Apache-2.0"
 description = "Vector embeddings and semantic search for Helix platform"
 repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
-description = "Vector embeddings and similarity search for Helix"
 
 [dependencies]
 helix-core = { path = "../helix-core" }

--- a/crates/helix-llm/Cargo.toml
+++ b/crates/helix-llm/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 license = "Apache-2.0"
 description = "Large language model integration for Helix platform"
 repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
-description = "LLM integration and natural language processing for Helix agents"
 
 [dependencies]
 helix-core = { path = "../helix-core" }
@@ -23,6 +22,7 @@ reqwest = { workspace = true }
 # hf-hub = { workspace = true }       # Commented out for now
 # tokenizers = { workspace = true }   # Commented out for now
 regex = { workspace = true }
+once_cell = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 uuid = { workspace = true }

--- a/crates/helix-llm/src/intent_lattice.rs
+++ b/crates/helix-llm/src/intent_lattice.rs
@@ -1,0 +1,61 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Cached regex for universal quantifiers.
+///
+/// Matches common universal quantifier words such as "all", "every", "each" and "any".
+static UNIVERSAL_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)\b(all|every|each|any)\b").expect("valid universal regex"));
+
+/// Cached regex for existential quantifiers.
+///
+/// Matches common existential quantifier words such as "some", "any", "exists", "a" and "an".
+static EXISTENTIAL_REGEX: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"(?i)\b(some|any|exists|a|an)\b").expect("valid existential regex"));
+
+/// Types of quantifiers that can be detected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Quantifier {
+    /// Represents universal quantifiers like "all" or "every".
+    Universal,
+    /// Represents existential quantifiers like "some" or "exists".
+    Existential,
+}
+
+/// Determine whether the provided text contains a universal or existential quantifier.
+///
+/// Returns `Quantifier::Universal` if a universal quantifier is found,
+/// `Quantifier::Existential` if an existential quantifier is found,
+/// and `None` otherwise.
+pub fn detect_quantifier(text: &str) -> Option<Quantifier> {
+    if UNIVERSAL_REGEX.is_match(text) {
+        Some(Quantifier::Universal)
+    } else if EXISTENTIAL_REGEX.is_match(text) {
+        Some(Quantifier::Existential)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_universal_quantifier() {
+        let text = "all agents must comply";
+        assert_eq!(detect_quantifier(text), Some(Quantifier::Universal));
+    }
+
+    #[test]
+    fn detects_existential_quantifier() {
+        let text = "some agents may comply";
+        assert_eq!(detect_quantifier(text), Some(Quantifier::Existential));
+    }
+
+    #[test]
+    fn detects_none_when_no_quantifier_present() {
+        let text = "agents comply";
+        assert_eq!(detect_quantifier(text), None);
+    }
+}

--- a/crates/helix-security/Cargo.toml
+++ b/crates/helix-security/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 license = "Apache-2.0"
 description = "Security, authentication, and authorization for Helix platform"
 repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
-description = "Security and encryption utilities for Helix"
 
 [dependencies]
 helix-core = { path = "../helix-core" }

--- a/crates/helix-wasm/Cargo.toml
+++ b/crates/helix-wasm/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 license = "Apache-2.0"
 description = "WebAssembly runtime integration for Helix agents"
 repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
-description = "WASM runtime and plugin system for Helix agents"
 
 [dependencies]
 helix-core = { path = "../helix-core" }


### PR DESCRIPTION
## Summary
- cache quantifier regexes with `once_cell::sync::Lazy`
- expose new `intent_lattice` module
- add unit tests for quantifier detection
- fix duplicate package descriptions in several manifests

## Testing
- `cargo test -p helix-llm`
- `cargo tarpaulin -p helix-llm --out Xml`


------
https://chatgpt.com/codex/tasks/task_e_68aa737bcbcc832e93d30fbc050f2868