### PR TITLE
feat: enhance intent lattice parsing and credential checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ wasmtime-wasi = "24.0"
 # Rule engine and pattern matching
 # rete = "0.3"           # Commented out for now
 regex = "1.10"
+once_cell = "1.19"
 # cron = "0.12"          # Commented out for now
 
 # Additional utilities
@@ -71,6 +72,7 @@ base64 = "0.22"
 url = "2.5"
 sha2 = "0.10"
 futures = "0.3"
+clap = { version = "4", features = ["derive"] }
 
 [profile.release]
 lto = true

--- a/README.md
+++ b/README.md
@@ -16,6 +16,42 @@ cargo build --workspace
 cargo test --workspace
 ```
 
+## Quint Translator
+
+The `helix-llm` crate includes a small CLI tool that leverages a language model to translate plain English descriptions into [Quint](https://quint-lang.org) specifications.
+
+Set an API key for your preferred provider and run. The translator checks for `OPENROUTER_API_KEY`, `OPENAI_API_KEY`, or a generic `LLM_API_KEY` (with optional `LLM_BASE_URL`). The `--model`, `--temperature`, `--output`, and `--base-url` flags offer additional control:
+
+```bash
+# Using OpenRouter
+OPENROUTER_API_KEY=your_key_here \
+cargo run -p helix-llm --bin quint_translator -- "describe a simple counter that increments"
+
+# Using OpenAI
+OPENAI_API_KEY=your_key_here \
+cargo run -p helix-llm --bin quint_translator -- "describe a simple counter that increments"
+```
+
+The model will respond with a Quint specification based on the provided prompt.
+
+Before issuing a request to the model, the translator performs a lightweight **intent-facet** analysis to highlight potential ambiguities. If aspects like temporal scope, quantifier, or guard keywords (e.g. `if`, `when`, `unless`, `only if`) are missing, clarifying questions are printed to help refine the prompt.
+
+You can customize the model or write output to a file:
+
+```bash
+OPENAI_API_KEY=your_key_here \
+cargo run -p helix-llm --bin quint_translator --model gpt-4o --temperature 0.1 --output counter.qnt -- "describe a simple counter that increments"
+```
+
+You can also read a prompt from a file instead of the command line:
+
+```bash
+OPENAI_API_KEY=your_key_here \
+cargo run -p helix-llm --bin quint_translator --prompt-file spec.txt
+```
+
+If no API key is detected the translator now exits with a non-zero status so automated scripts can surface configuration issues.
+
 ## Project Structure
 
 - `/crates`: Core Rust libraries and potentially Rust-based plugins.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ cargo run -p helix-llm --bin quint_translator -- "describe a simple counter that
 # Using OpenAI
 OPENAI_API_KEY=your_key_here \
 cargo run -p helix-llm --bin quint_translator -- "describe a simple counter that increments"
+
+# Using a custom OpenAI-compatible endpoint
+LLM_API_KEY=your_key_here LLM_BASE_URL=https://my-llm.example/v1 \
+cargo run -p helix-llm --bin quint_translator -- "describe a simple counter that increments"
 ```
 
 The model will respond with a Quint specification based on the provided prompt.

--- a/crates/helix-core/src/agent.rs
+++ b/crates/helix-core/src/agent.rs
@@ -25,17 +25,12 @@ use tokio::sync::mpsc;
 use uuid::Uuid;
 
 /// Specifies the runtime environment for an agent.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, sqlx::Type)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, sqlx::Type, Default)]
 #[sqlx(type_name = "agent_runtime_type", rename_all = "lowercase")] // For PostgreSQL enum mapping
 pub enum AgentRuntime {
+    #[default]
     Native,
     Wasm,
-}
-
-impl Default for AgentRuntime {
-    fn default() -> Self {
-        AgentRuntime::Native
-    }
 }
 
 // --- Placeholder Traits for Context Dependencies ---

--- a/crates/helix-core/src/lib.rs
+++ b/crates/helix-core/src/lib.rs
@@ -12,7 +12,7 @@
 // limitations under the License.
 
 #![deny(unsafe_code)]
-#![warn(missing_docs)] // TODO: Enforce this later
+#![allow(missing_docs)] // Documentation is incomplete; re-enable once ready
 
 //! Core Helix types, traits, and utilities shared across the platform.
 

--- a/crates/helix-core/src/recipe.rs
+++ b/crates/helix-core/src/recipe.rs
@@ -14,7 +14,7 @@
 
 //! Defines the structure and components of a Recipe.
 
-use crate::agent::{AgentConfig, AgentRuntime};
+use crate::agent::AgentConfig;
 use crate::types::{AgentId, ProfileId, RecipeId};
 use crate::HelixError;
 use std::collections::{HashMap, HashSet, VecDeque};

--- a/crates/helix-embeddings/Cargo.toml
+++ b/crates/helix-embeddings/Cargo.toml
@@ -3,9 +3,8 @@ name = "helix-embeddings"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "Vector embeddings and semantic search for Helix platform"
-repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 description = "Vector embeddings and similarity search for Helix"
+repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 
 [dependencies]
 helix-core = { path = "../helix-core" }

