### PR TITLE
Add initial Axum GUI service and LLM completion transformer agent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/helix-security",
     "crates/helix-embeddings",
     "crates/helix-agent-sdk-macros", # Added new macros crate
+    "crates/helix-gui",
     # Add other core crates as needed
 ]
 
@@ -32,6 +33,7 @@ thiserror = "1.0"
 async-trait = "0.1"
 async-nats = { version = "0.38.0" }
 sqlx = { version = "0.7", features = ["runtime-tokio-rustls", "postgres", "json", "uuid"] }
+axum = { version = "0.7", features = ["json"] }
 
 # LLM and AI dependencies
 reqwest = { version = "0.12", features = ["json", "rustls-tls"] }

--- a/crates/helix-core/Cargo.toml
+++ b/crates/helix-core/Cargo.toml
@@ -31,9 +31,10 @@ rand = { version = "0.8", optional = true }
 tempfile = { version = "3.8", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "test-util"] }
 base64 = "0.22.1" # Added for mock encryption service in tests
 futures = "0.3"
+proptest = "1.3"
 
 [features]
 default = []

--- a/crates/helix-core/src/filter_agent.rs
+++ b/crates/helix-core/src/filter_agent.rs
@@ -1,0 +1,110 @@
+use crate::agent::{Agent, AgentConfig, TransformerAgent, TransformerContext};
+use crate::event::Event;
+use crate::types::AgentId;
+use crate::HelixError;
+use async_trait::async_trait;
+
+/// A deterministic transformer agent that forwards only events whose type matches a configured allowlist.
+///
+/// This demonstrates how event-processing agents can be composed in the Helix runtime.
+pub struct TypeFilterAgent {
+    config: AgentConfig,
+    allowed_types: Vec<String>,
+}
+
+impl TypeFilterAgent {
+    /// Create a new type-filtering agent with an allowlist of event types.
+    pub fn new(config: AgentConfig, allowed_types: Vec<String>) -> Self {
+        Self {
+            config,
+            allowed_types,
+        }
+    }
+}
+
+#[async_trait]
+impl Agent for TypeFilterAgent {
+    fn id(&self) -> AgentId {
+        self.config.id
+    }
+
+    fn config(&self) -> &AgentConfig {
+        &self.config
+    }
+}
+
+#[async_trait]
+impl TransformerAgent for TypeFilterAgent {
+    async fn transform(
+        &mut self,
+        _ctx: TransformerContext,
+        event: Event,
+    ) -> Result<Vec<Event>, HelixError> {
+        if self.allowed_types.iter().any(|t| t == &event.r#type) {
+            Ok(vec![event])
+        } else {
+            Ok(vec![])
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::test_transformer_context;
+    use proptest::prelude::*;
+    use serde_json::json;
+    use tokio::runtime::Builder;
+    use uuid::Uuid;
+
+    #[tokio::test]
+    async fn filter_agent_allows_only_matching_events() {
+        // Given a filter agent configured to allow "foo.event"
+        let id = Uuid::new_v4();
+        let profile_id = Uuid::new_v4();
+        let config = AgentConfig::new(id, profile_id, None, "filter".to_string(), json!({}));
+        let mut agent = TypeFilterAgent::new(config, vec!["foo.event".to_string()]);
+
+        // When events of different types are processed
+        let ctx = || test_transformer_context(id, profile_id);
+        let allowed_event = Event::new(id.to_string(), "foo.event".to_string(), None);
+        let disallowed_event = Event::new(id.to_string(), "bar.event".to_string(), None);
+        let allowed_output = agent.transform(ctx(), allowed_event).await.unwrap();
+        let disallowed_output = agent.transform(ctx(), disallowed_event).await.unwrap();
+
+        // Then only the allowed event is forwarded
+        assert_eq!(allowed_output.len(), 1);
+        assert_eq!(allowed_output[0].r#type, "foo.event");
+        assert!(disallowed_output.is_empty());
+    }
+
+    proptest! {
+        #[test]
+        fn prop_filter_only_outputs_allowed(flags in proptest::collection::vec(proptest::bool::ANY, 0..20)) {
+            let rt = Builder::new_current_thread()
+                .enable_time()
+                .build()
+                .expect("runtime");
+            let result = rt.block_on(async move {
+                let id = Uuid::new_v4();
+                let profile_id = Uuid::new_v4();
+                let config = AgentConfig::new(id, profile_id, None, "filter".to_string(), json!({}));
+                let mut agent = TypeFilterAgent::new(config, vec!["foo.event".to_string()]);
+                let ctx = || test_transformer_context(id, profile_id);
+
+                let mut outputs = Vec::new();
+                for flag in &flags {
+                    let etype = if *flag { "foo.event" } else { "other" };
+                    let event = Event::new(id.to_string(), etype.to_string(), None);
+                    outputs.extend(agent.transform(ctx(), event).await.unwrap());
+                }
+
+                let expected = flags.iter().filter(|b| **b).count();
+                prop_assert_eq!(outputs.len(), expected);
+                prop_assert!(outputs.iter().all(|e| e.r#type == "foo.event"));
+                Ok(())
+            });
+            result.unwrap();
+        }
+    }
+}

--- a/crates/helix-core/src/lib.rs
+++ b/crates/helix-core/src/lib.rs
@@ -28,6 +28,10 @@ pub mod recipe;
 pub mod state;
 pub mod types;
 
+pub mod timer_agent;
+pub mod filter_agent;
+pub mod llm_agent;
+
 /// Evolutionary mutation testing framework
 #[cfg(feature = "mutation-testing")]
 pub mod mutation_testing;

--- a/crates/helix-core/src/llm_agent.rs
+++ b/crates/helix-core/src/llm_agent.rs
@@ -1,0 +1,146 @@
+use crate::agent::{Agent, AgentConfig, TransformerAgent, TransformerContext};
+use crate::event::Event;
+use crate::types::AgentId;
+use crate::HelixError;
+use async_trait::async_trait;
+use serde_json::json;
+use std::sync::Arc;
+
+/// Trait representing a generic language model capable of completing prompts.
+#[async_trait]
+pub trait LanguageModel: Send + Sync {
+    /// Produce a completion for the given prompt.
+    async fn complete(&self, prompt: &str) -> Result<String, HelixError>;
+}
+
+/// A transformer agent that converts `llm.prompt` events into `llm.completion` events
+/// using an injected [`LanguageModel`].
+pub struct LlmCompletionAgent {
+    config: AgentConfig,
+    model: Arc<dyn LanguageModel>,
+}
+
+impl LlmCompletionAgent {
+    /// Create a new agent backed by the provided language model.
+    pub fn new(config: AgentConfig, model: Arc<dyn LanguageModel>) -> Self {
+        Self { config, model }
+    }
+}
+
+#[async_trait]
+impl Agent for LlmCompletionAgent {
+    fn id(&self) -> AgentId {
+        self.config.id
+    }
+
+    fn config(&self) -> &AgentConfig {
+        &self.config
+    }
+}
+
+#[async_trait]
+impl TransformerAgent for LlmCompletionAgent {
+    async fn transform(
+        &mut self,
+        ctx: TransformerContext,
+        event: Event,
+    ) -> Result<Vec<Event>, HelixError> {
+        if event.r#type != "llm.prompt" {
+            // Pass through events we don't handle
+            return Ok(vec![event]);
+        }
+
+        let prompt = event
+            .data
+            .as_ref()
+            .and_then(|d| d.get("prompt"))
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| HelixError::validation_error("data.prompt", "missing prompt"))?;
+
+        let completion = self.model.complete(prompt).await?;
+        let out = Event::new(
+            ctx.agent_id.to_string(),
+            "llm.completion".to_string(),
+            Some(json!({
+                "prompt": prompt,
+                "completion": completion,
+            })),
+        );
+        Ok(vec![out])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::test_transformer_context;
+    use proptest::prelude::*;
+    use std::sync::Arc;
+    use tokio::runtime::Builder;
+    use uuid::Uuid;
+
+    struct EchoModel;
+
+    #[async_trait]
+    impl LanguageModel for EchoModel {
+        async fn complete(&self, prompt: &str) -> Result<String, HelixError> {
+            Ok(format!("{}!", prompt))
+        }
+    }
+
+    #[tokio::test]
+    async fn llm_agent_transforms_prompt_event() {
+        // Given an LLM agent backed by an echo model
+        let id = Uuid::new_v4();
+        let profile_id = Uuid::new_v4();
+        let config = AgentConfig::new(id, profile_id, None, "llm".to_string(), json!({}));
+        let model = Arc::new(EchoModel);
+        let mut agent = LlmCompletionAgent::new(config, model);
+        let ctx = test_transformer_context(id, profile_id);
+        let event = Event::new(
+            id.to_string(),
+            "llm.prompt".to_string(),
+            Some(json!({"prompt":"hi"})),
+        );
+
+        // When the event is transformed
+        let out = agent.transform(ctx, event).await.unwrap();
+
+        // Then we receive a completion event with echoed text
+        assert_eq!(out.len(), 1);
+        let evt = &out[0];
+        assert_eq!(evt.r#type, "llm.completion");
+        let data = evt.data.as_ref().unwrap();
+        assert_eq!(data.get("prompt").unwrap(), "hi");
+        assert_eq!(data.get("completion").unwrap(), "hi!");
+    }
+
+    proptest! {
+        #[test]
+        fn prop_llm_agent_emits_completion(s in "[a-zA-Z0-9 ]{0,20}") {
+            let rt = Builder::new_current_thread()
+                .enable_time()
+                .build()
+                .expect("runtime");
+            let result = rt.block_on(async move {
+                let id = Uuid::new_v4();
+                let profile_id = Uuid::new_v4();
+                let config = AgentConfig::new(id, profile_id, None, "llm".to_string(), json!({}));
+                let model = Arc::new(EchoModel);
+                let mut agent = LlmCompletionAgent::new(config, model);
+                let ctx = test_transformer_context(id, profile_id);
+                let event = Event::new(id.to_string(), "llm.prompt".to_string(), Some(json!({"prompt": s.clone()})));
+
+                let out = agent.transform(ctx, event).await.unwrap();
+                prop_assert_eq!(out.len(), 1);
+                let evt = &out[0];
+                prop_assert_eq!(&evt.r#type, "llm.completion");
+                let data = evt.data.as_ref().unwrap();
+                prop_assert_eq!(data.get("prompt").unwrap().as_str().unwrap(), s.as_str());
+                prop_assert_eq!(data.get("completion").unwrap().as_str().unwrap(), format!("{}!", s));
+                Ok(())
+            });
+            result.unwrap();
+        }
+    }
+}

--- a/crates/helix-core/src/recipe.rs
+++ b/crates/helix-core/src/recipe.rs
@@ -11,16 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 //! Defines the structure and components of a Recipe.
 
 use crate::agent::AgentConfig;
+#[cfg(test)]
+use crate::agent::AgentRuntime;
 use crate::types::{AgentId, ProfileId, RecipeId};
 use crate::HelixError;
-use std::collections::{HashMap, HashSet, VecDeque};
 use serde::{Deserialize, Serialize};
-use sqlx::FromRow;
 use sqlx::types::Json;
+use sqlx::FromRow;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 /// Defines how a recipe is triggered.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -169,13 +170,19 @@ impl Recipe {
             for dep_id in &agent_config.dependencies {
                 if !agent_ids_set.contains(dep_id) {
                     return Err(HelixError::ValidationError {
-                        context: format!("Recipe.graph.agents[id={}].dependencies", agent_config.id),
+                        context: format!(
+                            "Recipe.graph.agents[id={}].dependencies",
+                            agent_config.id
+                        ),
                         message: format!("Dependency on non-existent agent ID: {}", dep_id),
                     });
                 }
                 if dep_id == &agent_config.id {
                     return Err(HelixError::ValidationError {
-                        context: format!("Recipe.graph.agents[id={}].dependencies", agent_config.id),
+                        context: format!(
+                            "Recipe.graph.agents[id={}].dependencies",
+                            agent_config.id
+                        ),
                         message: format!("Agent {} cannot depend on itself.", agent_config.id),
                     });
                 }
@@ -307,7 +314,9 @@ mod tests {
         let agent1_id = Uuid::new_v4();
 
         let agent1 = create_test_agent_config(agent1_id, "Agent1", "typeA", vec![]);
-        let graph_def = RecipeGraphDefinition { agents: vec![agent1] };
+        let graph_def = RecipeGraphDefinition {
+            agents: vec![agent1],
+        };
 
         let recipe = Recipe::new(
             recipe_id,
@@ -466,8 +475,16 @@ mod tests {
         let agent1 = create_test_agent_config(agent_id, "Agent1", "typeA", vec![]);
         let agent2 = create_test_agent_config(agent_id, "Agent2WithSameId", "typeB", vec![]); // Duplicate ID
 
-        let graph_def = RecipeGraphDefinition { agents: vec![agent1, agent2] };
-        let recipe = Recipe::new(Uuid::new_v4(), Uuid::new_v4(), "DupID Recipe".to_string(), None, graph_def);
+        let graph_def = RecipeGraphDefinition {
+            agents: vec![agent1, agent2],
+        };
+        let recipe = Recipe::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "DupID Recipe".to_string(),
+            None,
+            graph_def,
+        );
 
         let result = recipe.validate();
         assert!(result.is_err());
@@ -475,7 +492,10 @@ mod tests {
             assert_eq!(context, "Recipe.graph.agents");
             assert_eq!(message, "Recipe contains duplicate agent IDs");
         } else {
-            panic!("Expected ValidationError for duplicate agent IDs, got {:?}", result);
+            panic!(
+                "Expected ValidationError for duplicate agent IDs, got {:?}",
+                result
+            );
         }
     }
 
@@ -484,17 +504,32 @@ mod tests {
         let agent1_id = Uuid::new_v4();
         let non_existent_agent_id = Uuid::new_v4();
 
-        let agent1 = create_test_agent_config(agent1_id, "Agent1", "typeA", vec![non_existent_agent_id]);
-        let graph_def = RecipeGraphDefinition { agents: vec![agent1] };
-        let recipe = Recipe::new(Uuid::new_v4(), Uuid::new_v4(), "InvalidDep Recipe".to_string(), None, graph_def);
+        let agent1 =
+            create_test_agent_config(agent1_id, "Agent1", "typeA", vec![non_existent_agent_id]);
+        let graph_def = RecipeGraphDefinition {
+            agents: vec![agent1],
+        };
+        let recipe = Recipe::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "InvalidDep Recipe".to_string(),
+            None,
+            graph_def,
+        );
 
         let result = recipe.validate();
         assert!(result.is_err());
         if let Err(HelixError::ValidationError { context, message }) = result {
-            assert_eq!(context, format!("Recipe.graph.agents[id={}].dependencies", agent1_id));
+            assert_eq!(
+                context,
+                format!("Recipe.graph.agents[id={}].dependencies", agent1_id)
+            );
             assert!(message.contains("Dependency on non-existent agent ID"));
         } else {
-            panic!("Expected ValidationError for non-existent dependency, got {:?}", result);
+            panic!(
+                "Expected ValidationError for non-existent dependency, got {:?}",
+                result
+            );
         }
     }
 
@@ -503,16 +538,30 @@ mod tests {
         let agent1_id = Uuid::new_v4();
         let agent1 = create_test_agent_config(agent1_id, "Agent1", "typeA", vec![agent1_id]); // Depends on self
 
-        let graph_def = RecipeGraphDefinition { agents: vec![agent1] };
-        let recipe = Recipe::new(Uuid::new_v4(), Uuid::new_v4(), "SelfLoop Recipe".to_string(), None, graph_def);
+        let graph_def = RecipeGraphDefinition {
+            agents: vec![agent1],
+        };
+        let recipe = Recipe::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "SelfLoop Recipe".to_string(),
+            None,
+            graph_def,
+        );
 
         let result = recipe.validate();
         assert!(result.is_err());
         if let Err(HelixError::ValidationError { context, message }) = result {
-            assert_eq!(context, format!("Recipe.graph.agents[id={}].dependencies", agent1_id));
+            assert_eq!(
+                context,
+                format!("Recipe.graph.agents[id={}].dependencies", agent1_id)
+            );
             assert!(message.contains("cannot depend on itself"));
         } else {
-            panic!("Expected ValidationError for self-dependency, got {:?}", result);
+            panic!(
+                "Expected ValidationError for self-dependency, got {:?}",
+                result
+            );
         }
     }
 
@@ -527,8 +576,16 @@ mod tests {
         let agent_b = create_test_agent_config(agent_b_id, "AgentB", "typeB", vec![agent_a_id]);
         let agent_c = create_test_agent_config(agent_c_id, "AgentC", "typeC", vec![agent_b_id]);
 
-        let graph_def = RecipeGraphDefinition { agents: vec![agent_a, agent_b, agent_c] };
-        let recipe = Recipe::new(Uuid::new_v4(), Uuid::new_v4(), "Cyclic Recipe".to_string(), None, graph_def);
+        let graph_def = RecipeGraphDefinition {
+            agents: vec![agent_a, agent_b, agent_c],
+        };
+        let recipe = Recipe::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "Cyclic Recipe".to_string(),
+            None,
+            graph_def,
+        );
 
         let result = recipe.validate();
         assert!(result.is_err());
@@ -536,7 +593,10 @@ mod tests {
             assert_eq!(context, "Recipe.graph");
             assert_eq!(message, "Recipe graph contains cycles (not a valid DAG)");
         } else {
-            panic!("Expected ValidationError for cycle detection, got {:?}", result);
+            panic!(
+                "Expected ValidationError for cycle detection, got {:?}",
+                result
+            );
         }
     }
 
@@ -551,15 +611,23 @@ mod tests {
         let agent_a = create_test_agent_config(agent_a_id, "AgentA", "typeA", vec![]);
         let agent_b = create_test_agent_config(agent_b_id, "AgentB", "typeB", vec![agent_a_id]);
         let agent_c = create_test_agent_config(agent_c_id, "AgentC", "typeC", vec![agent_a_id]);
-        let agent_d = create_test_agent_config(agent_d_id, "AgentD", "typeD", vec![agent_b_id, agent_c_id]);
+        let agent_d =
+            create_test_agent_config(agent_d_id, "AgentD", "typeD", vec![agent_b_id, agent_c_id]);
 
-        let graph_def = RecipeGraphDefinition { agents: vec![agent_a, agent_b, agent_c, agent_d] };
-        let recipe = Recipe::new(Uuid::new_v4(), Uuid::new_v4(), "Complex DAG".to_string(), None, graph_def);
+        let graph_def = RecipeGraphDefinition {
+            agents: vec![agent_a, agent_b, agent_c, agent_d],
+        };
+        let recipe = Recipe::new(
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            "Complex DAG".to_string(),
+            None,
+            graph_def,
+        );
 
         assert!(recipe.validate().is_ok());
         assert_eq!(recipe.agent_count(), 4);
     }
-
 
     #[test]
     fn test_trigger_schedule_creation() {
@@ -577,16 +645,27 @@ mod tests {
     fn test_recipe_serialization_deserialization() {
         let original_recipe = create_simple_recipe();
 
-        let serialized = serde_json::to_string_pretty(&original_recipe).expect("Serialization failed");
-        let deserialized: Recipe = serde_json::from_str(&serialized).expect("Deserialization failed");
+        let serialized =
+            serde_json::to_string_pretty(&original_recipe).expect("Serialization failed");
+        let deserialized: Recipe =
+            serde_json::from_str(&serialized).expect("Deserialization failed");
 
         assert_eq!(original_recipe.id, deserialized.id);
         assert_eq!(original_recipe.name, deserialized.name);
-        assert_eq!(original_recipe.graph.agents.len(), deserialized.graph.agents.len());
+        assert_eq!(
+            original_recipe.graph.agents.len(),
+            deserialized.graph.agents.len()
+        );
         // Detailed check of agent properties including dependencies
         for i in 0..original_recipe.graph.agents.len() {
-            assert_eq!(original_recipe.graph.agents[i].id, deserialized.graph.agents[i].id);
-            assert_eq!(original_recipe.graph.agents[i].dependencies, deserialized.graph.agents[i].dependencies);
+            assert_eq!(
+                original_recipe.graph.agents[i].id,
+                deserialized.graph.agents[i].id
+            );
+            assert_eq!(
+                original_recipe.graph.agents[i].dependencies,
+                deserialized.graph.agents[i].dependencies
+            );
         }
     }
 
@@ -622,8 +701,12 @@ mod tests {
             dependencies: vec![],
         };
 
-        let graph1 = RecipeGraphDefinition { agents: vec![agent1] };
-        let graph2 = RecipeGraphDefinition { agents: vec![agent2] };
+        let graph1 = RecipeGraphDefinition {
+            agents: vec![agent1],
+        };
+        let graph2 = RecipeGraphDefinition {
+            agents: vec![agent2],
+        };
 
         assert_eq!(graph1, graph2);
 
@@ -640,7 +723,9 @@ mod tests {
             enabled: true,
             dependencies: vec![agent3_dep_id],
         };
-        let graph3 = RecipeGraphDefinition { agents: vec![agent3] };
+        let graph3 = RecipeGraphDefinition {
+            agents: vec![agent3],
+        };
         assert_ne!(graph1, graph3); // Different due to dependencies
     }
 

--- a/crates/helix-core/src/test_utils/mod.rs
+++ b/crates/helix-core/src/test_utils/mod.rs
@@ -11,12 +11,77 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! Test utilities and helpers for high-quality testing.
+//!
+//! Includes Test Effectiveness Score (TES) helpers and lightweight fixtures for
+//! creating credential providers and state stores in unit tests. These fixtures
+//! keep test code concise while remaining fully deterministic.
 
-//! Test Effectiveness Score (TES) utilities for high-quality testing
-//! 
-//! TES = Mutation Score × Assertion Density × Behavior Coverage × Speed Factor
-
+use crate::agent::{CredentialProvider, SourceContext, StateStore, TransformerContext};
+use crate::event::Event;
+use crate::types::{AgentId, ProfileId};
+use crate::HelixError;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use std::time::Instant;
+use tokio::sync::mpsc;
+
+/// A credential provider that always returns `None`.
+///
+/// Useful in tests that do not require authentication material.
+pub struct NoopCredentialProvider;
+
+#[async_trait]
+impl CredentialProvider for NoopCredentialProvider {
+    async fn get_credential(&self, _id: &str) -> Result<Option<String>, HelixError> {
+        Ok(None)
+    }
+}
+
+/// Simple in-memory [`StateStore`] for tests.
+#[derive(Default)]
+pub struct MemoryStateStore(Mutex<HashMap<String, Vec<u8>>>);
+
+#[async_trait]
+impl StateStore for MemoryStateStore {
+    async fn get_state(&self, key: &str) -> Result<Option<Vec<u8>>, HelixError> {
+        Ok(self.0.lock().unwrap().get(key).cloned())
+    }
+
+    async fn set_state(&self, key: &str, value: &[u8]) -> Result<(), HelixError> {
+        self.0
+            .lock()
+            .unwrap()
+            .insert(key.to_string(), value.to_vec());
+        Ok(())
+    }
+}
+
+/// Construct a [`TransformerContext`] with in-memory state and no credentials.
+pub fn test_transformer_context(agent_id: AgentId, profile_id: ProfileId) -> TransformerContext {
+    TransformerContext {
+        agent_id,
+        profile_id,
+        credential_provider: Arc::new(NoopCredentialProvider),
+        state_store: Arc::new(MemoryStateStore::default()),
+    }
+}
+
+/// Construct a [`SourceContext`] with in-memory state and no credentials.
+pub fn test_source_context(
+    agent_id: AgentId,
+    profile_id: ProfileId,
+    event_tx: mpsc::Sender<Event>,
+) -> SourceContext {
+    SourceContext {
+        agent_id,
+        profile_id,
+        credential_provider: Arc::new(NoopCredentialProvider),
+        state_store: Arc::new(MemoryStateStore::default()),
+        event_tx,
+    }
+}
 
 /// Test Effectiveness Score calculator and tracker
 #[derive(Debug, Clone)]
@@ -60,9 +125,14 @@ impl TesTracker {
             total_mutations: 0,
         }
     }
-    
+
     /// Record an assertion
-    pub fn assert_eq<T: std::fmt::Debug>(&mut self, actual: T, expected: T, description: &str) -> bool {
+    pub fn assert_eq<T: std::fmt::Debug>(
+        &mut self,
+        actual: T,
+        expected: T,
+        description: &str,
+    ) -> bool {
         let passed = format!("{:?}", actual) == format!("{:?}", expected);
         self.assertions.push(Assertion {
             description: description.to_string(),
@@ -72,43 +142,44 @@ impl TesTracker {
         });
         passed
     }
-    
+
     /// Record a behavior test
     pub fn test_behavior(&mut self, behavior: BehaviorTest) {
         self.behaviors.push(behavior);
     }
-    
+
     /// Record mutation testing results
     pub fn record_mutations(&mut self, caught: usize, total: usize) {
         self.mutations_caught = caught;
         self.total_mutations = total;
     }
-    
+
     /// Calculate the Test Effectiveness Score
     pub fn calculate_tes(&self) -> TesScore {
         let duration = self.start_time.elapsed();
-        
+
         // Mutation Score
         let mutation_score = if self.total_mutations > 0 {
             (self.mutations_caught as f64 / self.total_mutations as f64).min(1.0)
         } else {
             0.85 // Default if no mutations tested
         };
-        
+
         // Assertion Density (normalized by target of 3)
         let assertion_density = (self.assertions.len() as f64 / 3.0).min(1.0);
-        
+
         // Behavior Coverage
         let behavior_patterns = ["happy_path", "error", "edge_case", "boundary", "concurrent"];
-        let covered = behavior_patterns.iter()
+        let covered = behavior_patterns
+            .iter()
             .filter(|p| self.behaviors.iter().any(|b| b.scenario.contains(*p)))
             .count();
         let behavior_coverage = (covered as f64 / behavior_patterns.len() as f64).min(1.0);
-        
+
         // Speed Factor
         let avg_ms = duration.as_millis() as f64;
         let speed_factor = 1.0 / (1.0 + avg_ms / 100.0);
-        
+
         TesScore {
             mutation_score,
             assertion_density,
@@ -117,7 +188,7 @@ impl TesTracker {
             overall: mutation_score * assertion_density * behavior_coverage * speed_factor,
         }
     }
-    
+
     /// Generate a test report
     pub fn report(&self) -> String {
         let score = self.calculate_tes();
@@ -170,8 +241,11 @@ impl TesScore {
 #[macro_export]
 macro_rules! tes_assert_eq {
     ($tracker:expr, $actual:expr, $expected:expr, $desc:expr) => {
-        assert!($tracker.assert_eq($actual, $expected, $desc), 
-                "Assertion failed: {}", $desc);
+        assert!(
+            $tracker.assert_eq($actual, $expected, $desc),
+            "Assertion failed: {}",
+            $desc
+        );
     };
 }
 
@@ -200,15 +274,15 @@ impl<T> TestDataBuilder<T> {
     pub fn new(data: T) -> Self {
         Self { data }
     }
-    
-    pub fn with<F>(mut self, f: F) -> Self 
-    where 
-        F: FnOnce(&mut T)
+
+    pub fn with<F>(mut self, f: F) -> Self
+    where
+        F: FnOnce(&mut T),
     {
         f(&mut self.data);
         self
     }
-    
+
     pub fn build(self) -> T {
         self.data
     }
@@ -217,17 +291,17 @@ impl<T> TestDataBuilder<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     #[test]
     fn test_tes_tracker_comprehensive() {
         let mut tracker = TesTracker::new("test_tes_tracker");
-        
+
         // Multiple assertions
         tes_assert_eq!(tracker, 1 + 1, 2, "Basic addition");
         tes_assert_eq!(tracker, "hello".len(), 5, "String length");
         tes_assert_eq!(tracker, vec![1, 2, 3].len(), 3, "Vector length");
         tes_assert_eq!(tracker, true, true, "Boolean equality");
-        
+
         // Behavior tests
         tes_behavior!(tracker, "happy_path",
             given: "A valid input",
@@ -235,24 +309,24 @@ mod tests {
             then: "Expected output is produced",
             true
         );
-        
+
         tes_behavior!(tracker, "edge_case",
             given: "Empty input",
             when: "Processing occurs",
             then: "Handles gracefully",
             true
         );
-        
+
         // Mutation testing simulation
         tracker.record_mutations(9, 10);
-        
+
         // Check TES score
         let score = tracker.calculate_tes();
         assert!(score.mutation_score >= 0.85);
         assert!(score.assertion_density >= 1.0);
         assert!(score.behavior_coverage >= 0.4);
         assert!(score.speed_factor >= 0.8);
-        
+
         println!("{}", tracker.report());
     }
 }

--- a/crates/helix-core/src/timer_agent.rs
+++ b/crates/helix-core/src/timer_agent.rs
@@ -1,0 +1,105 @@
+use crate::agent::{Agent, AgentConfig, SourceAgent, SourceContext};
+use crate::types::AgentId;
+use crate::HelixError;
+use async_trait::async_trait;
+use serde_json::json;
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// A simple deterministic source agent that emits an event after a fixed interval.
+///
+/// This demonstrates how non-LLM agents can participate in the Helix runtime.
+pub struct TimerSourceAgent {
+    config: AgentConfig,
+    interval: Duration,
+}
+
+impl TimerSourceAgent {
+    /// Create a new timer agent that waits `interval` before emitting an event.
+    pub fn new(config: AgentConfig, interval: Duration) -> Self {
+        Self { config, interval }
+    }
+}
+
+#[async_trait]
+impl Agent for TimerSourceAgent {
+    fn id(&self) -> AgentId {
+        self.config.id
+    }
+
+    fn config(&self) -> &AgentConfig {
+        &self.config
+    }
+}
+
+#[async_trait]
+impl SourceAgent for TimerSourceAgent {
+    async fn run(&mut self, ctx: SourceContext) -> Result<(), HelixError> {
+        sleep(self.interval).await;
+        let payload = json!({
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+        });
+        ctx.emit(payload, Some("timer.tick".to_string())).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::test_source_context;
+    use proptest::prelude::*;
+    use serde_json::json;
+    use tokio::sync::mpsc;
+    use uuid::Uuid;
+
+    #[tokio::test(start_paused = true)]
+    async fn timer_agent_emits_event() {
+        // Given a timer agent configured with a 10ms interval
+        let id = Uuid::new_v4();
+        let profile_id = Uuid::new_v4();
+        let config = AgentConfig::new(id, profile_id, None, "timer".to_string(), json!({}));
+        let (tx, mut rx) = mpsc::channel(1);
+        let ctx = test_source_context(id, profile_id, tx);
+
+        // When the agent is run and time advances past the interval
+        let mut agent = TimerSourceAgent::new(config, Duration::from_millis(10));
+        let handle = tokio::spawn(async move { agent.run(ctx).await.unwrap() });
+        tokio::time::advance(Duration::from_millis(10)).await;
+
+        // Then a timer.tick event is emitted with data
+        let event = rx.recv().await.expect("event");
+        assert_eq!(event.r#type, "timer.tick");
+        assert!(event.data.is_some());
+        handle.await.unwrap();
+    }
+
+    proptest! {
+        # [test]
+        fn prop_timer_emits_event(ms in 1u64..100) {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_time()
+                .build()
+                .expect("runtime");
+            rt.block_on(async move {
+                // Given a timer agent configured with a random interval
+                tokio::time::pause();
+                let id = Uuid::new_v4();
+                let profile_id = Uuid::new_v4();
+                let config = AgentConfig::new(id, profile_id, None, "timer".to_string(), json!({}));
+                let (tx, mut rx) = mpsc::channel(1);
+                let ctx = test_source_context(id, profile_id, tx);
+                let mut agent = TimerSourceAgent::new(config, Duration::from_millis(ms));
+                let handle = tokio::spawn(async move { agent.run(ctx).await.unwrap() });
+
+                // When time advances to the interval
+                tokio::time::advance(Duration::from_millis(ms)).await;
+
+                // Then an event is produced
+                let event = rx.recv().await.expect("event");
+                assert_eq!(event.r#type, "timer.tick");
+                assert!(event.data.is_some());
+                handle.await.unwrap();
+            });
+        }
+    }
+}

--- a/crates/helix-gui/Cargo.toml
+++ b/crates/helix-gui/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "helix-gui"
+version = "0.1.0"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+[dependencies]
+axum = { workspace = true }
+helix-core = { path = "../helix-core" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tower = { version = "0.4", features = ["util"] }
+
+[dev-dependencies]
+proptest = "1.3"
+hyper = { version = "1", features = ["full"] }

--- a/crates/helix-gui/src/lib.rs
+++ b/crates/helix-gui/src/lib.rs
@@ -1,0 +1,84 @@
+//! Minimal GUI preparation crate exposing an HTTP endpoint to list events.
+//! This leverages Axum to serve JSON data that a future web-based GUI can consume.
+
+use axum::{extract::State, routing::get, Json, Router};
+use helix_core::event::Event;
+use std::sync::{Arc, Mutex};
+
+/// Shared application state holding events to be displayed by the GUI.
+#[derive(Clone, Default)]
+pub struct AppState {
+    /// In-memory list of events collected from the Helix runtime.
+    pub events: Arc<Mutex<Vec<Event>>>,
+}
+
+/// Build an Axum [`Router`] serving an `/events` endpoint returning all known events.
+///
+/// # Examples
+///
+/// ```
+/// use helix_gui::{app, AppState};
+/// let state = AppState::default();
+/// let router = app(state);
+/// ```
+#[must_use]
+pub fn app(state: AppState) -> Router {
+    Router::new().route("/events", get(list_events)).with_state(state)
+}
+
+async fn list_events(State(state): State<AppState>) -> Json<Vec<Event>> {
+    let events = state.events.lock().expect("poisoned").clone();
+    Json(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{body::{Body, to_bytes}, http::Request};
+    use proptest::prelude::*;
+    use serde_json::json;
+    use tower::util::ServiceExt;
+
+    #[tokio::test]
+    async fn list_events_returns_inserted_events() {
+        let state = AppState::default();
+        {
+            let mut events = state.events.lock().unwrap();
+            events.push(Event::new("/test".into(), "type".into(), Some(json!({"k":"v"}))));
+        }
+        let router = app(state);
+        let response = router
+            .oneshot(Request::builder().uri("/events").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), 200);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let events: Vec<Event> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].r#type, "type");
+    }
+
+    proptest! {
+        #[test]
+        fn prop_events_endpoint_len(types in prop::collection::vec("[a-z]+".prop_map(|s| s.to_string()), 0..5)) {
+            let state = AppState::default();
+            {
+                let mut events = state.events.lock().unwrap();
+                for t in &types {
+                    events.push(Event::new("/src".into(), t.clone(), None));
+                }
+            }
+            let router = app(state.clone());
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            let response = rt.block_on(async {
+                router
+                    .oneshot(Request::builder().uri("/events").body(Body::empty()).unwrap())
+                    .await
+                    .unwrap()
+            });
+            let body = rt.block_on(async { to_bytes(response.into_body(), usize::MAX).await.unwrap() });
+            let events: Vec<Event> = serde_json::from_slice(&body).unwrap();
+            prop_assert_eq!(events.len(), types.len());
+        }
+    }
+}

--- a/progress.md
+++ b/progress.md
@@ -2,6 +2,7 @@
 
 ## Done
 
+- 2025-09-08: Introduced `helix-gui` crate exposing Axum `/events` endpoint with property-based tests for future GUI.
 - 2025-04-28: Reviewed `docs/specification.md`.
 - 2025-04-28: Initialized Rust workspace (`Cargo.toml`).
 - 2025-04-28: Created `crates/helix-core` structure (`Cargo.toml`, `src/lib.rs`, `src/agent.rs`, `src/errors.rs`).


### PR DESCRIPTION
## Summary
- expose new LlmCompletionAgent that turns `llm.prompt` events into `llm.completion` events using an injected language model
- validate LLM agent behavior with BDD and property-based tests
- export the LLM agent from Helix core for downstream use
- factor out shared test fixtures to reduce duplication across agents
- add helix-gui crate with Axum router serving `/events` for future GUI
- verify event listing via BDD and property-based tests, and track progress

## Testing
- `cargo test -p helix-core --lib`
- `cargo test -p helix-gui`


------
https://chatgpt.com/codex/tasks/task_e_68befe674400832ebb455101465db026