### PR TITLE
feat: extend Quint translator with file prompts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ base64 = "0.22"
 url = "2.5"
 sha2 = "0.10"
 futures = "0.3"
+clap = { version = "4", features = ["derive"] }
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -16,6 +16,40 @@ cargo build --workspace
 cargo test --workspace
 ```
 
+## Quint Translator
+
+The `helix-llm` crate includes a small CLI tool that leverages a language model to translate plain English descriptions into [Quint](https://quint-lang.org) specifications.
+
+Set an API key for your preferred provider and run. The translator checks for `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, or a generic `LLM_API_KEY` (with optional `LLM_BASE_URL`). The `--model`, `--temperature`, `--output`, and `--base-url` flags offer additional control:
+
+```bash
+# Using OpenRouter
+OPENROUTER_API_KEY=your_key_here \
+cargo run -p helix-llm --bin quint_translator -- "describe a simple counter that increments"
+
+# Using OpenAI
+OPENAI_API_KEY=your_key_here \
+cargo run -p helix-llm --bin quint_translator -- "describe a simple counter that increments"
+```
+
+The model will respond with a Quint specification based on the provided prompt.
+
+Before issuing a request to the model, the translator performs a lightweight **intent-facet** analysis to highlight potential ambiguities. If aspects like temporal scope or quantifier are missing, clarifying questions are printed to help refine the prompt.
+
+You can customize the model or write output to a file:
+
+```bash
+OPENAI_API_KEY=your_key_here \
+cargo run -p helix-llm --bin quint_translator --model gpt-4o --temperature 0.1 --output counter.qnt -- "describe a simple counter that increments"
+```
+
+You can also read a prompt from a file instead of the command line:
+
+```bash
+OPENAI_API_KEY=your_key_here \
+cargo run -p helix-llm --bin quint_translator --prompt-file spec.txt
+```
+
 ## Project Structure
 
 - `/crates`: Core Rust libraries and potentially Rust-based plugins.

--- a/crates/helix-embeddings/Cargo.toml
+++ b/crates/helix-embeddings/Cargo.toml
@@ -3,9 +3,8 @@ name = "helix-embeddings"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "Vector embeddings and semantic search for Helix platform"
-repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 description = "Vector embeddings and similarity search for Helix"
+repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 
 [dependencies]
 helix-core = { path = "../helix-core" }

--- a/crates/helix-llm/Cargo.toml
+++ b/crates/helix-llm/Cargo.toml
@@ -3,9 +3,8 @@ name = "helix-llm"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "Large language model integration for Helix platform"
-repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 description = "LLM integration and natural language processing for Helix agents"
+repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 
 [dependencies]
 helix-core = { path = "../helix-core" }
@@ -27,6 +26,7 @@ chrono = { workspace = true }
 futures = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/helix-llm/src/bin/quint_translator.rs
+++ b/crates/helix-llm/src/bin/quint_translator.rs
@@ -1,0 +1,131 @@
+use clap::{ArgGroup, Parser};
+use helix_llm::intent_lattice::IntentFacets;
+use helix_llm::providers::{LlmProvider, LlmRequest, Message, MessageRole, OpenAiProvider};
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+/// Translate plain English prompts into Quint specifications using an LLM.
+#[derive(Parser)]
+#[command(
+    name = "quint_translator",
+    about = "Translate English to Quint using an LLM",
+    group(
+        ArgGroup::new("input")
+            .required(true)
+            .args(["prompt", "prompt_file"])
+    )
+)]
+struct Args {
+    /// Prompt to translate
+    #[arg(group = "input")]
+    prompt: Vec<String>,
+
+    /// Read prompt from a file
+    #[arg(long, group = "input")]
+    prompt_file: Option<PathBuf>,
+
+    /// Model to use for translation
+    #[arg(short, long, default_value = "gpt-4o-mini")]
+    model: String,
+
+    /// Sampling temperature
+    #[arg(short, long, default_value_t = 0.2)]
+    temperature: f32,
+
+    /// Optional output file to write the generated Quint spec
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Override the LLM base URL
+    #[arg(long)]
+    base_url: Option<String>,
+}
+
+fn get_api_credentials() -> Result<(String, String), String> {
+    let configs = [
+        (
+            "OPENROUTER_API_KEY",
+            "OPENROUTER_BASE_URL",
+            "https://openrouter.ai/api/v1",
+        ),
+        (
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+            "https://api.openai.com/v1",
+        ),
+        ("LLM_API_KEY", "LLM_BASE_URL", "https://api.openai.com/v1"),
+    ];
+
+    for (key_env, url_env, default_url) in configs {
+        if let Ok(key) = env::var(key_env) {
+            let base = env::var(url_env).unwrap_or_else(|_| default_url.to_string());
+            return Ok((key, base));
+        }
+    }
+
+    Err("No LLM API key set. Use OPENAI_API_KEY, OPENROUTER_API_KEY, or LLM_API_KEY.".into())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let prompt = if let Some(file) = args.prompt_file {
+        fs::read_to_string(file)?
+    } else {
+        args.prompt.join(" ")
+    };
+
+    let facets = IntentFacets::parse(&prompt);
+    let questions = facets.clarifying_questions();
+    if !questions.is_empty() {
+        eprintln!("Potential ambiguities detected:");
+        for q in &questions {
+            eprintln!("- {}", q);
+        }
+    }
+
+    let (api_key, mut base_url) = match get_api_credentials() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("{}", e);
+            return Ok(());
+        }
+    };
+
+    if let Some(url) = args.base_url {
+        base_url = url;
+    }
+
+    let provider = OpenAiProvider::with_base_url(api_key, base_url);
+
+    let mut parameters = HashMap::new();
+    parameters.insert("model".to_string(), serde_json::json!(args.model));
+
+    let request = LlmRequest {
+        system_prompt: Some(
+            "You are a translation agent that converts plain English descriptions into Quint specifications following the Quint design principles found at https://quint-lang.org/docs/design-principles.".to_string(),
+        ),
+        messages: vec![Message {
+            role: MessageRole::User,
+            content: prompt,
+            function_call: None,
+        }],
+        max_tokens: Some(512),
+        temperature: Some(args.temperature),
+        top_p: None,
+        functions: None,
+        parameters,
+    };
+
+    let response = provider.complete(request).await?;
+
+    if let Some(path) = args.output {
+        fs::write(path, &response.content)?;
+    } else {
+        println!("{}", response.content);
+    }
+
+    Ok(())
+}