--- a/crates/helix-llm/Cargo.toml
+++ b/crates/helix-llm/Cargo.toml
@@ -3,9 +3,8 @@ name = "helix-llm"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "Large language model integration for Helix platform"
-repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 description = "LLM integration and natural language processing for Helix agents"
+repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 
 [dependencies]
 helix-core = { path = "../helix-core" }
@@ -23,10 +22,12 @@ reqwest = { workspace = true }
 # hf-hub = { workspace = true }       # Commented out for now
 # tokenizers = { workspace = true }   # Commented out for now
 regex = { workspace = true }
+once_cell = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/crates/helix-llm/src/agents.rs
+++ b/crates/helix-llm/src/agents.rs
@@ -27,7 +27,6 @@ use helix_core::{
     types::AgentId,
     HelixError,
 };
-use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
 /// An LLM-powered source agent that can generate events based on natural language instructions
@@ -35,7 +34,6 @@ pub struct LlmSourceAgent {
     config: AgentConfig,
     llm_config: LlmAgentConfig,
     provider: Arc<dyn LlmProvider>,
-    context: AgentContext,
 }
 
 impl LlmSourceAgent {
@@ -45,13 +43,10 @@ impl LlmSourceAgent {
         llm_config: LlmAgentConfig,
         provider: Arc<dyn LlmProvider>,
     ) -> Self {
-        let context = AgentContext::new(config.id, config.profile_id);
-
         Self {
             config,
             llm_config,
             provider,
-            context,
         }
     }
 }
@@ -109,7 +104,7 @@ impl LlmAgent for LlmSourceAgent {
     async fn process_natural_language(
         &mut self,
         input: &str,
-        context: &AgentContext,
+        _context: &AgentContext,
     ) -> Result<LlmResponse, LlmError> {
         let request = LlmRequest {
             system_prompt: Some(self.llm_config.system_prompt.clone()),
@@ -130,8 +125,8 @@ impl LlmAgent for LlmSourceAgent {
 
     async fn synthesize_recipe(
         &mut self,
-        description: &str,
-        context: &AgentContext,
+        _description: &str,
+        _context: &AgentContext,
     ) -> Result<helix_core::recipe::Recipe, LlmError> {
         // Use LLM to generate recipe from description
         // This would involve prompt engineering and parsing
@@ -165,7 +160,6 @@ pub struct LlmTransformerAgent {
     config: AgentConfig,
     llm_config: LlmAgentConfig,
     provider: Arc<dyn LlmProvider>,
-    context: AgentContext,
 }
 
 impl LlmTransformerAgent {
@@ -175,13 +169,10 @@ impl LlmTransformerAgent {
         llm_config: LlmAgentConfig,
         provider: Arc<dyn LlmProvider>,
     ) -> Self {
-        let context = AgentContext::new(config.id, config.profile_id);
-
         Self {
             config,
             llm_config,
             provider,
-            context,
         }
     }
 }
@@ -201,7 +192,7 @@ impl Agent for LlmTransformerAgent {
 impl TransformerAgent for LlmTransformerAgent {
     async fn transform(
         &mut self,
-        ctx: TransformerContext,
+        _ctx: TransformerContext,
         event: Event,
     ) -> Result<Vec<Event>, HelixError> {
         // Use LLM to transform the event
@@ -251,7 +242,7 @@ impl LlmAgent for LlmTransformerAgent {
     async fn process_natural_language(
         &mut self,
         input: &str,
-        context: &AgentContext,
+        _context: &AgentContext,
     ) -> Result<LlmResponse, LlmError> {
         let request = LlmRequest {
             system_prompt: Some(self.llm_config.system_prompt.clone()),
@@ -272,16 +263,16 @@ impl LlmAgent for LlmTransformerAgent {
 
     async fn synthesize_recipe(
         &mut self,
-        description: &str,
-        context: &AgentContext,
+        _description: &str,
+        _context: &AgentContext,
     ) -> Result<helix_core::recipe::Recipe, LlmError> {
         todo!("Implement recipe synthesis for transformer")
     }
 
     async fn analyze_event(
         &mut self,
-        event: &Event,
-        context: &AgentContext,
+        _event: &Event,
+        _context: &AgentContext,
     ) -> Result<Vec<String>, LlmError> {
         todo!("Implement event analysis for transformer")
     }
@@ -292,7 +283,6 @@ pub struct LlmActionAgent {
     config: AgentConfig,
     llm_config: LlmAgentConfig,
     provider: Arc<dyn LlmProvider>,
-    context: AgentContext,
 }
 
 impl LlmActionAgent {
@@ -302,13 +292,10 @@ impl LlmActionAgent {
         llm_config: LlmAgentConfig,
         provider: Arc<dyn LlmProvider>,
     ) -> Self {
-        let context = AgentContext::new(config.id, config.profile_id);
-
         Self {
             config,
             llm_config,
             provider,
-            context,
         }
     }
 }
@@ -326,7 +313,7 @@ impl Agent for LlmActionAgent {
 
 #[async_trait]
 impl ActionAgent for LlmActionAgent {
-    async fn execute(&mut self, ctx: ActionContext, event: Event) -> Result<(), HelixError> {
+    async fn execute(&mut self, _ctx: ActionContext, event: Event) -> Result<(), HelixError> {
         // Use LLM to determine what action to take
         let event_json = serde_json::to_string_pretty(&event)
             .map_err(|e| HelixError::InternalError(e.to_string()))?;
@@ -375,7 +362,7 @@ impl LlmAgent for LlmActionAgent {
     async fn process_natural_language(
         &mut self,
         input: &str,
-        context: &AgentContext,
+        _context: &AgentContext,
     ) -> Result<LlmResponse, LlmError> {
         let request = LlmRequest {
             system_prompt: Some(self.llm_config.system_prompt.clone()),
@@ -396,16 +383,16 @@ impl LlmAgent for LlmActionAgent {
 
     async fn synthesize_recipe(
         &mut self,
-        description: &str,
-        context: &AgentContext,
+        _description: &str,
+        _context: &AgentContext,
     ) -> Result<helix_core::recipe::Recipe, LlmError> {
         todo!("Implement recipe synthesis for action agent")
     }
 
     async fn analyze_event(
         &mut self,
-        event: &Event,
-        context: &AgentContext,
+        _event: &Event,
+        _context: &AgentContext,
     ) -> Result<Vec<String>, LlmError> {
         todo!("Implement event analysis for action agent")
     }

--- a/crates/helix-llm/src/bin/quint_translator.rs
+++ b/crates/helix-llm/src/bin/quint_translator.rs
@@ -1,0 +1,159 @@
+use clap::{ArgGroup, Parser};
+use helix_llm::intent_lattice::IntentFacets;
+use helix_llm::providers::{LlmProvider, LlmRequest, Message, MessageRole, OpenAiProvider};
+use std::collections::HashMap;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+/// Translate plain English prompts into Quint specifications using an LLM.
+#[derive(Parser)]
+#[command(
+    name = "quint_translator",
+    about = "Translate English to Quint using an LLM",
+    group(
+        ArgGroup::new("input")
+            .required(true)
+            .args(["prompt", "prompt_file"])
+    )
+)]
+struct Args {
+    /// Prompt to translate
+    #[arg(group = "input")]
+    prompt: Vec<String>,
+
+    /// Read prompt from a file
+    #[arg(long, group = "input")]
+    prompt_file: Option<PathBuf>,
+
+    /// Model to use for translation
+    #[arg(short, long, default_value = "gpt-4o-mini")]
+    model: String,
+
+    /// Sampling temperature
+    #[arg(short, long, default_value_t = 0.2)]
+    temperature: f32,
+
+    /// Optional output file to write the generated Quint spec
+    #[arg(short, long)]
+    output: Option<PathBuf>,
+
+    /// Override the LLM base URL
+    #[arg(long)]
+    base_url: Option<String>,
+}
+
+fn get_api_credentials() -> Result<(String, String), String> {
+    let configs = [
+        (
+            "OPENROUTER_API_KEY",
+            "OPENROUTER_BASE_URL",
+            "https://openrouter.ai/api/v1",
+        ),
+        (
+            "OPENAI_API_KEY",
+            "OPENAI_BASE_URL",
+            "https://api.openai.com/v1",
+        ),
+        ("LLM_API_KEY", "LLM_BASE_URL", "https://api.openai.com/v1"),
+    ];
+
+    for (key_env, url_env, default_url) in configs {
+        if let Ok(key) = env::var(key_env) {
+            let base = env::var(url_env).unwrap_or_else(|_| default_url.to_string());
+            return Ok((key, base));
+        }
+    }
+
+    Err("No LLM API key set. Use OPENAI_API_KEY, OPENROUTER_API_KEY, or LLM_API_KEY.".into())
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+    let prompt = if let Some(file) = args.prompt_file {
+        fs::read_to_string(file)?
+    } else {
+        args.prompt.join(" ")
+    };
+
+    let facets = IntentFacets::parse(&prompt);
+    let questions = facets.clarifying_questions();
+    if !questions.is_empty() {
+        eprintln!("Potential ambiguities detected:");
+        for q in &questions {
+            eprintln!("- {}", q);
+        }
+    }
+
+    let (api_key, mut base_url) = get_api_credentials().unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    });
+
+    if let Some(url) = args.base_url {
+        base_url = url;
+    }
+
+    let provider = OpenAiProvider::with_base_url(api_key, base_url);
+
+    let mut parameters = HashMap::new();
+    parameters.insert("model".to_string(), serde_json::json!(args.model));
+
+    let request = LlmRequest {
+        system_prompt: Some(
+            "You are a translation agent that converts plain English descriptions into Quint specifications following the Quint design principles found at https://quint-lang.org/docs/design-principles.".to_string(),
+        ),
+        messages: vec![Message {
+            role: MessageRole::User,
+            content: prompt,
+            function_call: None,
+        }],
+        max_tokens: Some(512),
+        temperature: Some(args.temperature),
+        top_p: None,
+        functions: None,
+        parameters,
+    };
+
+    let response = provider.complete(request).await?;
+
+    if let Some(path) = args.output {
+        fs::write(path, &response.content)?;
+    } else {
+        println!("{}", response.content);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn selects_openai_key() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        env::remove_var("OPENROUTER_API_KEY");
+        env::remove_var("LLM_API_KEY");
+        env::set_var("OPENAI_API_KEY", "k");
+        env::set_var("OPENAI_BASE_URL", "https://x");
+        let creds = get_api_credentials().unwrap();
+        assert_eq!(creds.0, "k");
+        assert_eq!(creds.1, "https://x");
+        env::remove_var("OPENAI_API_KEY");
+        env::remove_var("OPENAI_BASE_URL");
+    }
+
+    #[test]
+    fn errors_when_missing_key() {
+        let _lock = ENV_MUTEX.lock().unwrap();
+        env::remove_var("OPENROUTER_API_KEY");
+        env::remove_var("OPENAI_API_KEY");
+        env::remove_var("LLM_API_KEY");
+        assert!(get_api_credentials().is_err());
+    }
+}

--- a/crates/helix-llm/src/errors.rs
+++ b/crates/helix-llm/src/errors.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! Error types for LLM operations
 
 use thiserror::Error;

--- a/crates/helix-llm/src/intent_lattice.rs
+++ b/crates/helix-llm/src/intent_lattice.rs
@@ -1,0 +1,128 @@
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Temporal relationship between condition and outcome.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TemporalFacet {
+    /// Always true.
+    Always,
+    /// Eventually becomes true.
+    Eventually,
+    /// Happens immediately on next step.
+    Immediate,
+}
+
+/// Quantifier scope of the statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QuantifierFacet {
+    /// Applies to all cases.
+    Universal,
+    /// Applies to some cases.
+    Existential,
+}
+
+/// Guard/condition relationship.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GuardFacet {
+    /// Implication/if-then relationship.
+    IfThen,
+    /// Negated guard expressed with "unless".
+    Unless,
+    /// Restrictive guard expressed with "only if".
+    OnlyIf,
+}
+
+/// Facets extracted from natural language.
+#[derive(Debug, Default, Clone)]
+pub struct IntentFacets {
+    /// Temporal aspect.
+    pub temporal: Option<TemporalFacet>,
+    /// Quantifier aspect.
+    pub quantifier: Option<QuantifierFacet>,
+    /// Guard/condition aspect.
+    pub guard: Option<GuardFacet>,
+}
+
+impl IntentFacets {
+    /// Parse a prompt into intent facets using simple keyword heuristics.
+    pub fn parse(prompt: &str) -> Self {
+        let mut facets = IntentFacets::default();
+        let lower = prompt.to_lowercase();
+
+        if lower.contains("always") {
+            facets.temporal = Some(TemporalFacet::Always);
+        } else if lower.contains("eventually") {
+            facets.temporal = Some(TemporalFacet::Eventually);
+        } else if lower.contains("immediately") || lower.contains("next") {
+            facets.temporal = Some(TemporalFacet::Immediate);
+        }
+
+        static UNIVERSAL: Lazy<Regex> = Lazy::new(|| Regex::new(r"\b(all|every|each)\b").unwrap());
+        static EXISTENTIAL: Lazy<Regex> =
+            Lazy::new(|| Regex::new(r"\b(some|any|there exists|exists)\b").unwrap());
+        if UNIVERSAL.is_match(&lower) {
+            facets.quantifier = Some(QuantifierFacet::Universal);
+        } else if EXISTENTIAL.is_match(&lower) {
+            facets.quantifier = Some(QuantifierFacet::Existential);
+        }
+
+        static IF_THEN: Lazy<Regex> = Lazy::new(|| Regex::new(r"\b(if|when)\b").unwrap());
+        static UNLESS: Lazy<Regex> = Lazy::new(|| Regex::new(r"\bunless\b").unwrap());
+        static ONLY_IF: Lazy<Regex> = Lazy::new(|| Regex::new(r"\bonly if\b").unwrap());
+
+        if ONLY_IF.is_match(&lower) {
+            facets.guard = Some(GuardFacet::OnlyIf);
+        } else if UNLESS.is_match(&lower) {
+            facets.guard = Some(GuardFacet::Unless);
+        } else if IF_THEN.is_match(&lower) {
+            facets.guard = Some(GuardFacet::IfThen);
+        }
+
+        facets
+    }
+
+    /// Generate clarifying questions for missing facets.
+    pub fn clarifying_questions(&self) -> Vec<String> {
+        let mut qs = Vec::new();
+        if self.temporal.is_none() {
+            qs.push(
+                "Is this rule always true, eventually true, or immediately after the condition?"
+                    .to_string(),
+            );
+        }
+        if self.quantifier.is_none() {
+            qs.push("Should the rule apply to all cases or only to some?".to_string());
+        }
+        if self.guard.is_none() {
+            qs.push(
+                "Does the statement include a condition such as 'if', 'when', 'unless', or 'only if'?".to_string(),
+            );
+        }
+        qs
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_facets_and_questions() {
+        let facets = IntentFacets::parse("If a button is pressed, the light eventually turns on");
+        assert_eq!(facets.guard, Some(GuardFacet::IfThen));
+        assert_eq!(facets.temporal, Some(TemporalFacet::Eventually));
+        assert_eq!(facets.quantifier, None);
+
+        let qs = facets.clarifying_questions();
+        assert!(qs.iter().any(|q| q.contains("apply to all")));
+    }
+
+    #[test]
+    fn recognizes_guard_keywords() {
+        let unless = IntentFacets::parse("Turn on the alarm unless the system is in maintenance");
+        assert_eq!(unless.guard, Some(GuardFacet::Unless));
+
+        let only_if = IntentFacets::parse("Alert only if the sensor fails");
+        assert_eq!(only_if.guard, Some(GuardFacet::OnlyIf));
+    }
+}

--- a/crates/helix-llm/src/lib.rs
+++ b/crates/helix-llm/src/lib.rs
@@ -36,7 +36,7 @@ pub use errors::LlmError;
 pub use providers::{LlmProvider, LlmRequest, LlmResponse, ModelConfig};
 
 use async_trait::async_trait;
-use helix_core::{agent::Agent, event::Event, HelixError};
+use helix_core::{agent::Agent, event::Event};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -105,8 +105,7 @@ impl LlmAgentFactory {
         &self,
         config: LlmAgentConfig,
     ) -> Result<Box<dyn LlmAgent>, LlmError> {
-        let provider = self
-            .providers
+        self.providers
             .get(&config.provider)
             .ok_or_else(|| LlmError::ProviderNotFound(config.provider.clone()))?;
 

--- a/crates/helix-llm/src/lib.rs
+++ b/crates/helix-llm/src/lib.rs
@@ -11,11 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 #![warn(missing_docs)]
 
 //! LLM integration and natural language processing capabilities for Helix.
-//! 
+//!
 //! This crate provides:
 //! - Multiple LLM provider integrations (OpenAI, Anthropic, local models)
 //! - Natural language rule parsing and generation
@@ -23,16 +22,18 @@
 //! - Context-aware prompt engineering
 //! - Token management and cost optimization
 
-pub mod providers;
-pub mod prompts;
-pub mod parsers;
 pub mod agents;
 pub mod context;
 pub mod errors;
+/// Utilities for parsing intent facets from natural language prompts.
+pub mod intent_lattice;
+pub mod parsers;
+pub mod prompts;
+pub mod providers;
 
+pub use context::{AgentContext, ConversationContext};
 pub use errors::LlmError;
 pub use providers::{LlmProvider, LlmRequest, LlmResponse, ModelConfig};
-pub use context::{AgentContext, ConversationContext};
 
 use async_trait::async_trait;
 use helix_core::{agent::Agent, event::Event, HelixError};
@@ -104,7 +105,9 @@ impl LlmAgentFactory {
         &self,
         config: LlmAgentConfig,
     ) -> Result<Box<dyn LlmAgent>, LlmError> {
-        let provider = self.providers.get(&config.provider)
+        let provider = self
+            .providers
+            .get(&config.provider)
             .ok_or_else(|| LlmError::ProviderNotFound(config.provider.clone()))?;
 
         // Create agent implementation based on provider
@@ -127,11 +130,15 @@ pub mod utils {
     pub fn count_tokens(text: &str, _model: &str) -> Result<usize, LlmError> {
         // Rough approximation: 1 token ≈ 4 characters for English text
         // This would be replaced with actual tiktoken implementation when available
-        Ok((text.len() + 3) / 4)
+        Ok(text.len().div_ceil(4))
     }
 
     /// Truncate text to fit within token limit
-    pub fn truncate_to_tokens(text: &str, model: &str, max_tokens: usize) -> Result<String, LlmError> {
+    pub fn truncate_to_tokens(
+        text: &str,
+        model: &str,
+        max_tokens: usize,
+    ) -> Result<String, LlmError> {
         let estimated_tokens = count_tokens(text, model)?;
 
         if estimated_tokens <= max_tokens {
@@ -155,7 +162,7 @@ pub mod utils {
         patterns: &HashMap<String, String>,
     ) -> HashMap<String, String> {
         let mut extracted = HashMap::new();
-        
+
         for (key, pattern) in patterns {
             if let Ok(regex) = regex::Regex::new(pattern) {
                 if let Some(captures) = regex.captures(response) {
@@ -165,7 +172,7 @@ pub mod utils {
                 }
             }
         }
-        
+
         extracted
     }
 }
@@ -187,7 +194,7 @@ mod tests {
 
         let serialized = serde_json::to_string(&config).unwrap();
         let deserialized: LlmAgentConfig = serde_json::from_str(&serialized).unwrap();
-        
+
         assert_eq!(config.provider, deserialized.provider);
         assert_eq!(config.model, deserialized.model);
     }

--- a/crates/helix-llm/src/parsers.rs
+++ b/crates/helix-llm/src/parsers.rs
@@ -11,12 +11,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! Natural language parsing utilities for Helix
 
+use crate::errors::LlmError;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use crate::errors::LlmError;
 
 /// Parsed intent from natural language input
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -78,28 +77,37 @@ impl AutomationParser {
     /// Create a new automation parser
     pub fn new() -> Self {
         let mut patterns = HashMap::new();
-        
+
         // Email automation patterns
-        patterns.insert("email".to_string(), vec![
-            r"send.*email".to_string(),
-            r"email.*when".to_string(),
-            r"notify.*email".to_string(),
-        ]);
+        patterns.insert(
+            "email".to_string(),
+            vec![
+                r"send.*email".to_string(),
+                r"email.*when".to_string(),
+                r"notify.*email".to_string(),
+            ],
+        );
 
         // Webhook patterns
-        patterns.insert("webhook".to_string(), vec![
-            r"when.*webhook".to_string(),
-            r"http.*request".to_string(),
-            r"api.*call".to_string(),
-        ]);
+        patterns.insert(
+            "webhook".to_string(),
+            vec![
+                r"when.*webhook".to_string(),
+                r"http.*request".to_string(),
+                r"api.*call".to_string(),
+            ],
+        );
 
         // Schedule patterns
-        patterns.insert("schedule".to_string(), vec![
-            r"every.*\d+.*minutes?".to_string(),
-            r"daily.*at".to_string(),
-            r"weekly.*on".to_string(),
-            r"cron".to_string(),
-        ]);
+        patterns.insert(
+            "schedule".to_string(),
+            vec![
+                r"every.*\d+.*minutes?".to_string(),
+                r"daily.*at".to_string(),
+                r"weekly.*on".to_string(),
+                r"cron".to_string(),
+            ],
+        );
 
         Self { patterns }
     }
@@ -127,7 +135,7 @@ impl AutomationParser {
 
         // Extract entities (simplified)
         let entities = self.extract_entities(&input_lower)?;
-        
+
         // Extract conditions (simplified)
         let conditions = self.extract_conditions(&input_lower)?;
 
@@ -148,32 +156,40 @@ impl AutomationParser {
         if let Ok(time_regex) = regex::Regex::new(r"\b(\d{1,2}:\d{2})\b") {
             for cap in time_regex.captures_iter(input) {
                 if let Some(time_match) = cap.get(1) {
-                    entities.insert("time".to_string(), Entity {
-                        entity_type: "time".to_string(),
-                        value: time_match.as_str().to_string(),
-                        confidence: 0.9,
-                        span: TextSpan {
-                            start: time_match.start(),
-                            end: time_match.end(),
+                    entities.insert(
+                        "time".to_string(),
+                        Entity {
+                            entity_type: "time".to_string(),
+                            value: time_match.as_str().to_string(),
+                            confidence: 0.9,
+                            span: TextSpan {
+                                start: time_match.start(),
+                                end: time_match.end(),
+                            },
                         },
-                    });
+                    );
                 }
             }
         }
 
         // Extract email addresses
-        if let Ok(email_regex) = regex::Regex::new(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b") {
+        if let Ok(email_regex) =
+            regex::Regex::new(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b")
+        {
             for cap in email_regex.captures_iter(input) {
                 if let Some(email_match) = cap.get(0) {
-                    entities.insert("email".to_string(), Entity {
-                        entity_type: "email".to_string(),
-                        value: email_match.as_str().to_string(),
-                        confidence: 0.95,
-                        span: TextSpan {
-                            start: email_match.start(),
-                            end: email_match.end(),
+                    entities.insert(
+                        "email".to_string(),
+                        Entity {
+                            entity_type: "email".to_string(),
+                            value: email_match.as_str().to_string(),
+                            confidence: 0.95,
+                            span: TextSpan {
+                                start: email_match.start(),
+                                end: email_match.end(),
+                            },
                         },
-                    });
+                    );
                 }
             }
         }
@@ -182,15 +198,18 @@ impl AutomationParser {
         if let Ok(number_regex) = regex::Regex::new(r"\b\d+\b") {
             for cap in number_regex.captures_iter(input) {
                 if let Some(number_match) = cap.get(0) {
-                    entities.insert("number".to_string(), Entity {
-                        entity_type: "number".to_string(),
-                        value: number_match.as_str().to_string(),
-                        confidence: 0.8,
-                        span: TextSpan {
-                            start: number_match.start(),
-                            end: number_match.end(),
+                    entities.insert(
+                        "number".to_string(),
+                        Entity {
+                            entity_type: "number".to_string(),
+                            value: number_match.as_str().to_string(),
+                            confidence: 0.8,
+                            span: TextSpan {
+                                start: number_match.start(),
+                                end: number_match.end(),
+                            },
                         },
-                    });
+                    );
                 }
             }
         }
@@ -312,7 +331,7 @@ impl RecipeGenerator {
 
                 config
             }
-            _ => serde_json::json!({})
+            _ => serde_json::json!({}),
         }
     }
 }
@@ -330,8 +349,10 @@ mod tests {
     #[test]
     fn test_email_pattern_matching() {
         let parser = AutomationParser::new();
-        let result = parser.parse("Send me an email when the price changes").unwrap();
-        
+        let result = parser
+            .parse("Send me an email when the price changes")
+            .unwrap();
+
         assert!(result.suggested_agents.contains(&"email".to_string()));
         assert!(result.confidence > 0.0);
     }
@@ -339,14 +360,16 @@ mod tests {
     #[test]
     fn test_entity_extraction() {
         let parser = AutomationParser::new();
-        let result = parser.parse("Send email to user@example.com at 15:30").unwrap();
-        
+        let result = parser
+            .parse("Send email to user@example.com at 15:30")
+            .unwrap();
+
         assert!(result.entities.contains_key("email"));
         assert!(result.entities.contains_key("time"));
-        
+
         let email_entity = &result.entities["email"];
         assert_eq!(email_entity.value, "user@example.com");
-        
+
         let time_entity = &result.entities["time"];
         assert_eq!(time_entity.value, "15:30");
     }

--- a/crates/helix-llm/src/prompts.rs
+++ b/crates/helix-llm/src/prompts.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! Prompt templates and engineering utilities
 
 use serde::{Deserialize, Serialize};
@@ -80,11 +79,11 @@ impl PromptTemplate {
     /// Render the template with provided values
     pub fn render(&self, values: &HashMap<String, String>) -> Result<String, String> {
         let mut result = self.template.clone();
-        
+
         // Replace all variables in the template
         for (name, definition) in &self.variables {
             let placeholder = format!("{{{}}}", name);
-            
+
             if let Some(value) = values.get(name) {
                 result = result.replace(&placeholder, value);
             } else if definition.required {
@@ -95,7 +94,7 @@ impl PromptTemplate {
                 result = result.replace(&placeholder, "");
             }
         }
-        
+
         Ok(result)
     }
 }
@@ -180,7 +179,8 @@ Analyze this event and provide:
 3. Any anomalies or concerns
 4. Suggested follow-up actions
 
-Format your response as structured JSON."#.to_string(),
+Format your response as structured JSON."#
+                .to_string(),
         );
 
         template.add_variable(VariableDefinition {
@@ -251,7 +251,8 @@ Analyze the error and provide:
 3. Prevention strategies
 4. Code changes if applicable
 
-Be specific and actionable in your recommendations."#.to_string(),
+Be specific and actionable in your recommendations."#
+                .to_string(),
         );
 
         // Add variable definitions...
@@ -321,11 +322,8 @@ mod tests {
 
     #[test]
     fn test_prompt_template_creation() {
-        let template = PromptTemplate::new(
-            "test".to_string(),
-            "Hello {name}!".to_string(),
-        );
-        
+        let template = PromptTemplate::new("test".to_string(), "Hello {name}!".to_string());
+
         assert_eq!(template.name, "test");
         assert_eq!(template.template, "Hello {name}!");
     }
@@ -362,10 +360,7 @@ mod tests {
 
     #[test]
     fn test_missing_required_variable() {
-        let mut template = PromptTemplate::new(
-            "test".to_string(),
-            "Hello {name}!".to_string(),
-        );
+        let mut template = PromptTemplate::new("test".to_string(), "Hello {name}!".to_string());
 
         template.add_variable(VariableDefinition {
             name: "name".to_string(),
@@ -378,6 +373,8 @@ mod tests {
         let values = HashMap::new();
         let result = template.render(&values);
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains("Required variable 'name' not provided"));
+        assert!(result
+            .unwrap_err()
+            .contains("Required variable 'name' not provided"));
     }
 }

--- a/crates/helix-llm/src/providers.rs
+++ b/crates/helix-llm/src/providers.rs
@@ -389,7 +389,7 @@ impl LlmProvider for OpenAiProvider {
         // Make a simple API call to check health
         let response = self
             .client
-            .get(&format!("{}/models", self.base_url))
+            .get(format!("{}/models", self.base_url))
             .header("Authorization", format!("Bearer {}", self.api_key))
             .send()
             .await?;
@@ -407,16 +407,16 @@ impl LlmProvider for OpenAiProvider {
 
 /// Anthropic provider implementation
 pub struct AnthropicProvider {
-    api_key: String,
-    client: reqwest::Client,
+    _api_key: String,
+    _client: reqwest::Client,
 }
 
 impl AnthropicProvider {
     /// Create a new Anthropic provider
     pub fn new(api_key: String) -> Self {
         Self {
-            api_key,
-            client: reqwest::Client::new(),
+            _api_key: api_key,
+            _client: reqwest::Client::new(),
         }
     }
 }

--- a/crates/helix-llm/src/providers.rs
+++ b/crates/helix-llm/src/providers.rs
@@ -17,6 +17,7 @@ use crate::errors::LlmError;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::time::Duration;
 
 /// Configuration for an LLM model
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -178,7 +179,10 @@ impl OpenAiProvider {
         Self {
             api_key,
             base_url: "https://api.openai.com/v1".to_string(),
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("failed to build HTTP client"),
         }
     }
 
@@ -187,7 +191,10 @@ impl OpenAiProvider {
         Self {
             api_key,
             base_url,
-            client: reqwest::Client::new(),
+            client: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .expect("failed to build HTTP client"),
         }
     }
 }
@@ -309,7 +316,10 @@ impl LlmProvider for OpenAiProvider {
 
         if !resp.status().is_success() {
             let status = resp.status();
-            let text = resp.text().await.unwrap_or_default();
+            let text = resp
+                .text()
+                .await
+                .map_err(|e| LlmError::NetworkError(e.to_string()))?;
             return Err(LlmError::ApiError(format!(
                 "OpenAI error {}: {}",
                 status, text
@@ -381,8 +391,8 @@ impl LlmProvider for OpenAiProvider {
         _request: LlmRequest,
     ) -> Result<Box<dyn futures::Stream<Item = Result<String, LlmError>> + Unpin + Send>, LlmError>
     {
-        // Implementation would return streaming response
-        todo!("Implement streaming completion")
+        // Streaming is not yet implemented for the OpenAI provider
+        Err(LlmError::ModelNotSupported("streaming".into()))
     }
 
     async fn health_check(&self) -> Result<(), LlmError> {
@@ -449,19 +459,8 @@ impl LlmProvider for AnthropicProvider {
     }
 
     async fn complete(&self, _request: LlmRequest) -> Result<LlmResponse, LlmError> {
-        // Mock implementation
-        Ok(LlmResponse {
-            content: "Mock response from Anthropic".to_string(),
-            function_call: None,
-            usage: TokenUsage {
-                prompt_tokens: 12,
-                completion_tokens: 8,
-                total_tokens: 20,
-            },
-            model: "claude-3-sonnet".to_string(),
-            finish_reason: FinishReason::Stop,
-            metadata: HashMap::new(),
-        })
+        // Anthropic support is not yet implemented
+        Err(LlmError::ModelNotSupported("anthropic".into()))
     }
 
     async fn stream_complete(
@@ -469,11 +468,52 @@ impl LlmProvider for AnthropicProvider {
         _request: LlmRequest,
     ) -> Result<Box<dyn futures::Stream<Item = Result<String, LlmError>> + Unpin + Send>, LlmError>
     {
-        todo!("Implement streaming completion")
+        // Anthropic streaming is not implemented
+        Err(LlmError::ModelNotSupported("anthropic".into()))
     }
 
     async fn health_check(&self) -> Result<(), LlmError> {
         // Implementation would check Anthropic API health
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn openai_streaming_not_supported() {
+        let provider = OpenAiProvider::new("key".into());
+        let req = LlmRequest {
+            system_prompt: None,
+            messages: Vec::new(),
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            functions: None,
+            parameters: HashMap::new(),
+        };
+
+        let res = provider.stream_complete(req).await;
+        assert!(matches!(res, Err(LlmError::ModelNotSupported(_))));
+    }
+
+    #[tokio::test]
+    async fn anthropic_not_implemented() {
+        let provider = AnthropicProvider::new("key".into());
+        let req = LlmRequest {
+            system_prompt: None,
+            messages: Vec::new(),
+            max_tokens: None,
+            temperature: None,
+            top_p: None,
+            functions: None,
+            parameters: HashMap::new(),
+        };
+
+        let res = provider.complete(req).await;
+        assert!(matches!(res, Err(LlmError::ModelNotSupported(_))));
     }
 }

--- a/crates/helix-security/Cargo.toml
+++ b/crates/helix-security/Cargo.toml
@@ -3,9 +3,8 @@ name = "helix-security"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "Security, authentication, and authorization for Helix platform"
-repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 description = "Security and encryption utilities for Helix"
+repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 
 [dependencies]
 helix-core = { path = "../helix-core" }

--- a/crates/helix-wasm/Cargo.toml
+++ b/crates/helix-wasm/Cargo.toml
@@ -3,9 +3,8 @@ name = "helix-wasm"
 version = "0.1.0"
 edition = "2021"
 license = "Apache-2.0"
-description = "WebAssembly runtime integration for Helix agents"
-repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 description = "WASM runtime and plugin system for Helix agents"
+repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
 
 [dependencies]
 helix-core = { path = "../helix-core" }


### PR DESCRIPTION
## Summary
- expand intent-facet parsing with cached regexes and new guard keywords
- fail fast when no LLM API key is configured and test credential resolution
- document guard detection keywords and error exit in README

## Testing
- `cargo test -p helix-llm`
- `cargo clippy -p helix-llm --no-deps -- -D warnings` *(fails: unused variables and dead code in existing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f16ec608832eb0518b32086b6ccf