--- a/crates/helix-llm/src/intent_lattice.rs
+++ b/crates/helix-llm/src/intent_lattice.rs
@@ -1,0 +1,101 @@
+use regex::Regex;
+
+/// Temporal relationship between condition and outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TemporalFacet {
+    /// Always true.
+    Always,
+    /// Eventually becomes true.
+    Eventually,
+    /// Happens immediately on next step.
+    Immediate,
+}
+
+/// Quantifier scope of the statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuantifierFacet {
+    /// Applies to all cases.
+    Universal,
+    /// Applies to some cases.
+    Existential,
+}
+
+/// Guard/condition relationship.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuardFacet {
+    /// Implication/if-then relationship.
+    IfThen,
+}
+
+/// Facets extracted from natural language.
+#[derive(Debug, Default, Clone)]
+pub struct IntentFacets {
+    /// Temporal aspect.
+    pub temporal: Option<TemporalFacet>,
+    /// Quantifier aspect.
+    pub quantifier: Option<QuantifierFacet>,
+    /// Guard/condition aspect.
+    pub guard: Option<GuardFacet>,
+}
+
+impl IntentFacets {
+    /// Parse a prompt into intent facets using simple keyword heuristics.
+    pub fn parse(prompt: &str) -> Self {
+        let mut facets = IntentFacets::default();
+        let lower = prompt.to_lowercase();
+
+        if lower.contains("always") {
+            facets.temporal = Some(TemporalFacet::Always);
+        } else if lower.contains("eventually") {
+            facets.temporal = Some(TemporalFacet::Eventually);
+        } else if lower.contains("immediately") || lower.contains("next") {
+            facets.temporal = Some(TemporalFacet::Immediate);
+        }
+
+        let universal = Regex::new(r"\b(all|every|each)\b").unwrap();
+        let existential = Regex::new(r"\b(some|any|there exists|exists)\b").unwrap();
+        if universal.is_match(&lower) {
+            facets.quantifier = Some(QuantifierFacet::Universal);
+        } else if existential.is_match(&lower) {
+            facets.quantifier = Some(QuantifierFacet::Existential);
+        }
+
+        if lower.contains("if") || lower.contains("when") {
+            facets.guard = Some(GuardFacet::IfThen);
+        }
+
+        facets
+    }
+
+    /// Generate clarifying questions for missing facets.
+    pub fn clarifying_questions(&self) -> Vec<String> {
+        let mut qs = Vec::new();
+        if self.temporal.is_none() {
+            qs.push("Is this rule always true, eventually true, or immediately after the condition?".to_string());
+        }
+        if self.quantifier.is_none() {
+            qs.push("Should the rule apply to all cases or only to some?".to_string());
+        }
+        if self.guard.is_none() {
+            qs.push("Does the statement have a condition like 'if' or 'when'?".to_string());
+        }
+        qs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_facets_and_questions() {
+        let facets = IntentFacets::parse("If a button is pressed, the light eventually turns on");
+        assert_eq!(facets.guard, Some(GuardFacet::IfThen));
+        assert_eq!(facets.temporal, Some(TemporalFacet::Eventually));
+        assert_eq!(facets.quantifier, None);
+
+        let qs = facets.clarifying_questions();
+        assert!(qs.iter().any(|q| q.contains("apply to all")));
+    }
+}
+

--- a/crates/helix-llm/src/lib.rs
+++ b/crates/helix-llm/src/lib.rs
@@ -29,6 +29,7 @@ pub mod parsers;
 pub mod agents;
 pub mod context;
 pub mod errors;
+pub mod intent_lattice;
 
 pub use errors::LlmError;
 pub use providers::{LlmProvider, LlmRequest, LlmResponse, ModelConfig};

--- a/crates/helix-security/Cargo.toml
+++ b/crates/helix-security/Cargo.toml
@@ -3,9 +3,8 @@ name = "helix-security"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "Security, authentication, and authorization for Helix platform"
-repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 description = "Security and encryption utilities for Helix"
+repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 
 [dependencies]
 helix-core = { path = "../helix-core" }

--- a/crates/helix-wasm/Cargo.toml
+++ b/crates/helix-wasm/Cargo.toml
@@ -3,9 +3,8 @@ name = "helix-wasm"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "WebAssembly runtime integration for Helix agents"
-repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 description = "WASM runtime and plugin system for Helix agents"
+repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 
 [dependencies]
 helix-core = { path = "../helix-core" }


### PR DESCRIPTION
## Summary
- Allow `quint_translator` to read prompts from a file
- Simplify API credential lookup to reduce branching
- Document new `--prompt-file` usage in README

## Testing
- `cargo test -p helix-llm`
- `cargo clippy -p helix-llm --no-deps -- -D warnings` *(fails: unused imports, dead code, missing docs in existing modules)*
- `cargo mutants -p helix-llm --list`


------
https://chatgpt.com/codex/tasks/task_e_68a9f16ec608832eb0518b32086b6ccf