### PR TITLE
feat: federation, LLM desk operator, and CoPilot multi-participant mode

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -28,8 +28,9 @@ jobs:
             target: aarch64-unknown-linux-gnu
             cross: true
           - label: darwin-x64
-            os: macos-13
+            os: macos-14
             target: x86_64-apple-darwin
+            cross: true
           - label: darwin-arm64
             os: macos-14
             target: aarch64-apple-darwin
@@ -47,7 +48,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Install arm64 cross-compiler
-        if: matrix.cross == true
+        if: matrix.cross == true && runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -127,21 +127,9 @@ jobs:
 
           cp "${bin_dir}/helix-api${exe}" "$staging/bin/"
           if [[ "$os_name" == "windows" ]]; then
-            cat > "$staging/bin/helix.cmd" <<'EOF'
-@echo off
-if "%HELIX_UI_DIST%"=="" set "HELIX_UI_DIST=%~dp0..\ui\dist"
-"%~dp0helix-api.exe" %*
-EOF
+            printf '@echo off\nif "%%HELIX_UI_DIST%%"=="" set "HELIX_UI_DIST=%%~dp0..\\ui\\dist"\n"%%~dp0helix-api.exe" %%*\n' > "$staging/bin/helix.cmd"
           else
-            cat > "$staging/bin/helix" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [[ -z "${HELIX_UI_DIST:-}" ]]; then
-  export HELIX_UI_DIST="$(cd "$SCRIPT_DIR/../ui/dist" && pwd)"
-fi
-exec "$SCRIPT_DIR/helix-api" "$@"
-EOF
+            printf '#!/usr/bin/env bash\nset -euo pipefail\nSCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\nif [[ -z "${HELIX_UI_DIST:-}" ]]; then\n  export HELIX_UI_DIST="$(cd "$SCRIPT_DIR/../ui/dist" && pwd)"\nfi\nexec "$SCRIPT_DIR/helix-api" "$@"\n' > "$staging/bin/helix"
             chmod 0755 "$staging/bin/helix"
           fi
           cp -R ui/dist "$staging/ui/dist"

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -14,12 +14,22 @@ env:
 
 jobs:
   package:
-    name: Package ${{ matrix.os }}
+    name: Package ${{ matrix.label }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - label: linux-x64
+            os: ubuntu-latest
+          - label: linux-arm64
+            os: ubuntu-24.04-arm
+          - label: darwin-x64
+            os: macos-13
+          - label: darwin-arm64
+            os: macos-14
+          - label: windows-x64
+            os: windows-latest
 
     steps:
       - name: Checkout
@@ -44,7 +54,19 @@ jobs:
 
       - name: Build API binary
         shell: bash
+        env:
+          SQLX_OFFLINE: "true"
         run: cargo build --release -p helix-api
+
+      - name: Smoke-test binary
+        shell: bash
+        run: |
+          exe="target/release/helix-api"
+          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+            exe="target/release/helix-api.exe"
+          fi
+          "$exe" --version
+          "$exe" --help
 
       - name: Package archive
         id: package
@@ -128,3 +150,4 @@ EOF
         uses: softprops/action-gh-release@v2
         with:
           files: dist/*.tar.gz
+          generate_release_notes: true

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -22,14 +22,20 @@ jobs:
         include:
           - label: linux-x64
             os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
           - label: linux-arm64
-            os: ubuntu-24.04-arm
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            cross: true
           - label: darwin-x64
             os: macos-13
+            target: x86_64-apple-darwin
           - label: darwin-arm64
             os: macos-14
+            target: aarch64-apple-darwin
           - label: windows-x64
             os: windows-latest
+            target: x86_64-pc-windows-msvc
 
     steps:
       - name: Checkout
@@ -37,6 +43,14 @@ jobs:
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install arm64 cross-compiler
+        if: matrix.cross == true
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
 
       - name: Install Node
         uses: actions/setup-node@v4
@@ -56,9 +70,16 @@ jobs:
         shell: bash
         env:
           SQLX_OFFLINE: "true"
-        run: cargo build --release -p helix-api
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: |
+          if [[ -n "${{ matrix.cross }}" ]]; then
+            cargo build --release -p helix-api --target ${{ matrix.target }}
+          else
+            cargo build --release -p helix-api
+          fi
 
       - name: Smoke-test binary
+        if: matrix.cross != true
         shell: bash
         run: |
           exe="target/release/helix-api"
@@ -74,32 +95,38 @@ jobs:
         run: |
           set -euo pipefail
 
-          case "${RUNNER_OS}" in
-            Linux) os="linux" ;;
-            macOS) os="darwin" ;;
-            Windows) os="windows" ;;
-            *) echo "unsupported runner OS: ${RUNNER_OS}" >&2; exit 1 ;;
-          esac
+          # Determine OS and arch from the matrix label
+          label="${{ matrix.label }}"
+          os="${label%%-*}"
+          arch="${label##*-}"
 
-          case "${RUNNER_ARCH}" in
-            X64) arch="x64" ;;
-            ARM64) arch="arm64" ;;
-            *) echo "unsupported runner arch: ${RUNNER_ARCH}" >&2; exit 1 ;;
+          case "$os" in
+            linux)   os_name="linux" ;;
+            darwin)  os_name="darwin" ;;
+            windows) os_name="windows" ;;
+            *) echo "unsupported os: $os" >&2; exit 1 ;;
           esac
 
           exe=""
-          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+          if [[ "$os_name" == "windows" ]]; then
             exe=".exe"
           fi
 
-          suffix="${os}-${arch}"
+          # Binary location: target/release/ for native, target/<target>/release/ for cross
+          if [[ -n "${{ matrix.cross }}" ]]; then
+            bin_dir="target/${{ matrix.target }}/release"
+          else
+            bin_dir="target/release"
+          fi
+
+          suffix="${os_name}-${arch}"
           archive="helix-api-${suffix}.tar.gz"
           staging="target/release-package/helix-api-${suffix}"
           rm -rf "$staging"
           mkdir -p "$staging/bin" "$staging/ui"
 
-          cp "target/release/helix-api${exe}" "$staging/bin/"
-          if [[ "${RUNNER_OS}" == "Windows" ]]; then
+          cp "${bin_dir}/helix-api${exe}" "$staging/bin/"
+          if [[ "$os_name" == "windows" ]]; then
             cat > "$staging/bin/helix.cmd" <<'EOF'
 @echo off
 if "%HELIX_UI_DIST%"=="" set "HELIX_UI_DIST=%~dp0..\ui\dist"

--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ Thumbs.db
 .windsurfrules
 
 # AI/Development tools and temporary files
-*rules*
 *private*
 *secret*
 *temp*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/helix-embeddings",
     "crates/helix-agent-sdk-macros", # Added new macros crate
     "crates/helix-gui",
+    "crates/helix-federation",
     # Add other core crates as needed
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/helix-agent-sdk-macros", # Added new macros crate
     "crates/helix-gui",
     "crates/helix-federation",
+    "crates/helix-operator",
     # Add other core crates as needed
 ]
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,10 @@ Helix is not positioned as a generic automation clone. The main product surface 
 - Onchain EVM transaction shell with dry-run support and receipt polling
 - Autopilot control plane with `off`, `assist`, and `auto` modes
 - Operator UI for dashboard, sources, watchlists, evidence, cases, policy, agents, credentials, automation, audit, onchain, and autopilot
+- CoPilot mode for multi-participant desk collaboration (humans + AI copilots, real-time SSE, confirmation queue)
+- Federation layer for swarming intelligence desks across peers
 - Effect-powered UI transport layer for typed browser-side timeouts, retries, and HTTP error normalization
+- Single-binary distribution with bundled UI for Linux, macOS, and Windows
 - GitHub Pages marketing site under `site/`
 
 ## Architecture
@@ -51,25 +54,56 @@ Helix uses a functional core / imperative shell design:
 
 ## Quickstart
 
+### Install (one line)
+
+**macOS / Linux:**
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform/main/scripts/install_helix.sh | bash
+```
+
+**Windows (PowerShell):**
+
+```powershell
+iwr https://raw.githubusercontent.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform/main/scripts/install_helix.ps1 -OutFile install_helix.ps1
+.\install_helix.ps1
+```
+
+Then run:
+
+```bash
+helix
+```
+
+Open `http://127.0.0.1:3000` in your browser. Done.
+
+### From source
+
 ```bash
 ./scripts/setup_local.sh
 ./scripts/run_local.sh
 ```
 
-Containerized local run with Postgres:
+### Containerized (with Postgres)
 
 ```bash
 ./scripts/run_compose.sh
 ```
 
-Prebuilt release archives install a `helix` launcher with the UI bundled; see
-[`docs/install.md`](docs/install.md).
+### CLI options
+
+```
+helix                              Start with defaults (127.0.0.1:3000)
+helix --addr 0.0.0.0:3000          Listen on all interfaces
+helix --ui-dist ./ui/dist          Serve UI from custom path
+helix --version                    Print version
+helix --help                       Show all options
+```
 
 Default local addresses:
 
-- API: `http://127.0.0.1:3000`
-- UI: `http://127.0.0.1:5173`
-- Compose UI/API: `http://127.0.0.1:3000`
+- API + UI: `http://127.0.0.1:3000`
+- Dev UI (from source): `http://127.0.0.1:5173`
 
 ## Public Environment Configuration
 

--- a/crates/helix-api/Cargo.toml
+++ b/crates/helix-api/Cargo.toml
@@ -28,6 +28,7 @@ sqlx = { workspace = true, features = ["runtime-tokio-rustls", "postgres", "json
 tower-http = { version = "0.5.0", features = ["trace", "cors", "fs"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+futures = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/crates/helix-api/Cargo.toml
+++ b/crates/helix-api/Cargo.toml
@@ -14,6 +14,7 @@ helix-llm = { path = "../helix-llm" }
 helix-rule-engine = { path = "../helix-rule-engine" }
 helix-runtime = { path = "../helix-runtime" }
 helix-security = { path = "../helix-security" }
+helix-federation = { path = "../helix-federation" }
 tokio = { version = "1", features = ["full"] }
 axum = "0.7"
 hyper = { version = "1", features = ["full"] }
@@ -21,6 +22,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 sha2 = { workspace = true }
+chrono = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio-rustls", "postgres", "json", "uuid", "chrono"] }
 tower-http = { version = "0.5.0", features = ["trace", "cors", "fs"] }
 tracing = "0.1"

--- a/crates/helix-api/Cargo.toml
+++ b/crates/helix-api/Cargo.toml
@@ -15,6 +15,7 @@ helix-rule-engine = { path = "../helix-rule-engine" }
 helix-runtime = { path = "../helix-runtime" }
 helix-security = { path = "../helix-security" }
 helix-federation = { path = "../helix-federation" }
+helix-operator = { path = "../helix-operator" }
 tokio = { version = "1", features = ["full"] }
 axum = "0.7"
 hyper = { version = "1", features = ["full"] }

--- a/crates/helix-api/src/federation.rs
+++ b/crates/helix-api/src/federation.rs
@@ -1,0 +1,444 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Federation API handlers: peer CRUD, dispatch log, inbound receive,
+//! and federation status.
+
+use crate::intel::IngestEvidenceRequest;
+use crate::{api_error_response, AppState, HelixError};
+use helix_core::intel_desk::{SourceDefinition, SourceKind};
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use helix_federation::{
+    compute_overview, DispatchLogEntry, FederationEvent, FederationEventKind,
+    OutboundDispatcher, PeerDesk, PeerRegistryQuery,
+};
+use serde::{Deserialize, Serialize};
+
+/// Query params for listing dispatch log entries.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct DispatchLogQuery {
+    pub(crate) limit: Option<usize>,
+}
+
+/// Request to create or update a peer desk.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct UpsertPeerRequest {
+    pub(crate) id: String,
+    pub(crate) name: String,
+    pub(crate) endpoint_url: String,
+    pub(crate) auth_token: String,
+    pub(crate) trust_score: u8,
+    pub(crate) enabled: bool,
+    #[serde(default)]
+    pub(crate) tags: Vec<String>,
+}
+
+/// Response for a single peer.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct PeerResponse {
+    pub(crate) peer: PeerDesk,
+}
+
+/// Response for listing peers.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct PeerListResponse {
+    pub(crate) peers: Vec<PeerDesk>,
+}
+
+/// Response for the dispatch log.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct DispatchLogResponse {
+    pub(crate) entries: Vec<DispatchLogEntry>,
+}
+
+/// Response for the inbound receive endpoint.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct FederationReceiveResponse {
+    pub(crate) accepted: bool,
+    pub(crate) evidence_id: Option<String>,
+    pub(crate) message: String,
+}
+
+/// Request to manually broadcast an event to peers.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ManualBroadcastRequest {
+    pub(crate) title: String,
+    pub(crate) summary: String,
+    pub(crate) content: String,
+    #[serde(default)]
+    pub(crate) url: Option<String>,
+    #[serde(default)]
+    pub(crate) entity_labels: Vec<String>,
+    #[serde(default)]
+    pub(crate) tags: Vec<String>,
+}
+
+/// Response for a manual broadcast.
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct ManualBroadcastResponse {
+    pub(crate) event_id: String,
+    pub(crate) dispatch_count: usize,
+    pub(crate) results: Vec<DispatchLogEntry>,
+}
+
+// --- Handlers ---
+
+pub(crate) async fn get_federation_overview(State(state): State<AppState>) -> Response {
+    let desk_id = state.federation_desk_id.clone();
+    let overview = compute_overview(&desk_id, &state.federation_registry, &state.federation_log).await;
+    (StatusCode::OK, Json(overview)).into_response()
+}
+
+pub(crate) async fn list_peers(
+    State(state): State<AppState>,
+    Query(query): Query<PeerRegistryQuery>,
+) -> Response {
+    let peers = state.federation_registry.list(&query).await;
+    (StatusCode::OK, Json(PeerListResponse { peers })).into_response()
+}
+
+pub(crate) async fn get_peer(
+    State(state): State<AppState>,
+    Path(peer_id): Path<String>,
+) -> Response {
+    match state.federation_registry.get(&peer_id).await {
+        Some(peer) => (StatusCode::OK, Json(PeerResponse { peer })).into_response(),
+        None => api_error_response(HelixError::not_found(format!("peer {peer_id}"))),
+    }
+}
+
+pub(crate) async fn upsert_peer(
+    State(state): State<AppState>,
+    Json(request): Json<UpsertPeerRequest>,
+) -> Response {
+    let now = chrono::Utc::now().to_rfc3339();
+    let existing = state.federation_registry.get(&request.id).await;
+    let peer = PeerDesk {
+        id: request.id,
+        name: request.name,
+        endpoint_url: request.endpoint_url,
+        auth_token: request.auth_token,
+        trust_score: request.trust_score,
+        enabled: request.enabled,
+        tags: request.tags,
+        created_at: existing
+            .as_ref()
+            .map(|p| p.created_at.clone())
+            .unwrap_or_else(|| now.clone()),
+        updated_at: now,
+    };
+
+    match state.federation_registry.upsert(peer.clone()).await {
+        Ok(saved) => {
+            let status = if existing.is_some() {
+                StatusCode::OK
+            } else {
+                StatusCode::CREATED
+            };
+            (status, Json(PeerResponse { peer: saved })).into_response()
+        }
+        Err(err) => api_error_response(HelixError::validation_error("peer", &err.to_string())),
+    }
+}
+
+pub(crate) async fn delete_peer(
+    State(state): State<AppState>,
+    Path(peer_id): Path<String>,
+) -> Response {
+    match state.federation_registry.remove(&peer_id).await {
+        Ok(peer) => (StatusCode::OK, Json(PeerResponse { peer })).into_response(),
+        Err(err) => api_error_response(HelixError::not_found(&err.to_string())),
+    }
+}
+
+pub(crate) async fn get_dispatch_log(
+    State(state): State<AppState>,
+    Query(query): Query<DispatchLogQuery>,
+) -> Response {
+    let limit = query.limit.unwrap_or(50).min(500);
+    let entries = state.federation_log.recent(limit).await;
+    (StatusCode::OK, Json(DispatchLogResponse { entries })).into_response()
+}
+
+pub(crate) async fn manual_broadcast(
+    State(state): State<AppState>,
+    Json(request): Json<ManualBroadcastRequest>,
+) -> Response {
+    let desk_id = state.federation_desk_id.clone();
+    let mut event = FederationEvent::new(
+        &desk_id,
+        FederationEventKind::ManualBroadcast,
+        &request.title,
+        &request.summary,
+        &request.content,
+        80,
+    );
+    event.url = request.url;
+    event.entity_labels = request.entity_labels;
+    event.tags = request.tags;
+
+    let dispatcher = OutboundDispatcher::new(
+        desk_id,
+        state.federation_registry.clone(),
+        state.federation_log.clone(),
+    );
+    let results = dispatcher.dispatch(&event).await;
+
+    (
+        StatusCode::OK,
+        Json(ManualBroadcastResponse {
+            event_id: event.id,
+            dispatch_count: results.len(),
+            results,
+        }),
+    )
+        .into_response()
+}
+
+/// Inbound federation receive endpoint.
+///
+/// Accepts a [`FederationEvent`] from a peer desk and ingests it as evidence
+/// with provenance pointing back to the source desk. A federation source is
+/// auto-registered if it does not already exist.
+pub(crate) async fn receive_federation_event(
+    State(state): State<AppState>,
+    Json(event): Json<FederationEvent>,
+) -> Response {
+    let source_id = format!("federation-{}", event.source_desk_id);
+
+    // Auto-register a federation source if it doesn't exist
+    {
+        let store = state.intel_desk.read().await;
+        if !store.has_source(&source_id) {
+            drop(store);
+            let federation_source = SourceDefinition {
+                id: source_id.clone(),
+                profile_id: "50000000-0000-0000-0000-000000000010".to_string(),
+                name: format!("Federation: {}", event.source_desk_id),
+                description: format!(
+                    "Inbound intelligence from peer desk {} (trust: {})",
+                    event.source_desk_id, event.trust_score
+                ),
+                kind: SourceKind::WebhookIngest,
+                endpoint_url: None,
+                credential_id: None,
+                credential_header_name: "Authorization".to_string(),
+                credential_header_prefix: Some("Bearer".to_string()),
+                cadence_minutes: 0,
+                trust_score: event.trust_score,
+                enabled: true,
+                tags: vec!["federation".to_string()],
+            };
+            let mut store = state.intel_desk.write().await;
+            store.upsert_source(federation_source);
+        }
+    }
+
+    // Build an evidence ingest request from the federation event
+    let mut tags = event.tags.clone();
+    tags.push(format!("federation-{}", event.source_desk_id));
+    tags.push(event.event_type.clone());
+
+    let ingest_request = IngestEvidenceRequest {
+        source_id,
+        title: event.title.clone(),
+        summary: event.summary.clone(),
+        content: event.content.clone(),
+        url: event.url.clone(),
+        observed_at: event.observed_at.clone(),
+        tags,
+        entity_labels: event.entity_labels.clone(),
+        proposed_claims: vec![],
+    };
+
+    // Ingest the evidence through the standard pipeline
+    let result = crate::intel::ingest_evidence_internal(&state, ingest_request).await;
+
+    match result {
+        Ok(response) => {
+            // Record audit event
+            let _ = crate::record_audit_event(
+                &state,
+                crate::AuditEvent::allow(
+                    "federation.receive",
+                    format!("evidence/{}", response.evidence.id),
+                    serde_json::json!({
+                        "source_desk_id": event.source_desk_id,
+                        "event_id": event.id,
+                        "event_type": event.event_type,
+                        "evidence_id": response.evidence.id,
+                        "duplicate": response.duplicate,
+                        "trust_score": event.trust_score,
+                    }),
+                ),
+            )
+            .await;
+
+            (
+                StatusCode::CREATED,
+                Json(FederationReceiveResponse {
+                    accepted: true,
+                    evidence_id: Some(response.evidence.id),
+                    message: format!(
+                        "Evidence ingested from desk {} (trust: {})",
+                        event.source_desk_id, event.trust_score
+                    ),
+                }),
+            )
+                .into_response()
+        }
+        Err(error) => {
+            let _ = crate::record_audit_event(
+                &state,
+                crate::AuditEvent::deny(
+                    "federation.receive",
+                    "federation/receive",
+                    &error.to_string(),
+                    serde_json::json!({
+                        "source_desk_id": event.source_desk_id,
+                        "event_id": event.id,
+                        "error": error.to_string(),
+                    }),
+                ),
+            )
+            .await;
+            api_error_response(error)
+        }
+    }
+}
+
+// --- Outbound dispatch hooks ---
+
+/// Dispatches a federation event for a case escalation.
+/// Called after a case transitions to a higher severity.
+pub(crate) async fn dispatch_case_escalated(
+    state: &AppState,
+    case_id: &str,
+    case_title: &str,
+    case_summary: &str,
+) {
+    dispatch_event(
+        state,
+        FederationEventKind::CaseEscalated,
+        &format!("Case escalated: {case_title}"),
+        case_summary,
+        &format!("Case {case_id} has been escalated."),
+        Some(case_id),
+        None,
+    )
+    .await;
+}
+
+/// Dispatches a federation event for a new case opening.
+pub(crate) async fn dispatch_case_opened(
+    state: &AppState,
+    case_id: &str,
+    case_title: &str,
+    case_summary: &str,
+) {
+    dispatch_event(
+        state,
+        FederationEventKind::CaseOpened,
+        &format!("Case opened: {case_title}"),
+        case_summary,
+        &format!("Case {case_id} has been opened."),
+        Some(case_id),
+        None,
+    )
+    .await;
+}
+
+/// Dispatches a federation event for a watchlist hit.
+pub(crate) async fn dispatch_watchlist_hit(
+    state: &AppState,
+    watchlist_id: &str,
+    evidence_title: &str,
+    evidence_summary: &str,
+) {
+    dispatch_event(
+        state,
+        FederationEventKind::WatchlistHit,
+        &format!("Watchlist hit: {watchlist_id}"),
+        evidence_summary,
+        &format!("Evidence '{evidence_title}' triggered watchlist {watchlist_id}."),
+        None,
+        Some(watchlist_id),
+    )
+    .await;
+}
+
+/// Dispatches a federation event for new evidence ingestion.
+pub(crate) async fn dispatch_evidence_ingested(
+    state: &AppState,
+    evidence_title: &str,
+    evidence_summary: &str,
+    source_id: &str,
+) {
+    dispatch_event(
+        state,
+        FederationEventKind::EvidenceIngested,
+        &format!("New evidence: {evidence_title}"),
+        evidence_summary,
+        &format!("Evidence ingested from source {source_id}."),
+        None,
+        None,
+    )
+    .await;
+}
+
+/// Core dispatch helper. Builds a FederationEvent and sends it to all enabled
+/// peers via the outbound dispatcher. Failures are logged but never propagated
+/// — federation is best-effort and must not block local operations.
+async fn dispatch_event(
+    state: &AppState,
+    kind: FederationEventKind,
+    title: &str,
+    summary: &str,
+    content: &str,
+    case_id: Option<&str>,
+    watchlist_id: Option<&str>,
+) {
+    // Skip if no enabled peers
+    if state.federation_registry.enabled_count().await == 0 {
+        return;
+    }
+
+    let mut event = FederationEvent::new(&state.federation_desk_id, kind, title, summary, content, 80);
+    event.case_id = case_id.map(|s| s.to_string());
+    event.watchlist_id = watchlist_id.map(|s| s.to_string());
+
+    let dispatcher = OutboundDispatcher::new(
+        state.federation_desk_id.clone(),
+        state.federation_registry.clone(),
+        state.federation_log.clone(),
+    );
+    let results = dispatcher.dispatch(&event).await;
+
+    if !results.is_empty() {
+        let delivered = results
+            .iter()
+            .filter(|r| r.status == helix_federation::DispatchStatus::Delivered)
+            .count();
+        let failed = results.len() - delivered;
+        tracing::info!(
+            event_id = %event.id,
+            event_type = %event.event_type,
+            delivered = delivered,
+            failed = failed,
+            "federation dispatch completed"
+        );
+    }
+}

--- a/crates/helix-api/src/intel.rs
+++ b/crates/helix-api/src/intel.rs
@@ -625,6 +625,16 @@ impl IntelDeskPostgresStore {
 }
 
 impl IntelDeskStore {
+    /// Returns true if a source with the given id exists.
+    pub(crate) fn has_source(&self, source_id: &str) -> bool {
+        self.sources.contains_key(source_id)
+    }
+
+    /// Inserts or replaces a source definition.
+    pub(crate) fn upsert_source(&mut self, source: SourceDefinition) {
+        self.sources.insert(source.id.clone(), source);
+    }
+
     pub(crate) fn seeded() -> Self {
         let mut store = Self {
             sources: BTreeMap::new(),
@@ -3447,7 +3457,7 @@ fn serde_error(error: serde_json::Error) -> HelixError {
     HelixError::InternalError(format!("intel desk serialization error: {error}"))
 }
 
-async fn mutate_intel_desk<T>(
+pub(crate) async fn mutate_intel_desk<T>(
     state: &AppState,
     mutation: impl FnOnce(&mut IntelDeskStore) -> Result<T, HelixError>,
 ) -> Result<T, HelixError> {
@@ -4042,8 +4052,8 @@ pub(crate) async fn ingest_evidence(
     State(state): State<AppState>,
     Json(request): Json<IngestEvidenceRequest>,
 ) -> Response {
-    let result = mutate_intel_desk(&state, |store| store.ingest_evidence(request)).await;
-    match result {
+    let source_id = request.source_id.clone();
+    match ingest_evidence_internal(&state, request).await {
         Ok(response) => {
             if let Err(error) = record_audit_event(
                 &state,
@@ -4064,10 +4074,41 @@ pub(crate) async fn ingest_evidence(
             {
                 return api_error_response(error);
             }
+
+            // Federation dispatch: share new evidence with peer desks
+            if !response.duplicate {
+                crate::federation::dispatch_evidence_ingested(
+                    &state,
+                    &response.evidence.title,
+                    &response.evidence.summary,
+                    &source_id,
+                )
+                .await;
+
+                // Dispatch watchlist hits
+                for hit in &response.hits {
+                    crate::federation::dispatch_watchlist_hit(
+                        &state,
+                        &hit.watchlist_id,
+                        &response.evidence.title,
+                        &response.evidence.summary,
+                    )
+                    .await;
+                }
+            }
+
             (StatusCode::CREATED, Json(response)).into_response()
         }
         Err(error) => api_error_response(error),
     }
+}
+
+/// Internal evidence ingestion without the Axum layer, for federation use.
+pub(crate) async fn ingest_evidence_internal(
+    state: &AppState,
+    request: IngestEvidenceRequest,
+) -> Result<IngestEvidenceResponse, HelixError> {
+    mutate_intel_desk(state, |store| store.ingest_evidence(request)).await
 }
 
 pub(crate) async fn list_cases(
@@ -4137,6 +4178,32 @@ pub(crate) async fn transition_case_handler(
             {
                 return api_error_response(error);
             }
+
+            // Federation dispatch: notify peers of case escalation
+            let status_str = format!("{:?}", transition.case.status).to_lowercase();
+            let case_summary = transition
+                .case
+                .briefing_summary
+                .as_deref()
+                .unwrap_or(&transition.case.latest_reason);
+            if status_str.contains("escalat") || status_str.contains("critical") || status_str.contains("high") {
+                crate::federation::dispatch_case_escalated(
+                    &state,
+                    &transition.case.id,
+                    &transition.case.title,
+                    case_summary,
+                )
+                .await;
+            } else if status_str.contains("open") {
+                crate::federation::dispatch_case_opened(
+                    &state,
+                    &transition.case.id,
+                    &transition.case.title,
+                    case_summary,
+                )
+                .await;
+            }
+
             (StatusCode::OK, Json(CaseTransitionResponse { transition })).into_response()
         }
         Err(error) => api_error_response(error),

--- a/crates/helix-api/src/intel.rs
+++ b/crates/helix-api/src/intel.rs
@@ -494,11 +494,11 @@ pub(crate) struct CaseTransitionResponse {
 
 #[derive(Debug, Clone)]
 pub(crate) struct IntelDeskStore {
-    sources: BTreeMap<String, SourceDefinition>,
-    watchlists: BTreeMap<String, Watchlist>,
-    evidence: BTreeMap<String, EvidenceItem>,
-    claims: BTreeMap<String, ClaimRecord>,
-    cases: BTreeMap<String, CaseFile>,
+    pub(crate) sources: BTreeMap<String, SourceDefinition>,
+    pub(crate) watchlists: BTreeMap<String, Watchlist>,
+    pub(crate) evidence: BTreeMap<String, EvidenceItem>,
+    pub(crate) claims: BTreeMap<String, ClaimRecord>,
+    pub(crate) cases: BTreeMap<String, CaseFile>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/helix-api/src/main.rs
+++ b/crates/helix-api/src/main.rs
@@ -14,8 +14,13 @@
 //! Helix REST API.
 
 mod evm_rpc;
+mod federation;
 mod intel;
 
+use crate::federation::{
+    delete_peer, get_dispatch_log, get_federation_overview, get_peer, list_peers,
+    manual_broadcast, receive_federation_event, upsert_peer,
+};
 use crate::intel::{
     collect_due_sources_handler, collect_source_handler, create_source, create_watchlist,
     export_autopilot_review_packet, export_market_brief_packet_handler, file_import_handler,
@@ -64,6 +69,7 @@ use helix_core::recipe::Recipe;
 use helix_core::state::{InMemoryStateStore, StateStore};
 use helix_core::types::{AgentId, CredentialId, ProfileId};
 use helix_core::HelixError;
+use helix_federation::{DispatchLog, PeerRegistry};
 use helix_llm::providers::{LlmProvider, LlmRequest, Message, MessageRole, OpenAiProvider};
 use helix_rule_engine::event_listener::RuleEngineEventListener;
 use helix_rule_engine::rules::{ParameterValue, RecipeTriggerPlan, Rule};
@@ -102,6 +108,9 @@ pub(crate) struct AppState {
     llm_provider: Option<Arc<dyn LlmProvider>>,
     llm_model: Option<String>,
     auth_service: Arc<AuthService>,
+    federation_registry: PeerRegistry,
+    federation_log: DispatchLog,
+    federation_desk_id: String,
 }
 
 const SYMBOLIC_PROGRAM_CACHE_CAPACITY: usize = 128;
@@ -803,6 +812,9 @@ async fn main() {
         llm_provider,
         llm_model,
         auth_service: Arc::new(api_auth_from_env()),
+        federation_registry: PeerRegistry::new(),
+        federation_log: DispatchLog::new(500),
+        federation_desk_id: helix_federation::desk_id_from_env(),
     };
     let app = app_with_optional_static_ui(state);
 
@@ -1872,7 +1884,7 @@ async fn onchain_get_receipt(Json(req): Json<OnchainReceiptRequest>) -> Response
     }
 }
 
-fn api_error_response(error: HelixError) -> Response {
+pub(crate) fn api_error_response(error: HelixError) -> Response {
     let status = match error {
         HelixError::NotFound(_) => StatusCode::NOT_FOUND,
         HelixError::ValidationError { .. } => StatusCode::BAD_REQUEST,
@@ -3318,6 +3330,16 @@ fn api_router() -> Router<AppState> {
         .route("/api/v1/autopilot/execute", post(post_autopilot_execute))
         .route("/api/v1/onchain/send_raw", post(onchain_send_raw))
         .route("/api/v1/onchain/receipt", post(onchain_get_receipt))
+        // Federation: peer desk networking
+        .route("/api/v1/federation/overview", get(get_federation_overview))
+        .route("/api/v1/federation/peers", get(list_peers).post(upsert_peer))
+        .route(
+            "/api/v1/federation/peers/:peer_id",
+            get(get_peer).delete(delete_peer),
+        )
+        .route("/api/v1/federation/dispatch-log", get(get_dispatch_log))
+        .route("/api/v1/federation/broadcast", post(manual_broadcast))
+        .route("/api/v1/federation/receive", post(receive_federation_event))
 }
 
 async fn require_api_auth(State(state): State<AppState>, req: Request, next: Next) -> Response {
@@ -3384,6 +3406,9 @@ mod tests {
             llm_provider,
             llm_model,
             auth_service: Arc::new(AuthService::disabled()),
+            federation_registry: helix_federation::PeerRegistry::new(),
+            federation_log: helix_federation::DispatchLog::new(100),
+            federation_desk_id: "test-desk".to_string(),
         }
     }
 
@@ -6591,5 +6616,207 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn federation_overview_returns_empty_state() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/federation/overview")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let overview: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(overview["status"]["peer_count"], 0);
+        assert_eq!(overview["status"]["federation_enabled"], false);
+    }
+
+    #[tokio::test]
+    async fn federation_peer_crud_roundtrip() {
+        let app = test_app();
+
+        // Create a peer
+        let peer_json = serde_json::json!({
+            "id": "desk-beta",
+            "name": "Beta Desk",
+            "endpoint_url": "https://beta.helix.io",
+            "auth_token": "secret-token-abc",
+            "trust_score": 80,
+            "enabled": true,
+            "tags": ["osint"],
+        });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/federation/peers")
+                    .header("content-type", "application/json")
+                    .body(Body::from(peer_json.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+
+        // List peers
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/federation/peers")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let list: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(list["peers"].as_array().unwrap().len(), 1);
+        assert_eq!(list["peers"][0]["id"], "desk-beta");
+
+        // Get single peer
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/federation/peers/desk-beta")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // Delete peer
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/v1/federation/peers/desk-beta")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn federation_peer_validation_rejects_bad_url() {
+        let app = test_app();
+        let peer_json = serde_json::json!({
+            "id": "desk-bad",
+            "name": "Bad Desk",
+            "endpoint_url": "not-a-url",
+            "auth_token": "secret-token-abc",
+            "trust_score": 80,
+            "enabled": true,
+            "tags": [],
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/federation/peers")
+                    .header("content-type", "application/json")
+                    .body(Body::from(peer_json.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn federation_dispatch_log_is_empty_initially() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/federation/dispatch-log")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let log: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(log["entries"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn federation_receive_ingests_evidence() {
+        let app = test_app();
+        let event_json = serde_json::json!({
+            "specversion": "1.0",
+            "id": "fed-test-001",
+            "type": "helix.case.escalated",
+            "source_desk_id": "desk-remote",
+            "target_desk_id": "*",
+            "title": "Remote case escalation",
+            "summary": "Executive departure at target company",
+            "content": "Full details of the escalation",
+            "url": null,
+            "observed_at": "2026-01-01T00:00:00Z",
+            "kind": "case_escalated",
+            "trust_score": 85,
+            "entity_labels": ["alice"],
+            "tags": ["osint"],
+            "case_id": null,
+            "watchlist_id": null,
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/federation/receive")
+                    .header("content-type", "application/json")
+                    .body(Body::from(event_json.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["accepted"], true);
+        assert!(result["evidence_id"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn federation_manual_broadcast_with_no_peers() {
+        let app = test_app();
+        let broadcast_json = serde_json::json!({
+            "title": "Manual broadcast",
+            "summary": "Test broadcast",
+            "content": "Content",
+            "url": null,
+            "entity_labels": [],
+            "tags": [],
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/federation/broadcast")
+                    .header("content-type", "application/json")
+                    .body(Body::from(broadcast_json.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["dispatch_count"], 0);
     }
 }

--- a/crates/helix-api/src/main.rs
+++ b/crates/helix-api/src/main.rs
@@ -16,10 +16,16 @@
 mod evm_rpc;
 mod federation;
 mod intel;
+mod operator;
 
 use crate::federation::{
     delete_peer, get_dispatch_log, get_federation_overview, get_peer, list_peers,
     manual_broadcast, receive_federation_event, upsert_peer,
+};
+use crate::operator::{
+    clear_operator_activity, get_operator_activity, get_operator_config,
+    get_operator_status, pause_operator, start_operator, stop_operator,
+    update_operator_config,
 };
 use crate::intel::{
     collect_due_sources_handler, collect_source_handler, create_source, create_watchlist,
@@ -111,6 +117,7 @@ pub(crate) struct AppState {
     federation_registry: PeerRegistry,
     federation_log: DispatchLog,
     federation_desk_id: String,
+    operator_loop: Arc<helix_operator::OperatorLoop>,
 }
 
 const SYMBOLIC_PROGRAM_CACHE_CAPACITY: usize = 128;
@@ -815,6 +822,9 @@ async fn main() {
         federation_registry: PeerRegistry::new(),
         federation_log: DispatchLog::new(500),
         federation_desk_id: helix_federation::desk_id_from_env(),
+        operator_loop: Arc::new(helix_operator::OperatorLoop::from_config(
+            helix_operator::DeskOperatorConfig::default(),
+        )),
     };
     let app = app_with_optional_static_ui(state);
 
@@ -3340,6 +3350,16 @@ fn api_router() -> Router<AppState> {
         .route("/api/v1/federation/dispatch-log", get(get_dispatch_log))
         .route("/api/v1/federation/broadcast", post(manual_broadcast))
         .route("/api/v1/federation/receive", post(receive_federation_event))
+        // Operator: LLM-driven desk operator
+        .route("/api/v1/operator/status", get(get_operator_status))
+        .route("/api/v1/operator/config", get(get_operator_config).put(update_operator_config))
+        .route("/api/v1/operator/start", post(start_operator))
+        .route("/api/v1/operator/stop", post(stop_operator))
+        .route("/api/v1/operator/pause", post(pause_operator))
+        .route(
+            "/api/v1/operator/activity",
+            get(get_operator_activity).delete(clear_operator_activity),
+        )
 }
 
 async fn require_api_auth(State(state): State<AppState>, req: Request, next: Next) -> Response {
@@ -3409,6 +3429,9 @@ mod tests {
             federation_registry: helix_federation::PeerRegistry::new(),
             federation_log: helix_federation::DispatchLog::new(100),
             federation_desk_id: "test-desk".to_string(),
+            operator_loop: Arc::new(helix_operator::OperatorLoop::from_config(
+                helix_operator::DeskOperatorConfig::default(),
+            )),
         }
     }
 
@@ -6818,5 +6841,225 @@ mod tests {
         let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
         let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(result["dispatch_count"], 0);
+    }
+
+    // ---- Operator integration tests ----
+
+    #[tokio::test]
+    async fn operator_status_returns_stopped_by_default() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/operator/status")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["status"], "stopped");
+        assert_eq!(result["cycle_count"], 0);
+        assert_eq!(result["activity_log_count"], 0);
+    }
+
+    #[tokio::test]
+    async fn operator_config_returns_default() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/operator/config")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["config"]["model"], "gpt-4o-mini");
+        assert_eq!(result["config"]["autopilot_mode"], "assist");
+        assert_eq!(result["config"]["action_scope"], "intelligence");
+    }
+
+    #[tokio::test]
+    async fn operator_update_config_changes_model() {
+        let app = test_app();
+        let req_body = serde_json::json!({
+            "model": "claude-opus-4",
+            "loop_interval_secs": 30
+        });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/operator/config")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["config"]["model"], "claude-opus-4");
+        assert_eq!(result["config"]["loop_interval_secs"], 30);
+    }
+
+    #[tokio::test]
+    async fn operator_update_config_rejects_invalid_interval() {
+        let app = test_app();
+        let req_body = serde_json::json!({"loop_interval_secs": 1});
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/operator/config")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn operator_start_then_stop_changes_status() {
+        let app = test_app();
+
+        // Start
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["status"], "running");
+
+        // Stop
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/stop")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["status"], "stopped");
+    }
+
+    #[tokio::test]
+    async fn operator_pause_changes_status_to_paused() {
+        let app = test_app();
+
+        // Start first
+        let _ = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Pause
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/pause")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["status"], "paused");
+    }
+
+    #[tokio::test]
+    async fn operator_activity_returns_empty_by_default() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/operator/activity")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["entries"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn operator_activity_with_limit_query_param() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/operator/activity?limit=10")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn operator_double_start_returns_bad_request() {
+        let app = test_app();
+        // First start
+        let _ = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // Second start should fail
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/start")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 }

--- a/crates/helix-api/src/main.rs
+++ b/crates/helix-api/src/main.rs
@@ -2813,7 +2813,7 @@ async fn complete_autopilot_proposal(
             content: user_payload,
             function_call: None,
         }],
-        max_tokens: Some(512),
+        max_tokens: Some(4096),
         temperature: Some(0.0),
         top_p: Some(1.0),
         functions: None,
@@ -3022,6 +3022,18 @@ async fn post_autopilot_execute(
         AutopilotGuardDecision::Allow {
             requires_confirmation,
         } => {
+            if requires_confirmation && !req.confirmed_by_human {
+                return (
+                    StatusCode::OK,
+                    Json(AutopilotExecuteResponse {
+                        allowed: false,
+                        reason: Some("assist_requires_confirmation".to_string()),
+                        requires_confirmation: true,
+                        result: None,
+                    }),
+                )
+                    .into_response();
+            }
             let result = async {
                 let value = match req.action {
                     AutopilotActionRequest::PolicySimulation { commands } => {
@@ -6664,7 +6676,9 @@ mod tests {
 
         assert!(matches!(
             payload.guard_preview.decision_unconfirmed,
-            AutopilotGuardDecision::Deny { reason } if reason == "assist_requires_confirmation"
+            AutopilotGuardDecision::Allow {
+                requires_confirmation: true
+            }
         ));
         assert!(matches!(
             payload.guard_preview.decision_confirmed,
@@ -6702,6 +6716,7 @@ mod tests {
             payload.reason.as_deref(),
             Some("assist_requires_confirmation")
         );
+        assert!(payload.requires_confirmation);
     }
 
     #[tokio::test]

--- a/crates/helix-api/src/main.rs
+++ b/crates/helix-api/src/main.rs
@@ -23,9 +23,10 @@ use crate::federation::{
     manual_broadcast, receive_federation_event, upsert_peer,
 };
 use crate::operator::{
-    clear_operator_activity, get_operator_activity, get_operator_config,
-    get_operator_status, pause_operator, start_operator, stop_operator,
-    update_operator_config,
+    clear_operator_activity, confirm_proposal, deny_proposal, get_operator_activity,
+    get_operator_config, get_operator_status, join_session, leave_session,
+    list_confirmations, list_sessions, operator_stream, pause_operator, session_heartbeat,
+    start_operator, stop_operator, update_operator_config,
 };
 use crate::intel::{
     collect_due_sources_handler, collect_source_handler, create_source, create_watchlist,
@@ -118,6 +119,7 @@ pub(crate) struct AppState {
     federation_log: DispatchLog,
     federation_desk_id: String,
     operator_loop: Arc<helix_operator::OperatorLoop>,
+    operator_registry: helix_operator::OperatorRegistry,
 }
 
 const SYMBOLIC_PROGRAM_CACHE_CAPACITY: usize = 128;
@@ -825,6 +827,7 @@ async fn main() {
         operator_loop: Arc::new(helix_operator::OperatorLoop::from_config(
             helix_operator::DeskOperatorConfig::default(),
         )),
+        operator_registry: helix_operator::OperatorRegistry::new(),
     };
     let app = app_with_optional_static_ui(state);
 
@@ -3360,6 +3363,26 @@ fn api_router() -> Router<AppState> {
             "/api/v1/operator/activity",
             get(get_operator_activity).delete(clear_operator_activity),
         )
+        // CoPilot mode: multi-participant collaboration
+        .route("/api/v1/operator/sessions", post(join_session).get(list_sessions))
+        .route(
+            "/api/v1/operator/sessions/:session_id",
+            delete(leave_session),
+        )
+        .route(
+            "/api/v1/operator/sessions/:session_id/heartbeat",
+            post(session_heartbeat),
+        )
+        .route("/api/v1/operator/confirmations", get(list_confirmations))
+        .route(
+            "/api/v1/operator/confirmations/:confirmation_id/confirm",
+            post(confirm_proposal),
+        )
+        .route(
+            "/api/v1/operator/confirmations/:confirmation_id/deny",
+            post(deny_proposal),
+        )
+        .route("/api/v1/operator/stream", get(operator_stream))
 }
 
 async fn require_api_auth(State(state): State<AppState>, req: Request, next: Next) -> Response {
@@ -3432,6 +3455,7 @@ mod tests {
             operator_loop: Arc::new(helix_operator::OperatorLoop::from_config(
                 helix_operator::DeskOperatorConfig::default(),
             )),
+            operator_registry: helix_operator::OperatorRegistry::new(),
         }
     }
 
@@ -7061,5 +7085,309 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // ---- CoPilot integration tests ----
+
+    #[tokio::test]
+    async fn copilot_join_creates_session() {
+        let app = test_app();
+        let req_body = serde_json::json!({
+            "display_name": "Alice",
+            "kind": "human",
+            "role": "operator"
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["session"]["display_name"], "Alice");
+        assert_eq!(result["session"]["kind"], "human");
+        assert_eq!(result["session"]["status"], "active");
+        assert!(result["session"]["id"].as_str().unwrap().starts_with("sess-"));
+    }
+
+    #[tokio::test]
+    async fn copilot_join_rejects_empty_name() {
+        let app = test_app();
+        let req_body = serde_json::json!({"display_name": ""});
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn copilot_list_sessions_shows_joined() {
+        let app = test_app();
+        // Join
+        let req_body = serde_json::json!({"display_name": "Bob", "kind": "human"});
+        let _ = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // List
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/operator/sessions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["sessions"].as_array().unwrap().len(), 1);
+        assert_eq!(result["human_count"], 1);
+        assert_eq!(result["ai_count"], 0);
+    }
+
+    #[tokio::test]
+    async fn copilot_leave_removes_session() {
+        let app = test_app();
+        // Join
+        let req_body = serde_json::json!({"display_name": "Carol"});
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let session_id = result["session"]["id"].as_str().unwrap();
+
+        // Leave
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(&format!("/api/v1/operator/sessions/{session_id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        // List should be empty
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/operator/sessions")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["sessions"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn copilot_heartbeat_keeps_session_alive() {
+        let app = test_app();
+        // Join
+        let req_body = serde_json::json!({"display_name": "Dave"});
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let session_id = result["session"]["id"].as_str().unwrap();
+
+        // Heartbeat
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(&format!("/api/v1/operator/sessions/{session_id}/heartbeat"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn copilot_heartbeat_returns_not_found_for_missing() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/sessions/nonexistent/heartbeat")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn copilot_confirmations_empty_initially() {
+        let app = test_app();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/operator/confirmations")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["pending"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn copilot_confirm_nonexistent_returns_not_found() {
+        let app = test_app();
+        let req_body = serde_json::json!({"session_id": "fake"});
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/confirmations/fake-id/confirm")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn copilot_confirm_with_missing_session_returns_not_found() {
+        let app = test_app();
+        let req_body = serde_json::json!({"session_id": "nonexistent-session"});
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/confirmations/fake-id/confirm")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn copilot_join_ai_copilot() {
+        let app = test_app();
+        let req_body = serde_json::json!({
+            "display_name": "AI Copilot",
+            "kind": "ai",
+            "role": "operator"
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(result["session"]["kind"], "ai");
+    }
+
+    #[tokio::test]
+    async fn copilot_viewer_cannot_confirm() {
+        let app = test_app();
+        // Join as viewer
+        let req_body = serde_json::json!({
+            "display_name": "Viewer",
+            "kind": "human",
+            "role": "viewer"
+        });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/sessions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        let result: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let session_id = result["session"]["id"].as_str().unwrap();
+
+        // Try to confirm — should be forbidden
+        let req_body = serde_json::json!({"session_id": session_id});
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/operator/confirmations/fake-id/confirm")
+                    .header("content-type", "application/json")
+                    .body(Body::from(req_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/crates/helix-api/src/main.rs
+++ b/crates/helix-api/src/main.rs
@@ -749,9 +749,126 @@ impl SymbolicProgramCache {
     }
 }
 
+/// Parsed command-line arguments.
+struct CliArgs {
+    addr: Option<SocketAddr>,
+    ui_dist: Option<PathBuf>,
+}
+
+const HELIX_VERSION: &str = env!("CARGO_PKG_VERSION");
+const HELIX_HELP_TEXT: &str = "\
+Helix — Event-Driven Multi-Agent Intelligence Platform
+
+USAGE:
+    helix [OPTIONS]
+
+OPTIONS:
+    --addr <ADDR>       Listen address (default: 127.0.0.1:3000, env: HELIX_API_ADDR)
+    --ui-dist <DIR>     Path to built UI static files (env: HELIX_UI_DIST)
+    --version, -V       Print version and exit
+    --help, -h          Print this help and exit
+
+ENVIRONMENT:
+    HELIX_API_ADDR              Listen address (default: 127.0.0.1:3000)
+    HELIX_UI_DIST               Path to UI static files directory
+    DATABASE_URL                PostgreSQL connection string (optional, in-memory if unset)
+    HELIX_AUTO_MIGRATE          Run DB migrations on startup (default: false)
+    HELIX_AUTH_REQUIRED         Require API token auth (default: false)
+    HELIX_API_TOKEN             API token for authentication
+    HELIX_AUTOPILOT_LLM_MODEL   LLM model for operator (e.g. gpt-4o)
+    HELIX_AUTOPILOT_MODE        Operator mode: off | assist | auto (default: assist)
+
+EXAMPLES:
+    helix                                    Start with defaults
+    helix --addr 0.0.0.0:3000                Listen on all interfaces
+    helix --ui-dist ./ui/dist                Serve UI from custom path
+    HELIX_AUTOPILOT_LLM_MODEL=gpt-4o helix   Start with LLM operator
+";
+
+fn parse_cli_args() -> CliArgs {
+    let mut args = CliArgs {
+        addr: None,
+        ui_dist: None,
+    };
+    let mut iter = std::env::args().skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--version" | "-V" => {
+                println!("helix {}", HELIX_VERSION);
+                std::process::exit(0);
+            }
+            "--help" | "-h" => {
+                print!("{}", HELIX_HELP_TEXT);
+                std::process::exit(0);
+            }
+            "--addr" => {
+                let Some(value) = iter.next() else {
+                    eprintln!("error: --addr requires a value (e.g. --addr 0.0.0.0:3000)");
+                    std::process::exit(2);
+                };
+                match value.parse::<SocketAddr>() {
+                    Ok(addr) => args.addr = Some(addr),
+                    Err(e) => {
+                        eprintln!("error: invalid --addr value '{value}': {e}");
+                        std::process::exit(2);
+                    }
+                }
+            }
+            "--ui-dist" => {
+                let Some(value) = iter.next() else {
+                    eprintln!("error: --ui-dist requires a value (e.g. --ui-dist ./ui/dist)");
+                    std::process::exit(2);
+                };
+                args.ui_dist = Some(PathBuf::from(value));
+            }
+            other if other.starts_with("--addr=") => {
+                let value = &other[7..];
+                match value.parse::<SocketAddr>() {
+                    Ok(addr) => args.addr = Some(addr),
+                    Err(e) => {
+                        eprintln!("error: invalid --addr value '{value}': {e}");
+                        std::process::exit(2);
+                    }
+                }
+            }
+            other if other.starts_with("--ui-dist=") => {
+                args.ui_dist = Some(PathBuf::from(&other[10..]));
+            }
+            other => {
+                eprintln!("error: unknown argument '{other}'\n\nRun 'helix --help' for usage.");
+                std::process::exit(2);
+            }
+        }
+    }
+    args
+}
+
+fn print_startup_banner(addr: SocketAddr, ui_served: bool, db_connected: bool) {
+    let ui_status = if ui_served { "enabled" } else { "disabled (no UI dist found)" };
+    let db_status = if db_connected { "PostgreSQL" } else { "in-memory" };
+    eprintln!();
+    eprintln!("  ╔══════════════════════════════════════════════╗");
+    eprintln!("  ║          Helix v{}                        ║", HELIX_VERSION);
+    eprintln!("  ║          Event-Driven Multi-Agent Platform   ║");
+    eprintln!("  ╚══════════════════════════════════════════════╝");
+    eprintln!();
+    eprintln!("  Web UI:     http://{}  ({})", addr, ui_status);
+    eprintln!("  API:        http://{}/api/v1/health", addr);
+    eprintln!("  Storage:    {}", db_status);
+    eprintln!();
+    eprintln!("  Press Ctrl+C to stop.");
+    eprintln!();
+}
+
 #[tokio::main]
 async fn main() {
+    let cli = parse_cli_args();
     tracing_subscriber::fmt::init();
+
+    // CLI --ui-dist overrides env var
+    if let Some(ui_dist) = &cli.ui_dist {
+        std::env::set_var(HELIX_UI_DIST_ENV, ui_dist);
+    }
 
     let (llm_provider, llm_model) = match llm_provider_from_env() {
         Some((provider, model)) => (Some(provider), Some(model)),
@@ -831,7 +948,10 @@ async fn main() {
     };
     let app = app_with_optional_static_ui(state);
 
-    let addr = api_addr_from_env();
+    let addr = cli.addr.unwrap_or_else(api_addr_from_env);
+    let ui_served = std::env::var_os(HELIX_UI_DIST_ENV).is_some();
+    let db_connected = postgres_pool.is_some();
+    print_startup_banner(addr, ui_served, db_connected);
     tracing::info!("listening on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();

--- a/crates/helix-api/src/operator.rs
+++ b/crates/helix-api/src/operator.rs
@@ -1,0 +1,264 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Operator API handlers: configuration, status, start/stop, activity log,
+//! and manual cycle trigger.
+
+use crate::{api_error_response, AppState, HelixError};
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use helix_core::autopilot_guard::AutopilotMode;
+use helix_operator::{
+    DeskOperatorConfig, OperatorActionScope, OperatorActivityEntry, OperatorStatus,
+};
+use serde::{Deserialize, Serialize};
+
+/// Query params for limiting activity log results.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct ActivityLogQuery {
+    /// Maximum number of entries to return (newest first). Defaults to 50.
+    pub limit: Option<usize>,
+}
+
+/// Response for `GET /api/v1/operator/status`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperatorStatusResponse {
+    /// Current run status (stopped/running/paused).
+    pub status: OperatorStatus,
+    /// Whether the operator is enabled in config.
+    pub enabled: bool,
+    /// Current autopilot mode.
+    pub autopilot_mode: AutopilotMode,
+    /// Current action scope.
+    pub action_scope: OperatorActionScope,
+    /// Loop interval in seconds.
+    pub loop_interval_secs: u64,
+    /// LLM model in use.
+    pub model: String,
+    /// Number of cycles executed.
+    pub cycle_count: u64,
+    /// Number of activity log entries.
+    pub activity_log_count: usize,
+}
+
+/// Request body for `PUT /api/v1/operator/config`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct UpdateOperatorConfigRequest {
+    /// Whether the operator loop is enabled.
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    /// Autopilot mode.
+    #[serde(default)]
+    pub autopilot_mode: Option<AutopilotMode>,
+    /// Action scope.
+    #[serde(default)]
+    pub action_scope: Option<OperatorActionScope>,
+    /// Loop interval in seconds.
+    #[serde(default)]
+    pub loop_interval_secs: Option<u64>,
+    /// Max actions per cycle.
+    #[serde(default)]
+    pub max_actions_per_cycle: Option<usize>,
+    /// Max context items.
+    #[serde(default)]
+    pub max_context_items: Option<usize>,
+    /// LLM model.
+    #[serde(default)]
+    pub model: Option<String>,
+    /// User-defined rules text.
+    #[serde(default)]
+    pub rules_text: Option<String>,
+    /// Whether to dispatch to federation peers.
+    #[serde(default)]
+    pub dispatch_to_peers: Option<bool>,
+    /// Whether to log denied proposals.
+    #[serde(default)]
+    pub log_denied_proposals: Option<bool>,
+}
+
+/// Response for `GET /api/v1/operator/config`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperatorConfigResponse {
+    pub config: DeskOperatorConfig,
+}
+
+/// Response for `POST /api/v1/operator/start` and `POST /api/v1/operator/stop`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperatorControlResponse {
+    pub status: OperatorStatus,
+}
+
+/// Response for `GET /api/v1/operator/activity`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperatorActivityResponse {
+    pub entries: Vec<OperatorActivityEntry>,
+}
+
+/// `GET /api/v1/operator/status`
+pub async fn get_operator_status(State(state): State<AppState>) -> Response {
+    let config = state.operator_loop.config().await;
+    let status = state.operator_loop.status().await;
+    let cycle_count = state.operator_loop.cycle_count().await;
+    let activity_log_count = state.operator_loop.activity_log().len().await;
+
+    Json(OperatorStatusResponse {
+        status,
+        enabled: config.enabled,
+        autopilot_mode: config.autopilot_mode,
+        action_scope: config.action_scope,
+        loop_interval_secs: config.loop_interval_secs,
+        model: config.model,
+        cycle_count,
+        activity_log_count,
+    })
+    .into_response()
+}
+
+/// `GET /api/v1/operator/config`
+pub async fn get_operator_config(State(state): State<AppState>) -> Response {
+    let config = state.operator_loop.config().await;
+    Json(OperatorConfigResponse { config }).into_response()
+}
+
+/// `PUT /api/v1/operator/config`
+pub async fn update_operator_config(
+    State(state): State<AppState>,
+    Json(req): Json<UpdateOperatorConfigRequest>,
+) -> Response {
+    let mut current = state.operator_loop.config().await;
+    if let Some(enabled) = req.enabled {
+        current.enabled = enabled;
+    }
+    if let Some(mode) = req.autopilot_mode {
+        current.autopilot_mode = mode;
+    }
+    if let Some(scope) = req.action_scope {
+        current.action_scope = scope;
+    }
+    if let Some(interval) = req.loop_interval_secs {
+        current.loop_interval_secs = interval;
+    }
+    if let Some(max_actions) = req.max_actions_per_cycle {
+        current.max_actions_per_cycle = max_actions;
+    }
+    if let Some(max_ctx) = req.max_context_items {
+        current.max_context_items = max_ctx;
+    }
+    if let Some(model) = req.model {
+        current.model = model;
+    }
+    if let Some(rules) = req.rules_text {
+        current.rules_text = rules;
+    }
+    if let Some(dispatch) = req.dispatch_to_peers {
+        current.dispatch_to_peers = dispatch;
+    }
+    if let Some(log_denied) = req.log_denied_proposals {
+        current.log_denied_proposals = log_denied;
+    }
+
+    if let Err(e) = state.operator_loop.set_config(current.clone()).await {
+        return api_error_response(HelixError::ValidationError {
+            context: "config".to_string(),
+            message: e.to_string(),
+        });
+    }
+
+    Json(OperatorConfigResponse { config: current }).into_response()
+}
+
+/// `POST /api/v1/operator/start`
+pub async fn start_operator(State(state): State<AppState>) -> Response {
+    match state.operator_loop.start().await {
+        Ok(()) => {
+            let status = state.operator_loop.status().await;
+            Json(OperatorControlResponse { status }).into_response()
+        }
+        Err(e) => api_error_response(HelixError::ValidationError {
+            context: "status".to_string(),
+            message: e.to_string(),
+        }),
+    }
+}
+
+/// `POST /api/v1/operator/stop`
+pub async fn stop_operator(State(state): State<AppState>) -> Response {
+    match state.operator_loop.stop().await {
+        Ok(()) => {
+            let status = state.operator_loop.status().await;
+            Json(OperatorControlResponse { status }).into_response()
+        }
+        Err(e) => api_error_response(HelixError::ValidationError {
+            context: "status".to_string(),
+            message: e.to_string(),
+        }),
+    }
+}
+
+/// `POST /api/v1/operator/pause`
+pub async fn pause_operator(State(state): State<AppState>) -> Response {
+    match state.operator_loop.pause().await {
+        Ok(()) => {
+            let status = state.operator_loop.status().await;
+            Json(OperatorControlResponse { status }).into_response()
+        }
+        Err(e) => api_error_response(HelixError::ValidationError {
+            context: "status".to_string(),
+            message: e.to_string(),
+        }),
+    }
+}
+
+/// `GET /api/v1/operator/activity`
+pub async fn get_operator_activity(
+    State(state): State<AppState>,
+    Query(query): Query<ActivityLogQuery>,
+) -> Response {
+    let limit = query.limit.unwrap_or(50).min(500);
+    let entries = state.operator_loop.activity_log().recent(limit).await;
+    Json(OperatorActivityResponse { entries }).into_response()
+}
+
+/// `DELETE /api/v1/operator/activity`
+///
+/// Clears the activity log. Implemented by replacing the loop with a fresh
+/// one — but since the loop is shared via Arc, we instead just drain via
+/// reading all and note that the log is bounded and will evict naturally.
+/// For now, this returns 200 with the current count (no-op clear).
+pub async fn clear_operator_activity(State(state): State<AppState>) -> Response {
+    // The activity log is bounded and self-evicting; we expose a no-op
+    // clear endpoint for forward compatibility.
+    let count = state.operator_loop.activity_log().len().await;
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "cleared": false,
+            "current_count": count,
+            "note": "Activity log is bounded and self-evicting; manual clear not yet implemented."
+        })),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    // Integration tests live in `main.rs`'s `#[cfg(test)] mod tests` block,
+    // where `default_app_state` and `app` are accessible. This empty module
+    // exists so that `cargo test -p helix-api` continues to discover the
+    // crate's test target without warnings about a missing tests module.
+}
+
+// Integration tests live in `main.rs`'s `#[cfg(test)] mod tests` block, where
+// `default_app_state` and `app` are accessible.

--- a/crates/helix-api/src/operator.rs
+++ b/crates/helix-api/src/operator.rs
@@ -20,10 +20,135 @@ use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
 use helix_core::autopilot_guard::AutopilotMode;
+use helix_core::intel_desk::CaseStatus;
+use helix_operator::context::{
+    DeskContext, DeskContextSnapshot, DeskContextSummary, EvidenceSummary,
+    RecentDecisionSummary, WatchlistSummary,
+};
 use helix_operator::{
     DeskOperatorConfig, OperatorActionScope, OperatorActivityEntry, OperatorStatus,
 };
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+/// Adapter that implements [`DeskContext`] by snapshotting the API's intel desk.
+struct ApiDeskContext {
+    snapshot: DeskContextSnapshot,
+}
+
+impl DeskContext for ApiDeskContext {
+    fn snapshot(&self, _max_items: usize) -> DeskContextSnapshot {
+        self.snapshot.clone()
+    }
+}
+
+/// Builds a [`DeskContextSnapshot`] from the API's intel desk store.
+async fn build_desk_snapshot(
+    desk: &crate::intel::IntelDeskStore,
+    max_items: usize,
+    activity_log: &helix_operator::OperatorActivityLog,
+) -> DeskContextSnapshot {
+    let source_count = desk.sources.len();
+    let watchlist_count = desk.watchlists.len();
+    let evidence_count = desk.evidence.len();
+    let claim_count = desk.claims.len();
+    let open_case_count = desk
+        .cases
+        .values()
+        .filter(|c| !matches!(c.status, CaseStatus::Closed))
+        .count();
+    let escalated_case_count = desk
+        .cases
+        .values()
+        .filter(|c| matches!(c.status, CaseStatus::Escalated))
+        .count();
+
+    // Top cases (open, sorted by evidence count as a proxy for priority)
+    let mut top_cases: Vec<_> = desk
+        .cases
+        .values()
+        .filter(|c| !matches!(c.status, CaseStatus::Closed))
+        .map(|c| DeskContextSummary {
+            id: c.id.clone(),
+            title: c.title.clone(),
+            status: format!("{:?}", c.status).to_lowercase(),
+            watchlist_id: c.watchlist_id.clone(),
+            primary_entity: c.primary_entity.clone(),
+            evidence_count: c.evidence_ids.len(),
+            claim_count: c.claim_ids.len(),
+            latest_reason: c.latest_reason.clone(),
+            priority_total: (c.evidence_ids.len() as u64) * 10 + (c.claim_ids.len() as u64) * 5,
+        })
+        .collect();
+    top_cases.sort_by(|a, b| b.priority_total.cmp(&a.priority_total));
+    top_cases.truncate(max_items);
+
+    // Recent evidence
+    let recent_evidence: Vec<EvidenceSummary> = desk
+        .evidence
+        .values()
+        .rev()
+        .take(max_items)
+        .map(|e| {
+            let trust_score = desk
+                .sources
+                .get(&e.source_id)
+                .map(|s| s.trust_score)
+                .unwrap_or(0);
+            EvidenceSummary {
+                id: e.id.clone(),
+                title: e.title.clone(),
+                source_id: e.source_id.clone(),
+                trust_score,
+                observed_at: e.observed_at.clone(),
+                entity_labels: e.entity_labels.clone(),
+                tags: e.tags.clone(),
+            }
+        })
+        .collect();
+
+    // Active watchlists
+    let active_watchlists: Vec<WatchlistSummary> = desk
+        .watchlists
+        .values()
+        .filter(|w| w.enabled)
+        .take(max_items)
+        .map(|w| WatchlistSummary {
+            id: w.id.clone(),
+            name: w.name.clone(),
+            severity: format!("{:?}", w.severity).to_lowercase(),
+            keywords: w.keywords.clone(),
+            enabled: w.enabled,
+        })
+        .collect();
+
+    // Recent decisions from activity log
+    let recent_decisions: Vec<RecentDecisionSummary> = activity_log
+        .recent(5)
+        .await
+        .into_iter()
+        .map(|e| RecentDecisionSummary {
+            action_type: e.action_type,
+            decision: if e.allowed { "allowed".into() } else { "denied".into() },
+            denial_reason: e.denial_reason,
+            rationale: e.rationale,
+            timestamp: e.timestamp,
+        })
+        .collect();
+
+    DeskContextSnapshot {
+        source_count,
+        watchlist_count,
+        evidence_count,
+        claim_count,
+        open_case_count,
+        escalated_case_count,
+        top_cases,
+        recent_evidence,
+        active_watchlists,
+        recent_decisions,
+    }
+}
 
 /// Query params for limiting activity log results.
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -183,6 +308,62 @@ pub async fn update_operator_config(
 pub async fn start_operator(State(state): State<AppState>) -> Response {
     match state.operator_loop.start().await {
         Ok(()) => {
+            // Spawn the background loop task
+            let operator_loop = Arc::clone(&state.operator_loop);
+            let llm_provider = state.llm_provider.clone();
+            let intel_desk = Arc::clone(&state.intel_desk);
+            let activity_log = operator_loop.activity_log().clone();
+
+            // If no LLM provider is configured, we can't run the loop
+            let Some(provider) = llm_provider else {
+                let status = state.operator_loop.status().await;
+                return Json(OperatorControlResponse { status }).into_response();
+            };
+
+            tokio::spawn(async move {
+                tracing::info!("operator loop task started");
+                loop {
+                    // Check if we should still be running
+                    let status = operator_loop.status().await;
+                    if status != OperatorStatus::Running {
+                        tracing::info!("operator loop task stopping (status={:?})", status);
+                        break;
+                    }
+
+                    // Get config for interval and context size
+                    let config = operator_loop.config().await;
+
+                    // Build desk context snapshot from the intel desk
+                    let snapshot = {
+                        let desk = intel_desk.read().await;
+                        build_desk_snapshot(&desk, config.max_context_items, &activity_log).await
+                    };
+                    let context = ApiDeskContext { snapshot };
+
+                    // Run one cycle
+                    match operator_loop.run_cycle(&context, provider.as_ref()).await {
+                        Ok(response) => {
+                            tracing::info!(
+                                proposals = response.proposals.len(),
+                                allowed = response.allowed_count,
+                                denied = response.denied_count,
+                                "operator cycle completed"
+                            );
+                        }
+                        Err(e) => {
+                            tracing::warn!("operator cycle error: {}", e);
+                        }
+                    }
+
+                    // Sleep until next cycle
+                    tokio::time::sleep(std::time::Duration::from_secs(
+                        config.loop_interval_secs.max(5),
+                    ))
+                    .await;
+                }
+                tracing::info!("operator loop task exited");
+            });
+
             let status = state.operator_loop.status().await;
             Json(OperatorControlResponse { status }).into_response()
         }

--- a/crates/helix-api/src/operator.rs
+++ b/crates/helix-api/src/operator.rs
@@ -15,7 +15,7 @@
 //! and manual cycle trigger.
 
 use crate::{api_error_response, AppState, HelixError};
-use axum::extract::{Query, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::Json;
@@ -250,6 +250,269 @@ pub async fn clear_operator_activity(State(state): State<AppState>) -> Response 
         })),
     )
         .into_response()
+}
+
+// ---- CoPilot mode: sessions, confirmations, SSE stream ----
+
+use helix_operator::{
+    CollaborationEvent, ConfirmationRequest, JoinSessionRequest,
+    OperatorSession, SessionKind, SessionRole,
+};
+
+/// Response for `POST /api/v1/operator/sessions` (join).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JoinSessionResponse {
+    pub session: OperatorSession,
+}
+
+/// Response for `GET /api/v1/operator/sessions`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionListResponse {
+    pub sessions: Vec<OperatorSession>,
+    pub human_count: usize,
+    pub ai_count: usize,
+}
+
+/// Response for `GET /api/v1/operator/confirmations`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfirmationListResponse {
+    pub pending: Vec<ConfirmationRequest>,
+    pub recent: Vec<ConfirmationRequest>,
+}
+
+/// Request body for confirming/denying a confirmation.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ResolveConfirmationRequest {
+    /// Session id of the human resolving this request.
+    pub session_id: String,
+    /// Denial reason (only used for deny).
+    #[serde(default)]
+    pub denial_reason: Option<String>,
+}
+
+/// Response for confirm/deny endpoints.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResolveConfirmationResponse {
+    pub request: ConfirmationRequest,
+}
+
+/// `POST /api/v1/operator/sessions` — join the desk as a CoPilot participant.
+pub async fn join_session(
+    State(state): State<AppState>,
+    Json(req): Json<JoinSessionRequest>,
+) -> Response {
+    if req.display_name.trim().is_empty() {
+        return api_error_response(HelixError::ValidationError {
+            context: "display_name".to_string(),
+            message: "display_name must not be empty".to_string(),
+        });
+    }
+    let session = OperatorSession::new(
+        req.display_name,
+        req.kind,
+        req.role,
+        req.location,
+    );
+    let _id = state.operator_registry.add(session.clone()).await;
+    state.operator_loop.broadcaster().broadcast(
+        CollaborationEvent::session_joined(session.clone()),
+    );
+    Json(JoinSessionResponse { session }).into_response()
+}
+
+/// `DELETE /api/v1/operator/sessions/:session_id` — leave the desk.
+pub async fn leave_session(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Response {
+    let removed = state.operator_registry.remove(&session_id).await;
+    if let Some(ref session) = removed {
+        state.operator_loop.broadcaster().broadcast(
+            CollaborationEvent::session_left(session.id.clone(), session.display_name.clone()),
+        );
+        Json(serde_json::json!({ "removed": true, "session_id": session_id }))
+            .into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "session not found" })),
+        )
+            .into_response()
+    }
+}
+
+/// `GET /api/v1/operator/sessions` — list all active CoPilot participants.
+pub async fn list_sessions(State(state): State<AppState>) -> Response {
+    let sessions = state.operator_registry.list().await;
+    let (human_count, ai_count) = state.operator_registry.counts_by_kind().await;
+    Json(SessionListResponse {
+        sessions,
+        human_count,
+        ai_count,
+    })
+    .into_response()
+}
+
+/// `POST /api/v1/operator/sessions/:session_id/heartbeat` — keep session alive.
+pub async fn session_heartbeat(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> Response {
+    if state.operator_registry.heartbeat(&session_id).await {
+        state.operator_loop.broadcaster().broadcast(
+            CollaborationEvent::heartbeat(session_id),
+        );
+        Json(serde_json::json!({ "ok": true })).into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "session not found" })),
+        )
+            .into_response()
+    }
+}
+
+/// `GET /api/v1/operator/confirmations` — list pending and recent confirmations.
+pub async fn list_confirmations(State(state): State<AppState>) -> Response {
+    let pending = state.operator_loop.confirmation_queue().pending().await;
+    let recent = state.operator_loop.confirmation_queue().all().await;
+    Json(ConfirmationListResponse { pending, recent }).into_response()
+}
+
+/// `POST /api/v1/operator/confirmations/:id/confirm` — confirm a pending AI proposal.
+pub async fn confirm_proposal(
+    State(state): State<AppState>,
+    Path(confirmation_id): Path<String>,
+    Json(req): Json<ResolveConfirmationRequest>,
+) -> Response {
+    // Look up the session to get the resolver's name and verify permissions
+    let session = state.operator_registry.get(&req.session_id).await;
+    let session = match session {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "session not found" })),
+            )
+                .into_response();
+        }
+    };
+    if !session.role.can_confirm() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({ "error": "insufficient permissions" })),
+        )
+            .into_response();
+    }
+    let resolved = state
+        .operator_loop
+        .confirmation_queue()
+        .confirm(&confirmation_id, &session.id, &session.display_name)
+        .await;
+    match resolved {
+        Some(request) => {
+            state.operator_loop.broadcaster().broadcast(
+                CollaborationEvent::confirmation_resolved(request.clone()),
+            );
+            Json(ResolveConfirmationResponse { request }).into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "confirmation not found or already resolved" })),
+        )
+            .into_response(),
+    }
+}
+
+/// `POST /api/v1/operator/confirmations/:id/deny` — deny a pending AI proposal.
+pub async fn deny_proposal(
+    State(state): State<AppState>,
+    Path(confirmation_id): Path<String>,
+    Json(req): Json<ResolveConfirmationRequest>,
+) -> Response {
+    let session = state.operator_registry.get(&req.session_id).await;
+    let session = match session {
+        Some(s) => s,
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "error": "session not found" })),
+            )
+                .into_response();
+        }
+    };
+    if !session.role.can_confirm() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({ "error": "insufficient permissions" })),
+        )
+            .into_response();
+    }
+    let resolved = state
+        .operator_loop
+        .confirmation_queue()
+        .deny(&confirmation_id, &session.id, &session.display_name, req.denial_reason)
+        .await;
+    match resolved {
+        Some(request) => {
+            state.operator_loop.broadcaster().broadcast(
+                CollaborationEvent::confirmation_resolved(request.clone()),
+            );
+            Json(ResolveConfirmationResponse { request }).into_response()
+        }
+        None => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "confirmation not found or already resolved" })),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /api/v1/operator/stream` — SSE stream of collaboration events.
+pub async fn operator_stream(State(state): State<AppState>) -> Response {
+    use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
+
+    let rx = state.operator_loop.broadcaster().subscribe();
+    let stream = futures::stream::unfold(rx, |mut rx| async move {
+        match rx.recv().await {
+            Ok(event) => {
+                let json = serde_json::to_string(&event).unwrap_or_else(|_| "{}".to_string());
+                let kind = match &event {
+                    CollaborationEvent::SessionJoined { .. } => "session_joined",
+                    CollaborationEvent::SessionLeft { .. } => "session_left",
+                    CollaborationEvent::Heartbeat { .. } => "heartbeat",
+                    CollaborationEvent::LoopStarted { .. } => "loop_started",
+                    CollaborationEvent::LoopStopped { .. } => "loop_stopped",
+                    CollaborationEvent::LoopPaused { .. } => "loop_paused",
+                    CollaborationEvent::CycleCompleted { .. } => "cycle_completed",
+                    CollaborationEvent::ConfirmationRequested { .. } => "confirmation_requested",
+                    CollaborationEvent::ConfirmationResolved { .. } => "confirmation_resolved",
+                    CollaborationEvent::OperatorDecision { .. } => "operator_decision",
+                    CollaborationEvent::ConfigChanged { .. } => "config_changed",
+                    CollaborationEvent::SessionPruned { .. } => "session_pruned",
+                };
+                Some((
+                    Ok::<SseEvent, std::convert::Infallible>(SseEvent::default().event(kind).data(json)),
+                    rx,
+                ))
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => None,
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                // Skip missed events and continue
+                Some((
+                    Ok::<SseEvent, std::convert::Infallible>(SseEvent::default().comment("missed events")),
+                    rx,
+                ))
+            }
+        }
+    });
+
+    Sse::new(stream).keep_alive(
+        KeepAlive::new()
+            .interval(std::time::Duration::from_secs(15))
+            .text("keep-alive"),
+    )
+    .into_response()
 }
 
 #[cfg(test)]

--- a/crates/helix-core/src/autopilot_guard.rs
+++ b/crates/helix-core/src/autopilot_guard.rs
@@ -175,10 +175,10 @@ impl AutopilotGuardMachine {
                 }
 
                 if self.config.mode == AutopilotMode::Assist && !confirmed_by_human {
-                    self.stats.denied = self.stats.denied.saturating_add(1);
-                    return AutopilotGuardDecision::Deny {
-                        reason: "assist_requires_confirmation".to_string(),
-                    };
+                    // In assist mode, unconfirmed proposals are not denied — they
+                    // are allowed with requires_confirmation=true so the caller
+                    // can enqueue them for human review. The action-specific
+                    // checks below still apply.
                 }
 
                 match action {
@@ -227,15 +227,21 @@ mod tests {
     #[test]
     fn assist_mode_requires_confirmation() {
         let mut machine = AutopilotGuardMachine::default();
-        let denied = machine.step(AutopilotGuardInput::Evaluate {
+        // In assist mode, unconfirmed proposals are allowed with requires_confirmation=true
+        // so they can be enqueued for human review (not denied).
+        let result = machine.step(AutopilotGuardInput::Evaluate {
             action: AutopilotActionClass::PolicySimulation { command_count: 3 },
             confirmed_by_human: false,
         });
         assert!(matches!(
-            denied,
-            AutopilotGuardDecision::Deny { reason } if reason == "assist_requires_confirmation"
+            result,
+            AutopilotGuardDecision::Allow {
+                requires_confirmation: true
+            }
         ));
 
+        // When confirmed by human, still allowed with requires_confirmation=true
+        // (the confirmation flag means the human already approved it).
         let allowed = machine.step(AutopilotGuardInput::Evaluate {
             action: AutopilotActionClass::PolicySimulation { command_count: 3 },
             confirmed_by_human: true,

--- a/crates/helix-federation/Cargo.toml
+++ b/crates/helix-federation/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "helix-federation"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Federation layer for networking Helix intelligence desks"
+repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
+
+[dependencies]
+helix-core = { path = "../helix-core" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+url = { workspace = true }
+
+[dev-dependencies]
+futures = { workspace = true }

--- a/crates/helix-federation/src/dispatcher.rs
+++ b/crates/helix-federation/src/dispatcher.rs
@@ -1,0 +1,330 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Outbound dispatcher: sends federation events to peer desks via HTTP POST
+//! and records delivery outcomes in a dispatch log.
+
+use crate::peer::{PeerDesk, PeerRegistry};
+use crate::types::FederationEvent;
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::time::Instant;
+use tokio::sync::RwLock;
+
+/// The delivery status of an outbound dispatch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DispatchStatus {
+    /// The event was successfully delivered to the peer.
+    Delivered,
+    /// The peer returned an error status code.
+    Failed,
+    /// The peer was unreachable (network error, timeout, etc.).
+    Unreachable,
+}
+
+/// A single entry in the dispatch log.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DispatchLogEntry {
+    /// Unique entry id.
+    pub id: String,
+    /// The federation event id that was dispatched.
+    pub event_id: String,
+    /// The peer desk id that was the target.
+    pub peer_id: String,
+    /// The peer endpoint URL at dispatch time.
+    pub peer_endpoint: String,
+    /// The event kind.
+    pub event_kind: String,
+    /// The event title.
+    pub event_title: String,
+    /// Delivery status.
+    pub status: DispatchStatus,
+    /// HTTP status code if the peer responded, else null.
+    pub http_status: Option<u16>,
+    /// Error message if the dispatch failed.
+    pub error_message: Option<String>,
+    /// Round-trip latency in milliseconds.
+    pub latency_ms: u64,
+    /// ISO-8601 timestamp of the dispatch attempt.
+    pub dispatched_at: String,
+}
+
+/// A bounded, thread-safe log of recent dispatch attempts.
+#[derive(Debug, Clone)]
+pub struct DispatchLog {
+    inner: Arc<RwLock<VecDeque<DispatchLogEntry>>>,
+    capacity: usize,
+}
+
+impl DispatchLog {
+    /// Creates a new dispatch log with the given capacity.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(VecDeque::with_capacity(capacity))),
+            capacity,
+        }
+    }
+
+    /// Appends an entry, evicting the oldest if at capacity.
+    pub async fn append(&self, entry: DispatchLogEntry) {
+        let mut log = self.inner.write().await;
+        if log.len() >= self.capacity {
+            log.pop_front();
+        }
+        log.push_back(entry);
+    }
+
+    /// Returns the most recent `n` entries (newest first).
+    pub async fn recent(&self, n: usize) -> Vec<DispatchLogEntry> {
+        let log = self.inner.read().await;
+        log.iter()
+            .rev()
+            .take(n)
+            .cloned()
+            .collect()
+    }
+
+    /// Returns the total number of entries.
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    /// Returns true if the log is empty.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.read().await.is_empty()
+    }
+}
+
+/// The outbound dispatcher sends federation events to enabled peers.
+pub struct OutboundDispatcher {
+    registry: PeerRegistry,
+    log: DispatchLog,
+    http_client: reqwest::Client,
+    desk_id: String,
+}
+
+impl OutboundDispatcher {
+    /// Creates a new dispatcher bound to a peer registry and dispatch log.
+    pub fn new(
+        desk_id: String,
+        registry: PeerRegistry,
+        log: DispatchLog,
+    ) -> Self {
+        Self {
+            registry,
+            log,
+            http_client: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(15))
+                .build()
+                .expect("failed to build federation HTTP client"),
+            desk_id,
+        }
+    }
+
+    /// Dispatches a single event to all enabled peers.
+    ///
+    /// This is fail-closed: each peer dispatch is independent. A failure for
+    /// one peer does not prevent dispatch to others. All outcomes are logged.
+    pub async fn dispatch(&self, event: &FederationEvent) -> Vec<DispatchLogEntry> {
+        let peers = self.registry.enabled_peers().await;
+        let mut entries = Vec::with_capacity(peers.len());
+
+        for peer in peers {
+            let entry = self.dispatch_to_peer(event, &peer).await;
+            self.log.append(entry.clone()).await;
+            entries.push(entry);
+        }
+
+        entries
+    }
+
+    /// Dispatches an event to a single peer.
+    async fn dispatch_to_peer(
+        &self,
+        event: &FederationEvent,
+        peer: &PeerDesk,
+    ) -> DispatchLogEntry {
+        let start = Instant::now();
+        let url = peer.receive_url();
+
+        let result = self
+            .http_client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", peer.auth_token))
+            .header("Content-Type", "application/json")
+            .header("X-Helix-Desk-Id", &self.desk_id)
+            .json(event)
+            .send()
+            .await;
+
+        let latency_ms = start.elapsed().as_millis() as u64;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        match result {
+            Ok(response) => {
+                let status_code = response.status().as_u16();
+                if response.status().is_success() {
+                    DispatchLogEntry {
+                        id: format!("log-{}", uuid::Uuid::new_v4()),
+                        event_id: event.id.clone(),
+                        peer_id: peer.id.clone(),
+                        peer_endpoint: peer.endpoint_url.clone(),
+                        event_kind: event.event_type.clone(),
+                        event_title: event.title.clone(),
+                        status: DispatchStatus::Delivered,
+                        http_status: Some(status_code),
+                        error_message: None,
+                        latency_ms,
+                        dispatched_at: now,
+                    }
+                } else {
+                    let body = response.text().await.unwrap_or_default();
+                    DispatchLogEntry {
+                        id: format!("log-{}", uuid::Uuid::new_v4()),
+                        event_id: event.id.clone(),
+                        peer_id: peer.id.clone(),
+                        peer_endpoint: peer.endpoint_url.clone(),
+                        event_kind: event.event_type.clone(),
+                        event_title: event.title.clone(),
+                        status: DispatchStatus::Failed,
+                        http_status: Some(status_code),
+                        error_message: Some(format!("HTTP {status_code}: {body}").chars().take(512).collect()),
+                        latency_ms,
+                        dispatched_at: now,
+                    }
+                }
+            }
+            Err(err) => DispatchLogEntry {
+                id: format!("log-{}", uuid::Uuid::new_v4()),
+                event_id: event.id.clone(),
+                peer_id: peer.id.clone(),
+                peer_endpoint: peer.endpoint_url.clone(),
+                event_kind: event.event_type.clone(),
+                event_title: event.title.clone(),
+                status: DispatchStatus::Unreachable,
+                http_status: None,
+                error_message: Some(err.to_string()),
+                latency_ms,
+                dispatched_at: now,
+            },
+        }
+    }
+
+    /// Returns a reference to the dispatch log.
+    pub fn log(&self) -> &DispatchLog {
+        &self.log
+    }
+
+    /// Returns a reference to the peer registry.
+    pub fn registry(&self) -> &PeerRegistry {
+        &self.registry
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::peer::PeerDesk;
+
+    fn make_peer(id: &str, enabled: bool) -> PeerDesk {
+        PeerDesk {
+            id: id.to_string(),
+            name: format!("Peer {id}"),
+            endpoint_url: "http://localhost:9999".to_string(),
+            auth_token: "test-token-123".to_string(),
+            trust_score: 80,
+            enabled,
+            tags: vec![],
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_log_append_and_recent() {
+        let log = DispatchLog::new(3);
+        for i in 0..5 {
+            let entry = DispatchLogEntry {
+                id: format!("log-{i}"),
+                event_id: format!("evt-{i}"),
+                peer_id: "peer-a".to_string(),
+                peer_endpoint: "http://localhost".to_string(),
+                event_kind: "helix.case.escalated".to_string(),
+                event_title: format!("Event {i}"),
+                status: DispatchStatus::Delivered,
+                http_status: Some(200),
+                error_message: None,
+                latency_ms: 10,
+                dispatched_at: "2026-01-01T00:00:00Z".to_string(),
+            };
+            log.append(entry).await;
+        }
+        // Capacity is 3, so only 3 remain
+        assert_eq!(log.len().await, 3);
+        let recent = log.recent(10).await;
+        // Newest first
+        assert_eq!(recent[0].id, "log-4");
+        assert_eq!(recent[2].id, "log-2");
+    }
+
+    #[tokio::test]
+    async fn dispatch_log_empty() {
+        let log = DispatchLog::new(10);
+        assert!(log.is_empty().await);
+        assert_eq!(log.len().await, 0);
+        assert!(log.recent(5).await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn dispatcher_skips_disabled_peers() {
+        let registry = PeerRegistry::from_peers(vec![
+            make_peer("peer-a", false),
+            make_peer("peer-b", false),
+        ]);
+        let log = DispatchLog::new(100);
+        let dispatcher = OutboundDispatcher::new("desk-x".to_string(), registry, log);
+        let event = FederationEvent::new(
+            "desk-x",
+            crate::types::FederationEventKind::CaseEscalated,
+            "Test",
+            "Summary",
+            "Content",
+            80,
+        );
+        let entries = dispatcher.dispatch(&event).await;
+        assert!(entries.is_empty());
+        assert!(dispatcher.log().is_empty().await);
+    }
+
+    #[tokio::test]
+    async fn dispatcher_logs_unreachable_peer() {
+        // Point at a port that's not listening
+        let registry = PeerRegistry::from_peers(vec![make_peer("peer-a", true)]);
+        let log = DispatchLog::new(100);
+        let dispatcher = OutboundDispatcher::new("desk-x".to_string(), registry, log);
+        let event = FederationEvent::new(
+            "desk-x",
+            crate::types::FederationEventKind::CaseEscalated,
+            "Test",
+            "Summary",
+            "Content",
+            80,
+        );
+        let entries = dispatcher.dispatch(&event).await;
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].status, DispatchStatus::Unreachable);
+        assert!(entries[0].error_message.is_some());
+        assert!(entries[0].http_status.is_none());
+    }
+}

--- a/crates/helix-federation/src/errors.rs
+++ b/crates/helix-federation/src/errors.rs
@@ -1,0 +1,51 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Federation error types.
+
+use thiserror::Error;
+
+/// Errors produced by the federation layer.
+#[derive(Error, Debug)]
+pub enum FederationError {
+    /// A peer was not found in the registry.
+    #[error("peer desk {0} not found")]
+    PeerNotFound(String),
+    /// A peer with the same id already exists.
+    #[error("peer desk {0} already exists")]
+    PeerAlreadyExists(String),
+    /// Peer validation failed (bad URL, empty name, etc.).
+    #[error("peer validation failed: {0}")]
+    PeerValidation(String),
+    /// Outbound HTTP dispatch failed.
+    #[error("dispatch to peer {peer_id} failed: {message}")]
+    DispatchFailed {
+        /// The peer that was the target of the dispatch.
+        peer_id: String,
+        /// Human-readable error message.
+        message: String,
+    },
+    /// Serialization of a federation event failed.
+    #[error("serialization error: {0}")]
+    Serialization(String),
+    /// The dispatch log entry was not found.
+    #[error("dispatch log entry {0} not found")]
+    LogEntryNotFound(String),
+}
+
+impl FederationError {
+    /// Whether this error is a peer-not-found variant.
+    pub fn is_peer_not_found(&self) -> bool {
+        matches!(self, Self::PeerNotFound(_))
+    }
+}

--- a/crates/helix-federation/src/lib.rs
+++ b/crates/helix-federation/src/lib.rs
@@ -1,0 +1,46 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Federation layer for networking Helix intelligence desks.
+//!
+//! This crate provides the primitives for swarming multiple Helix instances:
+//!
+//! - [`PeerDesk`] represents a trusted remote desk with an endpoint, auth token,
+//!   and trust score.
+//! - [`PeerRegistry`] holds the set of configured peers and supports CRUD.
+//! - [`FederationEvent`] is the CloudEvents-compatible payload dispatched to
+//!   peers when significant intelligence events occur.
+//! - [`OutboundDispatcher`] sends federation events to peers via HTTP POST and
+//!   records delivery outcomes in a [`DispatchLog`].
+//! - [`DispatchLogEntry`] records each outbound dispatch attempt with status
+//!   and latency.
+//!
+//! All operations are deterministic and fail-closed: a peer that cannot be
+//! reached is recorded as failed, and the local desk continues operating
+//! without blocking on federation delivery.
+
+pub mod dispatcher;
+pub mod errors;
+pub mod peer;
+pub mod types;
+
+pub use dispatcher::{DispatchLog, DispatchLogEntry, DispatchStatus, OutboundDispatcher};
+pub use errors::FederationError;
+pub use peer::{PeerDesk, PeerRegistry, PeerRegistryQuery};
+pub use types::{
+    compute_overview, desk_id_from_env, FederationEvent, FederationEventKind,
+    FederationOverview, FederationStatus,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/helix-federation/src/peer.rs
+++ b/crates/helix-federation/src/peer.rs
@@ -1,0 +1,324 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Peer desk registry: the set of trusted remote Helix instances.
+
+use crate::errors::FederationError;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use url::Url;
+
+/// Minimum trust score a peer can have.
+pub const MIN_PEER_TRUST: u8 = 0;
+/// Maximum trust score a peer can have.
+pub const MAX_PEER_TRUST: u8 = 100;
+/// Minimum length for a peer name.
+pub const MIN_PEER_NAME_LEN: usize = 1;
+/// Maximum length for a peer name.
+pub const MAX_PEER_NAME_LEN: usize = 128;
+/// Maximum length for a peer id.
+pub const MAX_PEER_ID_LEN: usize = 64;
+/// Minimum length for an auth token.
+pub const MIN_AUTH_TOKEN_LEN: usize = 8;
+
+/// A trusted remote Helix intelligence desk.
+///
+/// Peers are addressed by their endpoint URL. When the local desk dispatches
+/// a [`crate::FederationEvent`], it POSTs the event payload to
+/// `{endpoint_url}/api/v1/federation/receive` with the configured auth token
+/// in the `Authorization` header.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PeerDesk {
+    /// Stable identifier for this peer (slug-style, unique within the registry).
+    pub id: String,
+    /// Human-readable name for this peer desk.
+    pub name: String,
+    /// Base endpoint URL (e.g. `https://helix.example.com`).
+    pub endpoint_url: String,
+    /// Bearer token used to authenticate outbound dispatches to this peer.
+    pub auth_token: String,
+    /// Trust score (0–100) that this desk assigns to intelligence received
+    /// from this peer. Higher is more trusted.
+    pub trust_score: u8,
+    /// Whether outbound dispatch to this peer is currently enabled.
+    pub enabled: bool,
+    /// Optional tags for grouping or filtering peers.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// ISO-8601 timestamp of when this peer was registered.
+    pub created_at: String,
+    /// ISO-8601 timestamp of the most recent update.
+    pub updated_at: String,
+}
+
+impl PeerDesk {
+    /// Validates this peer's fields.
+    pub fn validate(&self) -> Result<(), FederationError> {
+        if self.id.trim().is_empty() || self.id.len() > MAX_PEER_ID_LEN {
+            return Err(FederationError::PeerValidation(format!(
+                "peer id must be 1–{MAX_PEER_ID_LEN} characters"
+            )));
+        }
+        if self.name.trim().len() < MIN_PEER_NAME_LEN || self.name.len() > MAX_PEER_NAME_LEN {
+            return Err(FederationError::PeerValidation(format!(
+                "peer name must be {MIN_PEER_NAME_LEN}–{MAX_PEER_NAME_LEN} characters"
+            )));
+        }
+        if Url::parse(&self.endpoint_url).is_err() {
+            return Err(FederationError::PeerValidation(
+                "endpoint_url must be a valid URL".to_string(),
+            ));
+        }
+        if self.auth_token.trim().len() < MIN_AUTH_TOKEN_LEN {
+            return Err(FederationError::PeerValidation(format!(
+                "auth_token must be at least {MIN_AUTH_TOKEN_LEN} characters"
+            )));
+        }
+        if self.trust_score > MAX_PEER_TRUST {
+            return Err(FederationError::PeerValidation(format!(
+                "trust_score must be {MIN_PEER_TRUST}–{MAX_PEER_TRUST}"
+            )));
+        }
+        Ok(())
+    }
+
+    /// The full inbound URL for dispatching federation events to this peer.
+    pub fn receive_url(&self) -> String {
+        let base = self.endpoint_url.trim_end_matches('/');
+        format!("{base}/api/v1/federation/receive")
+    }
+}
+
+/// Query parameters for listing peers.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PeerRegistryQuery {
+    /// If set, only return peers with this enabled state.
+    pub enabled: Option<bool>,
+    /// If set, only return peers with this tag.
+    pub tag: Option<String>,
+}
+
+/// Thread-safe registry of trusted peer desks.
+#[derive(Debug, Clone)]
+pub struct PeerRegistry {
+    inner: Arc<RwLock<BTreeMap<String, PeerDesk>>>,
+}
+
+impl Default for PeerRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PeerRegistry {
+    /// Creates an empty registry.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(BTreeMap::new())),
+        }
+    }
+
+    /// Creates a registry seeded with the given peers.
+    pub fn from_peers(peers: Vec<PeerDesk>) -> Self {
+        let map = peers.into_iter().map(|p| (p.id.clone(), p)).collect();
+        Self {
+            inner: Arc::new(RwLock::new(map)),
+        }
+    }
+
+    /// Lists peers, optionally filtered.
+    pub async fn list(&self, query: &PeerRegistryQuery) -> Vec<PeerDesk> {
+        let peers = self.inner.read().await;
+        peers
+            .values()
+            .filter(|peer| match query.enabled {
+                Some(want) => peer.enabled == want,
+                None => true,
+            })
+            .filter(|peer| match &query.tag {
+                Some(tag) => peer.tags.contains(tag),
+                None => true,
+            })
+            .cloned()
+            .collect()
+    }
+
+    /// Returns a single peer by id.
+    pub async fn get(&self, id: &str) -> Option<PeerDesk> {
+        let peers = self.inner.read().await;
+        peers.get(id).cloned()
+    }
+
+    /// Inserts or replaces a peer. Validates first.
+    pub async fn upsert(&self, peer: PeerDesk) -> Result<PeerDesk, FederationError> {
+        peer.validate()?;
+        let mut peers = self.inner.write().await;
+        peers.insert(peer.id.clone(), peer.clone());
+        Ok(peer)
+    }
+
+    /// Removes a peer by id.
+    pub async fn remove(&self, id: &str) -> Result<PeerDesk, FederationError> {
+        let mut peers = self.inner.write().await;
+        peers
+            .remove(id)
+            .ok_or_else(|| FederationError::PeerNotFound(id.to_string()))
+    }
+
+    /// Returns only enabled peers (used by the dispatcher).
+    pub async fn enabled_peers(&self) -> Vec<PeerDesk> {
+        let peers = self.inner.read().await;
+        peers.values().filter(|p| p.enabled).cloned().collect()
+    }
+
+    /// Returns the count of all peers.
+    pub async fn count(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    /// Returns the count of enabled peers.
+    pub async fn enabled_count(&self) -> usize {
+        self.inner
+            .read()
+            .await
+            .values()
+            .filter(|p| p.enabled)
+            .count()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_peer() -> PeerDesk {
+        PeerDesk {
+            id: "desk-alpha".to_string(),
+            name: "Alpha Desk".to_string(),
+            endpoint_url: "https://alpha.helix.io".to_string(),
+            auth_token: "secret-token-123".to_string(),
+            trust_score: 80,
+            enabled: true,
+            tags: vec!["osint".to_string()],
+            created_at: "2026-01-01T00:00:00Z".to_string(),
+            updated_at: "2026-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    #[test]
+    fn peer_validation_accepts_valid_peer() {
+        assert!(valid_peer().validate().is_ok());
+    }
+
+    #[test]
+    fn peer_validation_rejects_empty_id() {
+        let mut peer = valid_peer();
+        peer.id = "".to_string();
+        assert!(peer.validate().is_err());
+    }
+
+    #[test]
+    fn peer_validation_rejects_bad_url() {
+        let mut peer = valid_peer();
+        peer.endpoint_url = "not a url".to_string();
+        assert!(peer.validate().is_err());
+    }
+
+    #[test]
+    fn peer_validation_rejects_short_token() {
+        let mut peer = valid_peer();
+        peer.auth_token = "short".to_string();
+        assert!(peer.validate().is_err());
+    }
+
+    #[test]
+    fn peer_validation_rejects_trust_over_100() {
+        let mut peer = valid_peer();
+        peer.trust_score = 101;
+        assert!(peer.validate().is_err());
+    }
+
+    #[test]
+    fn receive_url_strips_trailing_slash() {
+        let mut peer = valid_peer();
+        peer.endpoint_url = "https://alpha.helix.io/".to_string();
+        assert_eq!(
+            peer.receive_url(),
+            "https://alpha.helix.io/api/v1/federation/receive"
+        );
+    }
+
+    #[tokio::test]
+    async fn registry_upsert_and_get() {
+        let registry = PeerRegistry::new();
+        let peer = valid_peer();
+        registry.upsert(peer.clone()).await.unwrap();
+        let got = registry.get("desk-alpha").await.unwrap();
+        assert_eq!(got, peer);
+    }
+
+    #[tokio::test]
+    async fn registry_remove_returns_peer() {
+        let registry = PeerRegistry::from_peers(vec![valid_peer()]);
+        let removed = registry.remove("desk-alpha").await.unwrap();
+        assert_eq!(removed.id, "desk-alpha");
+        assert!(registry.get("desk-alpha").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn registry_remove_missing_returns_error() {
+        let registry = PeerRegistry::new();
+        let result = registry.remove("nope").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn registry_enabled_peers_filters_disabled() {
+        let mut peer = valid_peer();
+        peer.enabled = false;
+        let registry = PeerRegistry::from_peers(vec![peer]);
+        assert_eq!(registry.enabled_peers().await.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn registry_list_filters_by_tag() {
+        let mut peer_a = valid_peer();
+        peer_a.id = "desk-a".to_string();
+        peer_a.tags = vec!["osint".to_string()];
+        let mut peer_b = valid_peer();
+        peer_b.id = "desk-b".to_string();
+        peer_b.tags = vec!["market".to_string()];
+        let registry = PeerRegistry::from_peers(vec![peer_a, peer_b]);
+        let query = PeerRegistryQuery {
+            enabled: None,
+            tag: Some("osint".to_string()),
+        };
+        let result = registry.list(&query).await;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "desk-a");
+    }
+
+    #[tokio::test]
+    async fn registry_counts() {
+        let mut peer_a = valid_peer();
+        peer_a.id = "desk-a".to_string();
+        let mut peer_b = valid_peer();
+        peer_b.id = "desk-b".to_string();
+        peer_b.enabled = false;
+        let registry = PeerRegistry::from_peers(vec![peer_a, peer_b]);
+        assert_eq!(registry.count().await, 2);
+        assert_eq!(registry.enabled_count().await, 1);
+    }
+}

--- a/crates/helix-federation/src/tests.rs
+++ b/crates/helix-federation/src/tests.rs
@@ -1,0 +1,177 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the federation crate.
+
+use crate::{
+    DispatchLog, DispatchStatus, FederationEvent, FederationEventKind, OutboundDispatcher,
+    PeerDesk, PeerRegistry, PeerRegistryQuery,
+};
+
+fn make_peer(id: &str, enabled: bool) -> PeerDesk {
+    PeerDesk {
+        id: id.to_string(),
+        name: format!("Peer {id}"),
+        endpoint_url: "http://localhost:1".to_string(),
+        auth_token: "test-token-12".to_string(),
+        trust_score: 75,
+        enabled,
+        tags: vec!["test".to_string()],
+        created_at: "2026-01-01T00:00:00Z".to_string(),
+        updated_at: "2026-01-01T00:00:00Z".to_string(),
+    }
+}
+
+#[tokio::test]
+async fn full_federation_flow() {
+    let registry = PeerRegistry::new();
+    let log = DispatchLog::new(50);
+    let dispatcher = OutboundDispatcher::new("desk-alpha".to_string(), registry.clone(), log.clone());
+
+    // Register two peers, one disabled
+    let peer_a = make_peer("desk-beta", true);
+    let peer_b = make_peer("desk-gamma", false);
+    registry.upsert(peer_a.clone()).await.unwrap();
+    registry.upsert(peer_b).await.unwrap();
+
+    // Verify registry state
+    assert_eq!(registry.count().await, 2);
+    assert_eq!(registry.enabled_count().await, 1);
+
+    // Dispatch an event
+    let event = FederationEvent::new(
+        "desk-alpha",
+        FederationEventKind::CaseEscalated,
+        "Case #42 escalated to critical",
+        "Executive departure detected at target company",
+        "Full case details here",
+        85,
+    );
+    let entries = dispatcher.dispatch(&event).await;
+
+    // Only the enabled peer should receive a dispatch attempt
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].peer_id, "desk-beta");
+    // localhost:1 won't be reachable
+    assert_eq!(entries[0].status, DispatchStatus::Unreachable);
+
+    // Log should have one entry
+    assert_eq!(log.len().await, 1);
+    let recent = log.recent(10).await;
+    assert_eq!(recent.len(), 1);
+    assert_eq!(recent[0].event_id, event.id);
+
+    // Remove a peer
+    let removed = registry.remove("desk-beta").await.unwrap();
+    assert_eq!(removed.id, "desk-beta");
+    assert_eq!(registry.count().await, 1);
+}
+
+#[tokio::test]
+async fn registry_query_filters() {
+    let registry = PeerRegistry::from_peers(vec![
+        {
+            let mut p = make_peer("a", true);
+            p.tags = vec!["osint".to_string()];
+            p
+        },
+        {
+            let mut p = make_peer("b", false);
+            p.tags = vec!["osint".to_string()];
+            p
+        },
+        {
+            let mut p = make_peer("c", true);
+            p.tags = vec!["market".to_string()];
+            p
+        },
+    ]);
+
+    // All peers
+    let all = registry.list(&PeerRegistryQuery::default()).await;
+    assert_eq!(all.len(), 3);
+
+    // Enabled only
+    let enabled = registry
+        .list(&PeerRegistryQuery {
+            enabled: Some(true),
+            tag: None,
+        })
+        .await;
+    assert_eq!(enabled.len(), 2);
+
+    // Tag filter
+    let osint = registry
+        .list(&PeerRegistryQuery {
+            enabled: None,
+            tag: Some("osint".to_string()),
+        })
+        .await;
+    assert_eq!(osint.len(), 2);
+
+    // Combined
+    let combined = registry
+        .list(&PeerRegistryQuery {
+            enabled: Some(true),
+            tag: Some("osint".to_string()),
+        })
+        .await;
+    assert_eq!(combined.len(), 1);
+    assert_eq!(combined[0].id, "a");
+}
+
+#[tokio::test]
+async fn event_kind_event_types() {
+    assert_eq!(
+        FederationEventKind::CaseEscalated.event_type(),
+        "helix.case.escalated"
+    );
+    assert_eq!(
+        FederationEventKind::WatchlistHit.event_type(),
+        "helix.watchlist.hit"
+    );
+    assert_eq!(
+        FederationEventKind::EvidenceIngested.event_type(),
+        "helix.evidence.ingested"
+    );
+    assert_eq!(
+        FederationEventKind::ManualBroadcast.event_type(),
+        "helix.federation.broadcast"
+    );
+}
+
+#[tokio::test]
+async fn dispatch_log_capacity_eviction() {
+    let log = DispatchLog::new(5);
+    for i in 0..10 {
+        let entry = crate::DispatchLogEntry {
+            id: format!("e{i}"),
+            event_id: format!("ev{i}"),
+            peer_id: "p".to_string(),
+            peer_endpoint: "http://x".to_string(),
+            event_kind: "helix.test".to_string(),
+            event_title: format!("T{i}"),
+            status: DispatchStatus::Delivered,
+            http_status: Some(200),
+            error_message: None,
+            latency_ms: 5,
+            dispatched_at: "2026-01-01T00:00:00Z".to_string(),
+        };
+        log.append(entry).await;
+    }
+    assert_eq!(log.len().await, 5);
+    let recent = log.recent(10).await;
+    // Newest first: e9, e8, e7, e6, e5
+    assert_eq!(recent[0].id, "e9");
+    assert_eq!(recent[4].id, "e5");
+}

--- a/crates/helix-federation/src/types.rs
+++ b/crates/helix-federation/src/types.rs
@@ -1,0 +1,247 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Federation event types and status structures.
+
+use crate::peer::PeerRegistry;
+use serde::{Deserialize, Serialize};
+
+/// The kind of intelligence event being shared with peer desks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FederationEventKind {
+    /// A case was escalated to a higher severity.
+    CaseEscalated,
+    /// A new case was opened.
+    CaseOpened,
+    /// A watchlist was triggered by new evidence.
+    WatchlistHit,
+    /// New evidence was ingested.
+    EvidenceIngested,
+    /// A claim was corroborated or rejected.
+    ClaimReviewed,
+    /// An autopilot proposal was generated.
+    AutopilotProposal,
+    /// A manual broadcast (operator-initiated sharing).
+    ManualBroadcast,
+}
+
+impl FederationEventKind {
+    /// The CloudEvents `type` string for this event kind.
+    pub fn event_type(&self) -> &'static str {
+        match self {
+            Self::CaseEscalated => "helix.case.escalated",
+            Self::CaseOpened => "helix.case.opened",
+            Self::WatchlistHit => "helix.watchlist.hit",
+            Self::EvidenceIngested => "helix.evidence.ingested",
+            Self::ClaimReviewed => "helix.claim.reviewed",
+            Self::AutopilotProposal => "helix.autopilot.proposal",
+            Self::ManualBroadcast => "helix.federation.broadcast",
+        }
+    }
+}
+
+/// A CloudEvents-compatible federation event payload.
+///
+/// This is what gets POSTed to peer desks at `/api/v1/federation/receive`.
+/// The receiving desk creates evidence with provenance pointing back to
+/// `source_desk_id`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FederationEvent {
+    /// CloudEvents spec version.
+    pub specversion: String,
+    /// Unique event id.
+    pub id: String,
+    /// CloudEvents type (e.g. `helix.case.escalated`).
+    #[serde(rename = "type")]
+    pub event_type: String,
+    /// The desk id of the sending desk.
+    pub source_desk_id: String,
+    /// The desk id of the receiving desk, or `*` for broadcast.
+    pub target_desk_id: String,
+    /// Human-readable title for the event.
+    pub title: String,
+    /// Short summary of the intelligence.
+    pub summary: String,
+    /// Full content / detail payload.
+    pub content: String,
+    /// Optional URL pointing to the source material.
+    pub url: Option<String>,
+    /// ISO-8601 timestamp when the event was generated.
+    pub observed_at: String,
+    /// The kind of event, for routing.
+    pub kind: FederationEventKind,
+    /// Trust score (0–100) the sending desk assigns to this intelligence.
+    pub trust_score: u8,
+    /// Entity labels extracted from the event.
+    #[serde(default)]
+    pub entity_labels: Vec<String>,
+    /// Tags for categorization.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// The case id this event relates to, if any.
+    pub case_id: Option<String>,
+    /// The watchlist id that triggered, if any.
+    pub watchlist_id: Option<String>,
+}
+
+impl FederationEvent {
+    /// Creates a new federation event with the given fields.
+    pub fn new(
+        source_desk_id: &str,
+        kind: FederationEventKind,
+        title: &str,
+        summary: &str,
+        content: &str,
+        trust_score: u8,
+    ) -> Self {
+        let now = chrono::Utc::now();
+        Self {
+            specversion: "1.0".to_string(),
+            id: format!("fed-{}", uuid::Uuid::new_v4()),
+            event_type: kind.event_type().to_string(),
+            source_desk_id: source_desk_id.to_string(),
+            target_desk_id: "*".to_string(),
+            title: title.to_string(),
+            summary: summary.to_string(),
+            content: content.to_string(),
+            url: None,
+            observed_at: now.to_rfc3339(),
+            kind,
+            trust_score,
+            entity_labels: Vec::new(),
+            tags: Vec::new(),
+            case_id: None,
+            watchlist_id: None,
+        }
+    }
+}
+
+/// Overall federation status for the local desk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FederationStatus {
+    /// The local desk's id.
+    pub desk_id: String,
+    /// Total number of configured peers.
+    pub peer_count: usize,
+    /// Number of enabled peers.
+    pub enabled_peer_count: usize,
+    /// Total outbound dispatches attempted.
+    pub total_dispatches: usize,
+    /// Successful dispatches.
+    pub successful_dispatches: usize,
+    /// Failed dispatches.
+    pub failed_dispatches: usize,
+    /// Whether federation is enabled (has at least one enabled peer).
+    pub federation_enabled: bool,
+}
+
+/// A summary overview returned by the federation status endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FederationOverview {
+    /// The local desk's id.
+    pub desk_id: String,
+    /// All configured peers.
+    pub peers: Vec<crate::peer::PeerDesk>,
+    /// Federation status summary.
+    pub status: FederationStatus,
+}
+
+/// Computes the federation overview from a registry and dispatch log.
+pub async fn compute_overview(
+    desk_id: &str,
+    registry: &PeerRegistry,
+    log: &crate::dispatcher::DispatchLog,
+) -> FederationOverview {
+    let peers = registry
+        .list(&crate::peer::PeerRegistryQuery::default())
+        .await;
+    let peer_count = peers.len();
+    let enabled_peer_count = peers.iter().filter(|p| p.enabled).count();
+    let entries = log.recent(100).await;
+    let total_dispatches = entries.len();
+    let successful_dispatches = entries
+        .iter()
+        .filter(|e| e.status == crate::dispatcher::DispatchStatus::Delivered)
+        .count();
+    let failed_dispatches = entries
+        .iter()
+        .filter(|e| e.status == crate::dispatcher::DispatchStatus::Failed)
+        .count();
+
+    FederationOverview {
+        desk_id: desk_id.to_string(),
+        peers,
+        status: FederationStatus {
+            desk_id: desk_id.to_string(),
+            peer_count,
+            enabled_peer_count,
+            total_dispatches,
+            successful_dispatches,
+            failed_dispatches,
+            federation_enabled: enabled_peer_count > 0,
+        },
+    }
+}
+
+/// Helper to create an Arc'd default desk id from an env var or fallback.
+pub fn desk_id_from_env() -> String {
+    std::env::var("HELIX_DESK_ID").unwrap_or_else(|_| "local-desk".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn federation_event_new_sets_correct_type() {
+        let event = FederationEvent::new(
+            "desk-a",
+            FederationEventKind::CaseEscalated,
+            "Case escalated",
+            "Summary",
+            "Content",
+            80,
+        );
+        assert_eq!(event.event_type, "helix.case.escalated");
+        assert_eq!(event.source_desk_id, "desk-a");
+        assert_eq!(event.target_desk_id, "*");
+        assert_eq!(event.specversion, "1.0");
+        assert!(!event.id.is_empty());
+    }
+
+    #[test]
+    fn federation_event_serializes_roundtrip() {
+        let event = FederationEvent::new(
+            "desk-a",
+            FederationEventKind::WatchlistHit,
+            "Hit",
+            "Summary",
+            "Content",
+            90,
+        );
+        let json = serde_json::to_string(&event).unwrap();
+        let back: FederationEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(event, back);
+    }
+
+    #[tokio::test]
+    async fn compute_overview_reports_counts() {
+        let registry = PeerRegistry::new();
+        let log = crate::dispatcher::DispatchLog::new(100);
+        let overview = compute_overview("desk-x", &registry, &log).await;
+        assert_eq!(overview.status.desk_id, "desk-x");
+        assert_eq!(overview.status.peer_count, 0);
+        assert_eq!(overview.status.federation_enabled, false);
+    }
+}

--- a/crates/helix-llm/src/providers.rs
+++ b/crates/helix-llm/src/providers.rs
@@ -188,11 +188,15 @@ impl OpenAiProvider {
 
     /// Create a new OpenAI provider with custom base URL
     pub fn with_base_url(api_key: String, base_url: String) -> Self {
+        let timeout_secs = std::env::var("LLM_TIMEOUT_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(120);
         Self {
             api_key,
             base_url,
             client: reqwest::Client::builder()
-                .timeout(Duration::from_secs(30))
+                .timeout(Duration::from_secs(timeout_secs))
                 .build()
                 .expect("failed to build HTTP client"),
         }

--- a/crates/helix-operator/Cargo.toml
+++ b/crates/helix-operator/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "helix-operator"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "LLM desk operator loop — autonomous intelligence desk operation within deterministic guardrails"
+repository = "https://github.com/TheDarkLightX/Helix-A-Next-Gen-Event-Driven-Multi-Agent-Platform"
+
+[dependencies]
+helix-core = { path = "../helix-core" }
+helix-llm = { path = "../helix-llm" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+thiserror = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+async-trait = { workspace = true }
+
+[dev-dependencies]
+futures = { workspace = true }

--- a/crates/helix-operator/src/collaboration.rs
+++ b/crates/helix-operator/src/collaboration.rs
@@ -1,0 +1,346 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Collaboration events: real-time broadcast of desk activity to all
+//! connected CoPilot participants via Server-Sent Events.
+
+use crate::confirmation::ConfirmationRequest;
+use crate::proposals::OperatorDecision;
+use crate::session::OperatorSession;
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+/// An event broadcast to all connected CoPilot participants.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CollaborationEvent {
+    /// A new session joined the desk.
+    SessionJoined {
+        /// The session that joined.
+        session: OperatorSession,
+        /// Timestamp (ISO-8601).
+        timestamp: String,
+    },
+    /// A session left the desk.
+    SessionLeft {
+        /// Session id.
+        session_id: String,
+        /// Display name.
+        display_name: String,
+        /// Timestamp.
+        timestamp: String,
+    },
+    /// A session sent a heartbeat.
+    Heartbeat {
+        /// Session id.
+        session_id: String,
+        /// Timestamp.
+        timestamp: String,
+    },
+    /// The operator loop started.
+    LoopStarted {
+        /// Timestamp.
+        timestamp: String,
+    },
+    /// The operator loop stopped.
+    LoopStopped {
+        /// Timestamp.
+        timestamp: String,
+    },
+    /// The operator loop paused.
+    LoopPaused {
+        /// Timestamp.
+        timestamp: String,
+    },
+    /// A cycle completed — proposals were generated and evaluated.
+    CycleCompleted {
+        /// Cycle number.
+        cycle: u64,
+        /// Number of proposals allowed.
+        allowed_count: usize,
+        /// Number of proposals denied.
+        denied_count: usize,
+        /// Number of proposals sent to confirmation queue.
+        pending_confirmation_count: usize,
+        /// Timestamp.
+        timestamp: String,
+    },
+    /// A proposal was submitted for human confirmation.
+    ConfirmationRequested {
+        /// The confirmation request.
+        request: ConfirmationRequest,
+        /// Timestamp.
+        timestamp: String,
+    },
+    /// A confirmation request was resolved (confirmed or denied).
+    ConfirmationResolved {
+        /// The resolved request.
+        request: ConfirmationRequest,
+        /// Timestamp.
+        timestamp: String,
+    },
+    /// An operator decision was made (allowed or denied by guard).
+    OperatorDecision {
+        /// Cycle number.
+        cycle: u64,
+        /// The decision.
+        decision: OperatorDecision,
+        /// Timestamp.
+        timestamp: String,
+    },
+    /// The operator config was changed.
+    ConfigChanged {
+        /// Timestamp.
+        timestamp: String,
+    },
+    /// A session was pruned (disconnected timeout).
+    SessionPruned {
+        /// Session id.
+        session_id: String,
+        /// Display name.
+        display_name: String,
+        /// Timestamp.
+        timestamp: String,
+    },
+}
+
+impl CollaborationEvent {
+    fn timestamp_now() -> String {
+        chrono::Utc::now().to_rfc3339()
+    }
+
+    /// Creates a SessionJoined event.
+    pub fn session_joined(session: OperatorSession) -> Self {
+        Self::SessionJoined {
+            session,
+            timestamp: Self::timestamp_now(),
+        }
+    }
+
+    /// Creates a SessionLeft event.
+    pub fn session_left(session_id: String, display_name: String) -> Self {
+        Self::SessionLeft {
+            session_id,
+            display_name,
+            timestamp: Self::timestamp_now(),
+        }
+    }
+
+    /// Creates a Heartbeat event.
+    pub fn heartbeat(session_id: String) -> Self {
+        Self::Heartbeat {
+            session_id,
+            timestamp: Self::timestamp_now(),
+        }
+    }
+
+    /// Creates a LoopStarted event.
+    pub fn loop_started() -> Self {
+        Self::LoopStarted {
+            timestamp: Self::timestamp_now(),
+        }
+    }
+
+    /// Creates a LoopStopped event.
+    pub fn loop_stopped() -> Self {
+        Self::LoopStopped {
+            timestamp: Self::timestamp_now(),
+        }
+    }
+
+    /// Creates a LoopPaused event.
+    pub fn loop_paused() -> Self {
+        Self::LoopPaused {
+            timestamp: Self::timestamp_now(),
+        }
+    }
+
+    /// Creates a CycleCompleted event.
+    pub fn cycle_completed(
+        cycle: u64,
+        allowed_count: usize,
+        denied_count: usize,
+        pending_confirmation_count: usize,
+    ) -> Self {
+        Self::CycleCompleted {
+            cycle,
+            allowed_count,
+            denied_count,
+            pending_confirmation_count,
+            timestamp: Self::timestamp_now(),
+        }
+    }
+
+    /// Creates a ConfirmationRequested event.
+    pub fn confirmation_requested(request: ConfirmationRequest) -> Self {
+        Self::ConfirmationRequested {
+            request,
+            timestamp: Self::timestamp_now(),
+        }
+    }
+
+    /// Creates a ConfirmationResolved event.
+    pub fn confirmation_resolved(request: ConfirmationRequest) -> Self {
+        Self::ConfirmationResolved {
+            request,
+            timestamp: Self::timestamp_now(),
+        }
+    }
+
+    /// Creates an OperatorDecision event.
+    pub fn operator_decision(cycle: u64, decision: OperatorDecision) -> Self {
+        Self::OperatorDecision {
+            cycle,
+            decision,
+            timestamp: Self::timestamp_now(),
+        }
+    }
+
+    /// Creates a ConfigChanged event.
+    pub fn config_changed() -> Self {
+        Self::ConfigChanged {
+            timestamp: Self::timestamp_now(),
+        }
+    }
+
+    /// Creates a SessionPruned event.
+    pub fn session_pruned(session_id: String, display_name: String) -> Self {
+        Self::SessionPruned {
+            session_id,
+            display_name,
+            timestamp: Self::timestamp_now(),
+        }
+    }
+}
+
+/// Thread-safe broadcaster for collaboration events.
+///
+/// Uses a tokio broadcast channel — each SSE client subscribes by calling
+/// `subscribe()`, which returns a receiver. Events are serialized as JSON
+/// for transmission over SSE.
+#[derive(Debug, Clone)]
+pub struct CollaborationBroadcaster {
+    sender: broadcast::Sender<CollaborationEvent>,
+}
+
+impl CollaborationBroadcaster {
+    /// Creates a new broadcaster with the given channel capacity.
+    pub fn new(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(capacity);
+        Self { sender }
+    }
+
+    /// Subscribes to the event stream. Each subscriber gets its own receiver.
+    pub fn subscribe(&self) -> broadcast::Receiver<CollaborationEvent> {
+        self.sender.subscribe()
+    }
+
+    /// Broadcasts an event to all subscribers.
+    pub fn broadcast(&self, event: CollaborationEvent) {
+        // Ignore send errors — no subscribers means nobody is listening,
+        // which is fine.
+        let _ = self.sender.send(event);
+    }
+
+    /// Returns the number of active subscribers.
+    pub fn subscriber_count(&self) -> usize {
+        self.sender.receiver_count()
+    }
+}
+
+impl Default for CollaborationBroadcaster {
+    fn default() -> Self {
+        Self::new(256)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proposals::OperatorProposal;
+    use crate::session::{SessionKind, SessionRole};
+
+    #[tokio::test]
+    async fn broadcast_delivers_to_subscribers() {
+        let broadcaster = CollaborationBroadcaster::new(16);
+        let mut rx1 = broadcaster.subscribe();
+        let mut rx2 = broadcaster.subscribe();
+
+        broadcaster.broadcast(CollaborationEvent::loop_started());
+
+        let event1 = rx1.recv().await.unwrap();
+        let event2 = rx2.recv().await.unwrap();
+
+        assert!(matches!(event1, CollaborationEvent::LoopStarted { .. }));
+        assert!(matches!(event2, CollaborationEvent::LoopStarted { .. }));
+    }
+
+    #[tokio::test]
+    async fn broadcast_with_no_subscribers_is_ok() {
+        let broadcaster = CollaborationBroadcaster::new(16);
+        // No subscribers — should not panic
+        broadcaster.broadcast(CollaborationEvent::loop_stopped());
+    }
+
+    #[tokio::test]
+    async fn subscriber_count_tracks_receivers() {
+        let broadcaster = CollaborationBroadcaster::new(16);
+        assert_eq!(broadcaster.subscriber_count(), 0);
+        let _rx1 = broadcaster.subscribe();
+        assert_eq!(broadcaster.subscriber_count(), 1);
+        let _rx2 = broadcaster.subscribe();
+        assert_eq!(broadcaster.subscriber_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn session_joined_event_serializes() {
+        let session = OperatorSession::new(
+            "Alice".to_string(),
+            SessionKind::Human,
+            SessionRole::Operator,
+            None,
+        );
+        let event = CollaborationEvent::session_joined(session);
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("session_joined"));
+        assert!(json.contains("Alice"));
+    }
+
+    #[tokio::test]
+    async fn confirmation_requested_event_serializes() {
+        let proposal = OperatorProposal {
+            action_type: "escalate_case".to_string(),
+            target_id: Some("case-1".to_string()),
+            rationale: "test".to_string(),
+            parameters: serde_json::Value::Null,
+        };
+        let request = ConfirmationRequest::new(1, proposal);
+        let event = CollaborationEvent::confirmation_requested(request);
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("confirmation_requested"));
+        assert!(json.contains("escalate_case"));
+    }
+
+    #[tokio::test]
+    async fn late_subscriber_misses_earlier_events() {
+        let broadcaster = CollaborationBroadcaster::new(16);
+        broadcaster.broadcast(CollaborationEvent::loop_started());
+        // Subscribe after the broadcast
+        let mut rx = broadcaster.subscribe();
+        broadcaster.broadcast(CollaborationEvent::loop_stopped());
+        let event = rx.recv().await.unwrap();
+        // Should only get the second event
+        assert!(matches!(event, CollaborationEvent::LoopStopped { .. }));
+    }
+}

--- a/crates/helix-operator/src/config.rs
+++ b/crates/helix-operator/src/config.rs
@@ -1,0 +1,319 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Desk operator configuration: user-defined rules for autonomous operation.
+
+use crate::errors::OperatorError;
+use helix_core::autopilot_guard::AutopilotMode;
+use serde::{Deserialize, Serialize};
+
+/// Minimum loop interval in seconds (safety floor).
+pub const MIN_LOOP_INTERVAL_SECS: u64 = 5;
+/// Maximum loop interval in seconds.
+pub const MAX_LOOP_INTERVAL_SECS: u64 = 3600;
+/// Maximum actions the operator can propose per loop cycle.
+pub const MAX_ACTIONS_PER_CYCLE: usize = 10;
+/// Maximum context items (cases/evidence) to include in the LLM prompt.
+pub const MAX_CONTEXT_ITEMS: usize = 20;
+/// Maximum operator rules text length.
+pub const MAX_RULES_TEXT_LEN: usize = 4096;
+
+/// The scope of actions the operator is permitted to propose.
+///
+/// This is a secondary gate on top of the [`AutopilotGuardMachine`]. Even if
+/// the guard would allow an action, the operator will not propose actions
+/// outside its configured scope.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OperatorActionScope {
+    /// Observe only — the operator can read the desk state and log analysis
+    /// but cannot propose any actions. Useful for monitoring mode.
+    ObserveOnly,
+    /// Intelligence actions — ingest evidence, review claims, escalate cases,
+    /// dispatch to federation peers. No policy or on-chain actions.
+    Intelligence,
+    /// Policy actions — includes intelligence actions plus policy simulations.
+    /// No on-chain actions.
+    Policy,
+    /// Full authority — all action types permitted by the guard.
+    /// On-chain actions still require guard confirmation if configured.
+    Full,
+}
+
+impl Default for OperatorActionScope {
+    fn default() -> Self {
+        Self::Intelligence
+    }
+}
+
+impl OperatorActionScope {
+    /// Whether this scope permits the given action type string.
+    pub fn permits(&self, action_type: &str) -> bool {
+        match self {
+            Self::ObserveOnly => false,
+            Self::Intelligence => {
+                matches!(
+                    action_type,
+                    "ingest_evidence"
+                        | "review_claim"
+                        | "escalate_case"
+                        | "open_case"
+                        | "federation_broadcast"
+                        | "log_analysis"
+                )
+            }
+            Self::Policy => matches!(
+                action_type,
+                "ingest_evidence"
+                    | "review_claim"
+                    | "escalate_case"
+                    | "open_case"
+                    | "federation_broadcast"
+                    | "log_analysis"
+                    | "policy_simulation"
+            ),
+            Self::Full => true,
+        }
+    }
+}
+
+/// The current run state of the operator loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OperatorStatus {
+    /// The operator is stopped.
+    Stopped,
+    /// The operator is running its observe-think-act loop.
+    Running,
+    /// The operator is paused (will resume when set to Running).
+    Paused,
+}
+
+impl Default for OperatorStatus {
+    fn default() -> Self {
+        Self::Stopped
+    }
+}
+
+/// User-defined configuration for the desk operator.
+///
+/// This is the "set of rules" the user gives the LLM. The operator loop
+/// enforces these rules deterministically — the LLM never sees a config
+/// it can override. Every proposed action is checked against both the
+/// [`OperatorActionScope`] and the [`AutopilotGuardMachine`] before
+/// execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeskOperatorConfig {
+    /// Whether the operator loop is enabled.
+    pub enabled: bool,
+    /// The autopilot mode the operator runs under. Must be `Assist` or `Auto`.
+    /// If set to `Off`, the operator will observe but never act.
+    pub autopilot_mode: AutopilotMode,
+    /// The scope of actions the operator is permitted to propose.
+    pub action_scope: OperatorActionScope,
+    /// Loop interval in seconds.
+    pub loop_interval_secs: u64,
+    /// Maximum actions the operator can propose per cycle.
+    pub max_actions_per_cycle: usize,
+    /// Maximum context items to include in the LLM prompt.
+    pub max_context_items: usize,
+    /// The LLM model to use (e.g. "gpt-4o-mini").
+    pub model: String,
+    /// User-defined rules text — natural language instructions the operator
+    /// must follow. This becomes part of the system prompt.
+    pub rules_text: String,
+    /// Whether to dispatch operator decisions to federation peers.
+    pub dispatch_to_peers: bool,
+    /// Whether to log denied proposals for audit.
+    pub log_denied_proposals: bool,
+}
+
+impl Default for DeskOperatorConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            autopilot_mode: AutopilotMode::Assist,
+            action_scope: OperatorActionScope::Intelligence,
+            loop_interval_secs: 60,
+            max_actions_per_cycle: 3,
+            max_context_items: 10,
+            model: "gpt-4o-mini".to_string(),
+            rules_text: String::new(),
+            dispatch_to_peers: false,
+            log_denied_proposals: true,
+        }
+    }
+}
+
+impl DeskOperatorConfig {
+    /// Validates this configuration.
+    pub fn validate(&self) -> Result<(), OperatorError> {
+        if self.loop_interval_secs < MIN_LOOP_INTERVAL_SECS
+            || self.loop_interval_secs > MAX_LOOP_INTERVAL_SECS
+        {
+            return Err(OperatorError::ConfigValidation(format!(
+                "loop_interval_secs must be between {MIN_LOOP_INTERVAL_SECS} and {MAX_LOOP_INTERVAL_SECS}"
+            )));
+        }
+        if self.max_actions_per_cycle == 0 || self.max_actions_per_cycle > MAX_ACTIONS_PER_CYCLE {
+            return Err(OperatorError::ConfigValidation(format!(
+                "max_actions_per_cycle must be between 1 and {MAX_ACTIONS_PER_CYCLE}"
+            )));
+        }
+        if self.max_context_items == 0 || self.max_context_items > MAX_CONTEXT_ITEMS {
+            return Err(OperatorError::ConfigValidation(format!(
+                "max_context_items must be between 1 and {MAX_CONTEXT_ITEMS}"
+            )));
+        }
+        if self.rules_text.len() > MAX_RULES_TEXT_LEN {
+            return Err(OperatorError::ConfigValidation(format!(
+                "rules_text must be at most {MAX_RULES_TEXT_LEN} characters"
+            )));
+        }
+        if self.model.trim().is_empty() {
+            return Err(OperatorError::ConfigValidation("model must not be empty".to_string()));
+        }
+        Ok(())
+    }
+
+    /// Builds the system prompt for the LLM operator.
+    pub fn system_prompt(&self) -> String {
+        let scope_desc = match self.action_scope {
+            OperatorActionScope::ObserveOnly => "You may only observe and log analysis. You cannot propose actions.",
+            OperatorActionScope::Intelligence => "You may propose: ingest_evidence, review_claim, escalate_case, open_case, federation_broadcast, log_analysis.",
+            OperatorActionScope::Policy => "You may propose intelligence actions plus policy_simulation.",
+            OperatorActionScope::Full => "You may propose any action type. On-chain actions still require guard confirmation.",
+        };
+
+        let mode_desc = match self.autopilot_mode {
+            AutopilotMode::Off => "Autopilot is OFF. You can observe but all actions will be denied.",
+            AutopilotMode::Assist => "Autopilot is in ASSIST mode. Your proposals will be presented for human confirmation.",
+            AutopilotMode::Auto => "Autopilot is in AUTO mode. Your proposals will be executed automatically within guardrails.",
+        };
+
+        format!(
+            concat!(
+                "You are a Helix Intelligence Desk Operator.\n",
+                "You operate an intelligence desk autonomously, observing the desk state\n",
+                "and proposing actions based on the rules below.\n",
+                "\n",
+                "## Operating Mode\n",
+                "{mode_desc}\n",
+                "\n",
+                "## Action Scope\n",
+                "{scope_desc}\n",
+                "\n",
+                "## Constraints\n",
+                "- You may propose at most {max_actions} actions per cycle.\n",
+                "- Every proposal is checked by a deterministic guard before execution.\n",
+                "- The guard can deny any proposal. Denied proposals are logged.\n",
+                "- You never bypass the guard. You propose; the guard decides.\n",
+                "\n",
+                "## Output Format\n",
+                "Return ONLY a JSON array of action objects. No prose. No markdown.\n",
+                "Each action object has:\n",
+                "  {{\"type\": \"<action_type>\", \"target_id\": \"<optional id>\", \"rationale\": \"<why>\", \"parameters\": {{...}}}}\n",
+                "\n",
+                "Action types:\n",
+                "- log_analysis: {{\"type\": \"log_analysis\", \"rationale\": \"<your analysis>\", \"parameters\": {{\"severity\": \"low|medium|high|critical\", \"summary\": \"<summary>\"}}}}\n",
+                "- escalate_case: {{\"type\": \"escalate_case\", \"target_id\": \"<case_id>\", \"rationale\": \"<why>\"}}\n",
+                "- open_case: {{\"type\": \"open_case\", \"target_id\": \"<evidence_id>\", \"rationale\": \"<why>\", \"parameters\": {{\"title\": \"<title>\", \"watchlist_id\": \"<id>\"}}}}\n",
+                "- review_claim: {{\"type\": \"review_claim\", \"target_id\": \"<claim_id>\", \"rationale\": \"<why>\", \"parameters\": {{\"status\": \"corroborated|rejected\"}}}}\n",
+                "- federation_broadcast: {{\"type\": \"federation_broadcast\", \"rationale\": \"<why>\", \"parameters\": {{\"title\": \"<title>\", \"summary\": \"<summary>\", \"content\": \"<content>\"}}}}\n",
+                "- policy_simulation: {{\"type\": \"policy_simulation\", \"rationale\": \"<why>\", \"parameters\": {{\"commands\": [<policy_command>]}}}}\n",
+                "\n",
+                "## User-Defined Rules\n",
+                "{rules}\n"
+            ),
+            mode_desc = mode_desc,
+            scope_desc = scope_desc,
+            max_actions = self.max_actions_per_cycle,
+            rules = if self.rules_text.trim().is_empty() {
+                "(none — use your best judgment)"
+            } else {
+                &self.rules_text
+            },
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_validates() {
+        assert!(DeskOperatorConfig::default().validate().is_ok());
+    }
+
+    #[test]
+    fn config_rejects_too_fast_loop() {
+        let mut config = DeskOperatorConfig::default();
+        config.loop_interval_secs = 1;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn config_rejects_too_many_actions() {
+        let mut config = DeskOperatorConfig::default();
+        config.max_actions_per_cycle = 100;
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn config_rejects_empty_model() {
+        let mut config = DeskOperatorConfig::default();
+        config.model = "  ".to_string();
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn system_prompt_includes_rules() {
+        let mut config = DeskOperatorConfig::default();
+        config.rules_text = "Always prioritize cases about entity X.".to_string();
+        let prompt = config.system_prompt();
+        assert!(prompt.contains("Always prioritize cases about entity X."));
+        assert!(prompt.contains("Helix Intelligence Desk Operator"));
+    }
+
+    #[test]
+    fn system_prompt_handles_empty_rules() {
+        let config = DeskOperatorConfig::default();
+        let prompt = config.system_prompt();
+        assert!(prompt.contains("(none — use your best judgment)"));
+    }
+
+    #[test]
+    fn action_scope_observe_only_denies_all() {
+        let scope = OperatorActionScope::ObserveOnly;
+        assert!(!scope.permits("ingest_evidence"));
+        assert!(!scope.permits("escalate_case"));
+        assert!(!scope.permits("policy_simulation"));
+    }
+
+    #[test]
+    fn action_scope_intelligence_allows_intel_actions() {
+        let scope = OperatorActionScope::Intelligence;
+        assert!(scope.permits("escalate_case"));
+        assert!(scope.permits("review_claim"));
+        assert!(scope.permits("federation_broadcast"));
+        assert!(!scope.permits("policy_simulation"));
+    }
+
+    #[test]
+    fn action_scope_full_allows_everything() {
+        let scope = OperatorActionScope::Full;
+        assert!(scope.permits("policy_simulation"));
+        assert!(scope.permits("escalate_case"));
+    }
+}

--- a/crates/helix-operator/src/confirmation.rs
+++ b/crates/helix-operator/src/confirmation.rs
@@ -1,0 +1,361 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Confirmation queue: pending AI proposals awaiting human review in
+//! CoPilot assist mode.
+
+use crate::proposals::OperatorProposal;
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// The status of a confirmation request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfirmationStatus {
+    /// Waiting for a human operator to review.
+    Pending,
+    /// A human operator confirmed the proposal.
+    Confirmed,
+    /// A human operator denied the proposal.
+    Denied,
+    /// The request expired before anyone reviewed it.
+    Expired,
+}
+
+/// A pending AI proposal awaiting human confirmation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfirmationRequest {
+    /// Unique request id.
+    pub id: String,
+    /// The cycle number this proposal came from.
+    pub cycle: u64,
+    /// The original proposal from the LLM.
+    pub proposal: OperatorProposal,
+    /// The LLM's rationale (copied from proposal for convenience).
+    pub rationale: String,
+    /// When the request was created (ISO-8601).
+    pub requested_at: String,
+    /// Current status.
+    pub status: ConfirmationStatus,
+    /// Session id of the human who confirmed or denied (if resolved).
+    pub resolved_by: Option<String>,
+    /// Display name of the resolver (if resolved).
+    pub resolved_by_name: Option<String>,
+    /// When the request was resolved (if resolved).
+    pub resolved_at: Option<String>,
+    /// Denial reason if denied.
+    pub denial_reason: Option<String>,
+}
+
+impl ConfirmationRequest {
+    /// Creates a new pending confirmation request from a proposal.
+    pub fn new(cycle: u64, proposal: OperatorProposal) -> Self {
+        let rationale = proposal.rationale.clone();
+        Self {
+            id: format!("conf-{}", uuid::Uuid::new_v4()),
+            cycle,
+            proposal,
+            rationale,
+            requested_at: Utc::now().to_rfc3339(),
+            status: ConfirmationStatus::Pending,
+            resolved_by: None,
+            resolved_by_name: None,
+            resolved_at: None,
+            denial_reason: None,
+        }
+    }
+
+    /// Whether this request is still pending review.
+    pub fn is_pending(&self) -> bool {
+        self.status == ConfirmationStatus::Pending
+    }
+}
+
+/// Thread-safe bounded queue of pending confirmation requests.
+#[derive(Debug, Clone)]
+pub struct ConfirmationQueue {
+    inner: Arc<RwLock<VecDeque<ConfirmationRequest>>>,
+    capacity: usize,
+}
+
+impl ConfirmationQueue {
+    /// Creates a new queue with the given capacity.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(VecDeque::with_capacity(capacity))),
+            capacity,
+        }
+    }
+
+    /// Enqueues a pending confirmation request. If at capacity, the oldest
+    /// pending request is expired to make room.
+    pub async fn enqueue(&self, request: ConfirmationRequest) -> String {
+        let id = request.id.clone();
+        let mut queue = self.inner.write().await;
+        if queue.len() >= self.capacity {
+            // Expire the oldest pending request
+            if let Some(front) = queue.front_mut() {
+                if front.is_pending() {
+                    front.status = ConfirmationStatus::Expired;
+                    front.resolved_at = Some(Utc::now().to_rfc3339());
+                }
+            }
+            // Remove expired entries from the front
+            while queue.front().map(|r| r.status == ConfirmationStatus::Expired).unwrap_or(false) {
+                queue.pop_front();
+            }
+        }
+        queue.push_back(request);
+        id
+    }
+
+    /// Returns all requests (pending and resolved), newest first.
+    pub async fn all(&self) -> Vec<ConfirmationRequest> {
+        let queue = self.inner.read().await;
+        queue.iter().rev().cloned().collect()
+    }
+
+    /// Returns only pending requests, oldest first.
+    pub async fn pending(&self) -> Vec<ConfirmationRequest> {
+        let queue = self.inner.read().await;
+        queue
+            .iter()
+            .filter(|r| r.is_pending())
+            .cloned()
+            .collect()
+    }
+
+    /// Returns a request by id.
+    pub async fn get(&self, id: &str) -> Option<ConfirmationRequest> {
+        let queue = self.inner.read().await;
+        queue.iter().find(|r| r.id == id).cloned()
+    }
+
+    /// Confirms a pending request. Returns the updated request, or None if
+    /// not found or not pending.
+    pub async fn confirm(
+        &self,
+        id: &str,
+        resolver_session_id: &str,
+        resolver_name: &str,
+    ) -> Option<ConfirmationRequest> {
+        let mut queue = self.inner.write().await;
+        let request = queue.iter_mut().find(|r| r.id == id)?;
+        if !request.is_pending() {
+            return None;
+        }
+        request.status = ConfirmationStatus::Confirmed;
+        request.resolved_by = Some(resolver_session_id.to_string());
+        request.resolved_by_name = Some(resolver_name.to_string());
+        request.resolved_at = Some(Utc::now().to_rfc3339());
+        Some(request.clone())
+    }
+
+    /// Denies a pending request. Returns the updated request, or None if
+    /// not found or not pending.
+    pub async fn deny(
+        &self,
+        id: &str,
+        resolver_session_id: &str,
+        resolver_name: &str,
+        reason: Option<String>,
+    ) -> Option<ConfirmationRequest> {
+        let mut queue = self.inner.write().await;
+        let request = queue.iter_mut().find(|r| r.id == id)?;
+        if !request.is_pending() {
+            return None;
+        }
+        request.status = ConfirmationStatus::Denied;
+        request.resolved_by = Some(resolver_session_id.to_string());
+        request.resolved_by_name = Some(resolver_name.to_string());
+        request.resolved_at = Some(Utc::now().to_rfc3339());
+        request.denial_reason = reason;
+        Some(request.clone())
+    }
+
+    /// Expires requests older than the given timeout (in seconds).
+    /// Returns the number of requests expired.
+    pub async fn expire_stale(&self, timeout_secs: i64) -> usize {
+        let now = Utc::now();
+        let mut count = 0;
+        let mut queue = self.inner.write().await;
+        for request in queue.iter_mut() {
+            if !request.is_pending() {
+                continue;
+            }
+            if let Ok(requested) = chrono::DateTime::parse_from_rfc3339(&request.requested_at) {
+                let age = (now - requested.with_timezone(&Utc)).num_seconds();
+                if age >= timeout_secs {
+                    request.status = ConfirmationStatus::Expired;
+                    request.resolved_at = Some(now.to_rfc3339());
+                    count += 1;
+                }
+            }
+        }
+        count
+    }
+
+    /// Returns the number of pending requests.
+    pub async fn pending_count(&self) -> usize {
+        self.inner
+            .read()
+            .await
+            .iter()
+            .filter(|r| r.is_pending())
+            .count()
+    }
+
+    /// Returns the total number of requests (pending + resolved).
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    /// Clears resolved (confirmed/denied/expired) entries.
+    pub async fn clear_resolved(&self) -> usize {
+        let mut queue = self.inner.write().await;
+        let before = queue.len();
+        queue.retain(|r| r.is_pending());
+        before - queue.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_proposal(action_type: &str, rationale: &str) -> OperatorProposal {
+        OperatorProposal {
+            action_type: action_type.to_string(),
+            target_id: Some("case-1".to_string()),
+            rationale: rationale.to_string(),
+            parameters: serde_json::Value::Null,
+        }
+    }
+
+    #[tokio::test]
+    async fn enqueue_and_get_pending() {
+        let queue = ConfirmationQueue::new(10);
+        let req = ConfirmationRequest::new(1, make_proposal("escalate_case", "test"));
+        let id = queue.enqueue(req).await;
+        let pending = queue.pending().await;
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, id);
+        assert_eq!(pending[0].status, ConfirmationStatus::Pending);
+    }
+
+    #[tokio::test]
+    async fn confirm_resolves_request() {
+        let queue = ConfirmationQueue::new(10);
+        let req = ConfirmationRequest::new(1, make_proposal("escalate_case", "test"));
+        let id = queue.enqueue(req).await;
+        let resolved = queue.confirm(&id, "sess-1", "Alice").await;
+        assert!(resolved.is_some());
+        let resolved = resolved.unwrap();
+        assert_eq!(resolved.status, ConfirmationStatus::Confirmed);
+        assert_eq!(resolved.resolved_by_name, Some("Alice".to_string()));
+        assert!(queue.pending().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn deny_resolves_request() {
+        let queue = ConfirmationQueue::new(10);
+        let req = ConfirmationRequest::new(1, make_proposal("escalate_case", "test"));
+        let id = queue.enqueue(req).await;
+        let resolved = queue
+            .deny(&id, "sess-1", "Bob", Some("not enough evidence".to_string()))
+            .await;
+        assert!(resolved.is_some());
+        let resolved = resolved.unwrap();
+        assert_eq!(resolved.status, ConfirmationStatus::Denied);
+        assert_eq!(resolved.denial_reason, Some("not enough evidence".to_string()));
+    }
+
+    #[tokio::test]
+    async fn confirm_nonexistent_returns_none() {
+        let queue = ConfirmationQueue::new(10);
+        assert!(queue.confirm("fake-id", "sess-1", "Alice").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn confirm_already_resolved_returns_none() {
+        let queue = ConfirmationQueue::new(10);
+        let req = ConfirmationRequest::new(1, make_proposal("escalate_case", "test"));
+        let id = queue.enqueue(req).await;
+        queue.confirm(&id, "sess-1", "Alice").await;
+        // Second confirm should fail
+        assert!(queue.confirm(&id, "sess-2", "Bob").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn capacity_evicts_oldest_pending() {
+        let queue = ConfirmationQueue::new(2);
+        let id1 = queue
+            .enqueue(ConfirmationRequest::new(1, make_proposal("log_analysis", "first")))
+            .await;
+        queue
+            .enqueue(ConfirmationRequest::new(2, make_proposal("log_analysis", "second")))
+            .await;
+        // Third enqueue should expire the first
+        queue
+            .enqueue(ConfirmationRequest::new(3, make_proposal("log_analysis", "third")))
+            .await;
+        let first = queue.get(&id1).await;
+        // The first should have been expired and removed
+        assert!(first.is_none() || first.unwrap().status == ConfirmationStatus::Expired);
+    }
+
+    #[tokio::test]
+    async fn expire_stale_expires_old_pending() {
+        let queue = ConfirmationQueue::new(10);
+        let mut req = ConfirmationRequest::new(1, make_proposal("escalate_case", "test"));
+        req.requested_at = (Utc::now() - chrono::Duration::seconds(300)).to_rfc3339();
+        queue.enqueue(req).await;
+        let expired = queue.expire_stale(60).await;
+        assert_eq!(expired, 1);
+        assert!(queue.pending().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn clear_resolved_removes_non_pending() {
+        let queue = ConfirmationQueue::new(10);
+        let id1 = queue
+            .enqueue(ConfirmationRequest::new(1, make_proposal("log_analysis", "first")))
+            .await;
+        let id2 = queue
+            .enqueue(ConfirmationRequest::new(2, make_proposal("log_analysis", "second")))
+            .await;
+        queue.confirm(&id1, "sess-1", "Alice").await;
+        assert_eq!(queue.len().await, 2);
+        let cleared = queue.clear_resolved().await;
+        assert_eq!(cleared, 1);
+        assert_eq!(queue.len().await, 1);
+        // Remaining should be the pending one
+        let remaining = queue.get(&id2).await.unwrap();
+        assert!(remaining.is_pending());
+    }
+
+    #[tokio::test]
+    async fn pending_count() {
+        let queue = ConfirmationQueue::new(10);
+        queue
+            .enqueue(ConfirmationRequest::new(1, make_proposal("log_analysis", "a")))
+            .await;
+        queue
+            .enqueue(ConfirmationRequest::new(2, make_proposal("log_analysis", "b")))
+            .await;
+        assert_eq!(queue.pending_count().await, 2);
+    }
+}

--- a/crates/helix-operator/src/context.rs
+++ b/crates/helix-operator/src/context.rs
@@ -1,0 +1,169 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Desk context: structured snapshot of the desk state fed to the LLM.
+
+use serde::{Deserialize, Serialize};
+
+/// A summary of a case for the LLM context.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeskContextSummary {
+    /// Case id.
+    pub id: String,
+    /// Case title.
+    pub title: String,
+    /// Case status.
+    pub status: String,
+    /// Watchlist id.
+    pub watchlist_id: String,
+    /// Primary entity (if any).
+    pub primary_entity: Option<String>,
+    /// Number of evidence items.
+    pub evidence_count: usize,
+    /// Number of claims.
+    pub claim_count: usize,
+    /// Latest reason / briefing.
+    pub latest_reason: String,
+    /// Priority total (higher = more urgent).
+    pub priority_total: u64,
+}
+
+/// A structured snapshot of the desk state for the LLM operator.
+///
+/// This is what the LLM "sees" when it thinks. It contains:
+/// - Top cases by priority
+/// - Recent evidence
+/// - Active watchlists
+/// - Desk overview stats
+/// - Recent operator decisions
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeskContextSnapshot {
+    /// Desk overview stats.
+    pub source_count: usize,
+    /// Number of watchlists.
+    pub watchlist_count: usize,
+    /// Total evidence.
+    pub evidence_count: usize,
+    /// Total claims.
+    pub claim_count: usize,
+    /// Open cases.
+    pub open_case_count: usize,
+    /// Escalated cases.
+    pub escalated_case_count: usize,
+    /// Top cases by priority (limited to max_context_items).
+    pub top_cases: Vec<DeskContextSummary>,
+    /// Recent evidence titles (limited to max_context_items).
+    pub recent_evidence: Vec<EvidenceSummary>,
+    /// Active watchlist names.
+    pub active_watchlists: Vec<WatchlistSummary>,
+    /// Recent operator decisions (last N).
+    pub recent_decisions: Vec<RecentDecisionSummary>,
+}
+
+/// Summary of an evidence item.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EvidenceSummary {
+    /// Evidence id.
+    pub id: String,
+    /// Title.
+    pub title: String,
+    /// Source id.
+    pub source_id: String,
+    /// Trust score of the source.
+    pub trust_score: u8,
+    /// Observed at timestamp.
+    pub observed_at: String,
+    /// Entity labels.
+    pub entity_labels: Vec<String>,
+    /// Tags.
+    pub tags: Vec<String>,
+}
+
+/// Summary of a watchlist.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WatchlistSummary {
+    /// Watchlist id.
+    pub id: String,
+    /// Name.
+    pub name: String,
+    /// Severity.
+    pub severity: String,
+    /// Keywords.
+    pub keywords: Vec<String>,
+    /// Whether it's enabled.
+    pub enabled: bool,
+}
+
+/// Summary of a recent operator decision.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecentDecisionSummary {
+    /// Action type proposed.
+    pub action_type: String,
+    /// Whether it was allowed or denied.
+    pub decision: String,
+    /// Denial reason (if denied).
+    pub denial_reason: Option<String>,
+    /// Rationale given by the LLM.
+    pub rationale: String,
+    /// Timestamp.
+    pub timestamp: String,
+}
+
+/// Builder for [`DeskContextSnapshot`].
+///
+/// This trait abstracts over the data source so the operator can work with
+/// any backend that can provide desk state.
+pub trait DeskContext: Send + Sync {
+    /// Assembles a context snapshot with at most `max_items` items per category.
+    fn snapshot(&self, max_items: usize) -> DeskContextSnapshot;
+}
+
+/// Formats a [`DeskContextSnapshot`] as a JSON string for the LLM user prompt.
+pub fn format_context_for_llm(snapshot: &DeskContextSnapshot) -> String {
+    serde_json::to_string_pretty(snapshot).unwrap_or_else(|_| "{}".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_context_produces_valid_json() {
+        let snapshot = DeskContextSnapshot {
+            source_count: 5,
+            watchlist_count: 3,
+            evidence_count: 42,
+            claim_count: 15,
+            open_case_count: 4,
+            escalated_case_count: 1,
+            top_cases: vec![DeskContextSummary {
+                id: "case-1".to_string(),
+                title: "Test Case".to_string(),
+                status: "open".to_string(),
+                watchlist_id: "wl-1".to_string(),
+                primary_entity: Some("entity-x".to_string()),
+                evidence_count: 3,
+                claim_count: 2,
+                latest_reason: "New evidence detected".to_string(),
+                priority_total: 850,
+            }],
+            recent_evidence: vec![],
+            active_watchlists: vec![],
+            recent_decisions: vec![],
+        };
+        let json = format_context_for_llm(&snapshot);
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["source_count"], 5);
+        assert_eq!(parsed["top_cases"][0]["id"], "case-1");
+    }
+}

--- a/crates/helix-operator/src/errors.rs
+++ b/crates/helix-operator/src/errors.rs
@@ -1,0 +1,45 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Operator error types.
+
+use thiserror::Error;
+
+/// Errors produced by the desk operator.
+#[derive(Error, Debug)]
+pub enum OperatorError {
+    /// The LLM provider is not configured.
+    #[error("LLM provider not configured")]
+    LlmNotConfigured,
+    /// The LLM returned an error.
+    #[error("LLM error: {0}")]
+    LlmError(String),
+    /// The LLM response could not be parsed into proposals.
+    #[error("parse error: {0}")]
+    ParseError(String),
+    /// The operator is not running.
+    #[error("operator not running")]
+    NotRunning,
+    /// The operator is already running.
+    #[error("operator already running")]
+    AlreadyRunning,
+    /// The guard denied all proposed actions.
+    #[error("all {0} proposals denied by guard")]
+    AllDenied(usize),
+    /// Configuration validation failed.
+    #[error("config validation failed: {0}")]
+    ConfigValidation(String),
+    /// Serialization error.
+    #[error("serialization error: {0}")]
+    Serialization(String),
+}

--- a/crates/helix-operator/src/lib.rs
+++ b/crates/helix-operator/src/lib.rs
@@ -1,0 +1,49 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! LLM desk operator: autonomous intelligence desk operation within
+//! deterministic guardrails.
+//!
+//! The operator runs an observe-think-act loop:
+//!
+//! 1. **Observe** — [`DeskContext`] assembles a structured snapshot of the
+//!    desk's current state (cases, evidence, watchlists, recent decisions).
+//! 2. **Think** — the LLM receives the context and a system prompt encoding
+//!    the user's rules, then proposes one or more actions.
+//! 3. **Act** — each proposed action is routed through the
+//!    [`AutopilotGuardMachine`] for deterministic evaluation. Only actions
+//!    the guard allows are executed. Denied actions are logged.
+//! 4. **Remember** — the operator records its decisions and outcomes for
+//!    audit and future context.
+//!
+//! The LLM never bypasses the guard. The user defines the rules (via
+//! [`DeskOperatorConfig`] and [`AutopilotGuardConfig`]); the guard enforces
+//! them deterministically; the LLM operates freely within those bounds.
+
+pub mod config;
+pub mod context;
+pub mod errors;
+pub mod loop_runner;
+pub mod proposals;
+
+pub use config::{DeskOperatorConfig, OperatorActionScope, OperatorStatus};
+pub use context::{DeskContext, DeskContextSnapshot, DeskContextSummary};
+pub use errors::OperatorError;
+pub use loop_runner::{OperatorActivityLog, OperatorActivityEntry, OperatorLoop};
+pub use proposals::{
+    OperatorAction, OperatorDecision, OperatorProposal, OperatorProposalResponse,
+    parse_operator_proposals,
+};
+
+#[cfg(test)]
+mod tests;

--- a/crates/helix-operator/src/lib.rs
+++ b/crates/helix-operator/src/lib.rs
@@ -12,7 +12,8 @@
 // limitations under the License.
 
 //! LLM desk operator: autonomous intelligence desk operation within
-//! deterministic guardrails.
+//! deterministic guardrails, with CoPilot mode for multi-participant
+//! collaboration.
 //!
 //! The operator runs an observe-think-act loop:
 //!
@@ -29,20 +30,38 @@
 //! The LLM never bypasses the guard. The user defines the rules (via
 //! [`DeskOperatorConfig`] and [`AutopilotGuardConfig`]); the guard enforces
 //! them deterministically; the LLM operates freely within those bounds.
+//!
+//! ## CoPilot Mode
+//!
+//! In CoPilot mode, multiple humans and AI copilots can co-operate the same
+//! desk together. The [`OperatorRegistry`] tracks who's connected, the
+//! [`ConfirmationQueue`] holds AI proposals awaiting human review (in assist
+//! mode), and the [`CollaborationBroadcaster`] pushes real-time events to all
+//! connected participants via Server-Sent Events.
 
+pub mod collaboration;
 pub mod config;
+pub mod confirmation;
 pub mod context;
 pub mod errors;
 pub mod loop_runner;
 pub mod proposals;
+pub mod registry;
+pub mod session;
 
+pub use collaboration::{CollaborationBroadcaster, CollaborationEvent};
 pub use config::{DeskOperatorConfig, OperatorActionScope, OperatorStatus};
+pub use confirmation::{ConfirmationQueue, ConfirmationRequest, ConfirmationStatus};
 pub use context::{DeskContext, DeskContextSnapshot, DeskContextSummary};
 pub use errors::OperatorError;
-pub use loop_runner::{OperatorActivityLog, OperatorActivityEntry, OperatorLoop};
+pub use loop_runner::{OperatorActivityEntry, OperatorActivityLog, OperatorLoop};
 pub use proposals::{
     OperatorAction, OperatorDecision, OperatorProposal, OperatorProposalResponse,
     parse_operator_proposals,
+};
+pub use registry::OperatorRegistry;
+pub use session::{
+    JoinSessionRequest, OperatorSession, SessionKind, SessionRole, SessionStatus,
 };
 
 #[cfg(test)]

--- a/crates/helix-operator/src/loop_runner.rs
+++ b/crates/helix-operator/src/loop_runner.rs
@@ -1,0 +1,627 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! The operator loop: observe-think-act cycle with deterministic guardrails.
+
+use crate::config::{DeskOperatorConfig, OperatorStatus};
+use crate::context::{format_context_for_llm, DeskContext};
+use crate::errors::OperatorError;
+use crate::proposals::{
+    parse_operator_proposals, proposal_to_action, OperatorAction, OperatorDecision,
+    OperatorProposal, OperatorProposalResponse,
+};
+use helix_core::autopilot_guard::{
+    AutopilotActionClass, AutopilotGuardDecision, AutopilotGuardMachine,
+};
+use helix_llm::providers::{LlmProvider, LlmRequest, Message, MessageRole};
+use serde::{Deserialize, Serialize};
+use std::collections::VecDeque;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// A single entry in the operator activity log.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OperatorActivityEntry {
+    /// Unique entry id.
+    pub id: String,
+    /// Cycle number.
+    pub cycle: u64,
+    /// The action type proposed.
+    pub action_type: String,
+    /// The LLM rationale.
+    pub rationale: String,
+    /// Whether the guard allowed it.
+    pub allowed: bool,
+    /// Denial reason if denied.
+    pub denial_reason: Option<String>,
+    /// Whether human confirmation is required.
+    pub requires_confirmation: bool,
+    /// ISO-8601 timestamp.
+    pub timestamp: String,
+}
+
+/// Bounded, thread-safe activity log.
+#[derive(Debug, Clone)]
+pub struct OperatorActivityLog {
+    inner: Arc<RwLock<VecDeque<OperatorActivityEntry>>>,
+    capacity: usize,
+}
+
+impl OperatorActivityLog {
+    /// Creates a new activity log with the given capacity.
+    pub fn new(capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(VecDeque::with_capacity(capacity))),
+            capacity,
+        }
+    }
+
+    /// Appends an entry, evicting oldest if at capacity.
+    pub async fn append(&self, entry: OperatorActivityEntry) {
+        let mut log = self.inner.write().await;
+        if log.len() >= self.capacity {
+            log.pop_front();
+        }
+        log.push_back(entry);
+    }
+
+    /// Returns the most recent `n` entries (newest first).
+    pub async fn recent(&self, n: usize) -> Vec<OperatorActivityEntry> {
+        let log = self.inner.read().await;
+        log.iter().rev().take(n).cloned().collect()
+    }
+
+    /// Returns the total count.
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    /// Returns true if empty.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.read().await.is_empty()
+    }
+}
+
+/// The operator loop state.
+#[derive(Debug)]
+pub struct OperatorLoop {
+    config: Arc<RwLock<DeskOperatorConfig>>,
+    status: Arc<RwLock<OperatorStatus>>,
+    guard: Arc<RwLock<AutopilotGuardMachine>>,
+    activity_log: OperatorActivityLog,
+    cycle_count: Arc<RwLock<u64>>,
+}
+
+impl OperatorLoop {
+    /// Creates a new operator loop with the given config and guard.
+    pub fn new(
+        config: DeskOperatorConfig,
+        guard: AutopilotGuardMachine,
+    ) -> Self {
+        Self {
+            config: Arc::new(RwLock::new(config)),
+            status: Arc::new(RwLock::new(OperatorStatus::Stopped)),
+            guard: Arc::new(RwLock::new(guard)),
+            activity_log: OperatorActivityLog::new(200),
+            cycle_count: Arc::new(RwLock::new(0)),
+        }
+    }
+
+    /// Creates a new operator loop, deriving the guard from the config.
+    ///
+    /// The guard's autopilot mode and on-chain flags are synchronized with the
+    /// config. Use [`OperatorLoop::new`] if you need to supply a custom guard
+    /// (e.g. one restored from a snapshot).
+    pub fn from_config(config: DeskOperatorConfig) -> Self {
+        let allow_onchain = matches!(
+            config.action_scope,
+            crate::config::OperatorActionScope::Full
+        );
+        let guard_config = helix_core::autopilot_guard::AutopilotGuardConfig {
+            mode: config.autopilot_mode,
+            allow_onchain,
+            require_onchain_confirmation: true,
+            require_onchain_dry_run: true,
+            max_policy_commands: 128,
+        };
+        Self::new(config, AutopilotGuardMachine::new(guard_config))
+    }
+
+    /// Returns the current config.
+    pub async fn config(&self) -> DeskOperatorConfig {
+        self.config.read().await.clone()
+    }
+
+    /// Updates the config.
+    pub async fn set_config(&self, config: DeskOperatorConfig) -> Result<(), OperatorError> {
+        config.validate()?;
+        // Sync the guard mode
+        let mut guard = self.guard.write().await;
+        guard.step(helix_core::autopilot_guard::AutopilotGuardInput::SetConfig {
+            config: helix_core::autopilot_guard::AutopilotGuardConfig {
+                mode: config.autopilot_mode,
+                allow_onchain: matches!(config.action_scope, crate::config::OperatorActionScope::Full),
+                require_onchain_confirmation: true,
+                require_onchain_dry_run: true,
+                max_policy_commands: 128,
+            },
+        });
+        *self.config.write().await = config;
+        Ok(())
+    }
+
+    /// Returns the current status.
+    pub async fn status(&self) -> OperatorStatus {
+        *self.status.read().await
+    }
+
+    /// Starts the operator loop.
+    pub async fn start(&self) -> Result<(), OperatorError> {
+        let mut status = self.status.write().await;
+        if *status == OperatorStatus::Running {
+            return Err(OperatorError::AlreadyRunning);
+        }
+        *status = OperatorStatus::Running;
+        Ok(())
+    }
+
+    /// Stops the operator loop.
+    pub async fn stop(&self) -> Result<(), OperatorError> {
+        let mut status = self.status.write().await;
+        *status = OperatorStatus::Stopped;
+        Ok(())
+    }
+
+    /// Pauses the operator loop.
+    pub async fn pause(&self) -> Result<(), OperatorError> {
+        let mut status = self.status.write().await;
+        *status = OperatorStatus::Paused;
+        Ok(())
+    }
+
+    /// Returns the current cycle count.
+    pub async fn cycle_count(&self) -> u64 {
+        *self.cycle_count.read().await
+    }
+
+    /// Returns a reference to the activity log.
+    pub fn activity_log(&self) -> &OperatorActivityLog {
+        &self.activity_log
+    }
+
+    /// Runs one observe-think-act cycle.
+    ///
+    /// This is the core of the operator. It:
+    /// 1. Reads the desk context
+    /// 2. Sends it to the LLM with the system prompt
+    /// 3. Parses the LLM response into proposals
+    /// 4. Evaluates each proposal through the guard
+    /// 5. Returns the proposals and decisions
+    ///
+    /// The caller is responsible for executing allowed actions.
+    pub async fn run_cycle(
+        &self,
+        context: &dyn DeskContext,
+        provider: &dyn LlmProvider,
+    ) -> Result<OperatorProposalResponse, OperatorError> {
+        let config = self.config.read().await.clone();
+
+        // Check status
+        {
+            let status = self.status.read().await;
+            if *status != OperatorStatus::Running {
+                return Err(OperatorError::NotRunning);
+            }
+        }
+
+        // Increment cycle
+        let cycle = {
+            let mut count = self.cycle_count.write().await;
+            *count += 1;
+            *count
+        };
+
+        // 1. Observe: build desk context
+        let snapshot = context.snapshot(config.max_context_items);
+        let user_prompt = format_context_for_llm(&snapshot);
+
+        // 2. Think: call LLM
+        let system_prompt = config.system_prompt();
+        let mut parameters = std::collections::HashMap::new();
+        parameters.insert("model".to_string(), serde_json::Value::String(config.model.clone()));
+
+        let llm_request = LlmRequest {
+            system_prompt: Some(system_prompt),
+            messages: vec![Message {
+                role: MessageRole::User,
+                content: user_prompt,
+                function_call: None,
+            }],
+            max_tokens: Some(1024),
+            temperature: Some(0.0),
+            top_p: Some(1.0),
+            functions: None,
+            parameters,
+        };
+
+        let llm_response = provider
+            .complete(llm_request)
+            .await
+            .map_err(|e| OperatorError::LlmError(e.to_string()))?;
+
+        // 3. Parse proposals
+        let proposals = parse_operator_proposals(&llm_response.content)?;
+
+        // Limit to max_actions_per_cycle
+        let proposals: Vec<OperatorProposal> = proposals
+            .into_iter()
+            .take(config.max_actions_per_cycle)
+            .collect();
+
+        // 4. Evaluate each proposal through scope + guard
+        let mut decisions = Vec::new();
+        let mut allowed_count = 0;
+        let mut denied_count = 0;
+
+        for proposal in &proposals {
+            // Scope check (first gate)
+            if !config.action_scope.permits(&proposal.action_type) {
+                let decision = OperatorDecision {
+                    proposal: proposal.clone(),
+                    allowed: false,
+                    denial_reason: Some("out_of_scope".to_string()),
+                    requires_confirmation: false,
+                };
+                if config.log_denied_proposals {
+                    self.log_activity(cycle, &decision).await;
+                }
+                decisions.push(decision);
+                denied_count += 1;
+                continue;
+            }
+
+            // Guard check (second gate — deterministic)
+            let action_class = classify_proposal(proposal);
+            let guard_decision = {
+                let mut guard = self.guard.write().await;
+                guard.step(helix_core::autopilot_guard::AutopilotGuardInput::Evaluate {
+                    action: action_class,
+                    confirmed_by_human: false, // LLM proposals are never "human confirmed"
+                })
+            };
+
+            let (allowed, denial_reason, requires_confirmation) = match guard_decision {
+                AutopilotGuardDecision::Allow {
+                    requires_confirmation,
+                } => {
+                    allowed_count += 1;
+                    (true, None, requires_confirmation)
+                }
+                AutopilotGuardDecision::Deny { reason } => {
+                    denied_count += 1;
+                    (false, Some(reason), false)
+                }
+                AutopilotGuardDecision::ConfigUpdated => {
+                    denied_count += 1;
+                    (false, Some("config_updated".to_string()), false)
+                }
+            };
+
+            let decision = OperatorDecision {
+                proposal: proposal.clone(),
+                allowed,
+                denial_reason: denial_reason.clone(),
+                requires_confirmation,
+            };
+
+            // Log all activities (both allowed and denied)
+            self.log_activity(cycle, &decision).await;
+
+            decisions.push(decision);
+        }
+
+        Ok(OperatorProposalResponse {
+            model: llm_response.model,
+            raw_response: llm_response.content,
+            proposals,
+            decisions,
+            allowed_count,
+            denied_count,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        })
+    }
+
+    /// Extracts allowed actions from a proposal response.
+    pub fn allowed_actions(response: &OperatorProposalResponse) -> Vec<OperatorAction> {
+        response
+            .decisions
+            .iter()
+            .filter(|d| d.allowed)
+            .filter_map(|d| proposal_to_action(&d.proposal))
+            .collect()
+    }
+
+    async fn log_activity(&self, cycle: u64, decision: &OperatorDecision) {
+        let entry = OperatorActivityEntry {
+            id: format!("op-{}", uuid::Uuid::new_v4()),
+            cycle,
+            action_type: decision.proposal.action_type.clone(),
+            rationale: decision.proposal.rationale.clone(),
+            allowed: decision.allowed,
+            denial_reason: decision.denial_reason.clone(),
+            requires_confirmation: decision.requires_confirmation,
+            timestamp: chrono::Utc::now().to_rfc3339(),
+        };
+        self.activity_log.append(entry).await;
+    }
+}
+
+/// Classifies an operator proposal into an autopilot guard action class.
+fn classify_proposal(proposal: &OperatorProposal) -> AutopilotActionClass {
+    match proposal.action_type.as_str() {
+        "policy_simulation" => {
+            let command_count = proposal
+                .parameters
+                .get("commands")
+                .and_then(|v| v.as_array())
+                .map(|arr| arr.len().min(usize::from(u16::MAX)) as u16)
+                .unwrap_or(0);
+            AutopilotActionClass::PolicySimulation { command_count }
+        }
+        _ => {
+            // All non-policy actions are treated as policy simulations with
+            // 1 command for guard purposes — they're intelligence actions
+            // that don't touch on-chain, so the guard's on-chain checks
+            // don't apply. The scope check already filtered them.
+            AutopilotActionClass::PolicySimulation { command_count: 1 }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::DeskContextSnapshot;
+    use helix_core::autopilot_guard::AutopilotMode;
+
+    struct StubContext;
+    impl DeskContext for StubContext {
+        fn snapshot(&self, _max_items: usize) -> DeskContextSnapshot {
+            DeskContextSnapshot {
+                source_count: 1,
+                watchlist_count: 1,
+                evidence_count: 1,
+                claim_count: 0,
+                open_case_count: 1,
+                escalated_case_count: 0,
+                top_cases: vec![],
+                recent_evidence: vec![],
+                active_watchlists: vec![],
+                recent_decisions: vec![],
+            }
+        }
+    }
+
+    struct StubLlmProvider;
+    #[async_trait::async_trait]
+    impl LlmProvider for StubLlmProvider {
+        fn name(&self) -> &str { "mock" }
+        async fn get_models(&self) -> Result<Vec<helix_llm::providers::ModelConfig>, helix_llm::errors::LlmError> {
+            Ok(vec![])
+        }
+        async fn complete(
+            &self,
+            _request: LlmRequest,
+        ) -> Result<helix_llm::providers::LlmResponse, helix_llm::errors::LlmError> {
+            Ok(helix_llm::providers::LlmResponse {
+                content: r#"[{"type":"log_analysis","rationale":"test","parameters":{"severity":"low","summary":"ok"}}]"#
+                    .to_string(),
+                function_call: None,
+                usage: helix_llm::providers::TokenUsage {
+                    prompt_tokens: 10,
+                    completion_tokens: 5,
+                    total_tokens: 15,
+                },
+                model: "mock".to_string(),
+                finish_reason: helix_llm::providers::FinishReason::Stop,
+                metadata: std::collections::HashMap::new(),
+            })
+        }
+        async fn stream_complete(
+            &self,
+            _request: LlmRequest,
+        ) -> Result<Box<dyn futures::Stream<Item = Result<String, helix_llm::errors::LlmError>> + Unpin + Send>, helix_llm::errors::LlmError> {
+            unimplemented!()
+        }
+        async fn health_check(&self) -> Result<(), helix_llm::errors::LlmError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn loop_starts_and_stops() {
+        let loop_runner = OperatorLoop::new(
+            DeskOperatorConfig::default(),
+            AutopilotGuardMachine::default(),
+        );
+        assert_eq!(loop_runner.status().await, OperatorStatus::Stopped);
+        loop_runner.start().await.unwrap();
+        assert_eq!(loop_runner.status().await, OperatorStatus::Running);
+        loop_runner.stop().await.unwrap();
+        assert_eq!(loop_runner.status().await, OperatorStatus::Stopped);
+    }
+
+    #[tokio::test]
+    async fn loop_double_start_fails() {
+        let loop_runner = OperatorLoop::new(
+            DeskOperatorConfig::default(),
+            AutopilotGuardMachine::default(),
+        );
+        loop_runner.start().await.unwrap();
+        assert!(loop_runner.start().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn run_cycle_when_stopped_fails() {
+        let loop_runner = OperatorLoop::new(
+            DeskOperatorConfig::default(),
+            AutopilotGuardMachine::default(),
+        );
+        let ctx = StubContext;
+        let provider = StubLlmProvider;
+        let result = loop_runner.run_cycle(&ctx, &provider).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn run_cycle_in_off_mode_denies_all() {
+        let config = DeskOperatorConfig {
+            enabled: true,
+            autopilot_mode: AutopilotMode::Off,
+            ..Default::default()
+        };
+        let loop_runner = OperatorLoop::from_config(config);
+        loop_runner.start().await.unwrap();
+        let ctx = StubContext;
+        let provider = StubLlmProvider;
+        let result = loop_runner.run_cycle(&ctx, &provider).await.unwrap();
+        assert_eq!(result.denied_count, 1);
+        assert_eq!(result.allowed_count, 0);
+    }
+
+    #[tokio::test]
+    async fn run_cycle_in_auto_mode_allows() {
+        let config = DeskOperatorConfig {
+            enabled: true,
+            autopilot_mode: AutopilotMode::Auto,
+            action_scope: crate::config::OperatorActionScope::Intelligence,
+            ..Default::default()
+        };
+        let loop_runner = OperatorLoop::from_config(config);
+        loop_runner.start().await.unwrap();
+        let ctx = StubContext;
+        let provider = StubLlmProvider;
+        let result = loop_runner.run_cycle(&ctx, &provider).await.unwrap();
+        assert_eq!(result.proposals.len(), 1);
+        assert_eq!(result.allowed_count, 1);
+        assert_eq!(result.denied_count, 0);
+    }
+
+    #[tokio::test]
+    async fn run_cycle_logs_activity() {
+        let config = DeskOperatorConfig {
+            enabled: true,
+            autopilot_mode: AutopilotMode::Auto,
+            ..Default::default()
+        };
+        let loop_runner = OperatorLoop::from_config(config);
+        loop_runner.start().await.unwrap();
+        let ctx = StubContext;
+        let provider = StubLlmProvider;
+        let _ = loop_runner.run_cycle(&ctx, &provider).await.unwrap();
+        assert_eq!(loop_runner.activity_log().len().await, 1);
+        let entries = loop_runner.activity_log().recent(10).await;
+        assert_eq!(entries[0].action_type, "log_analysis");
+        assert!(entries[0].allowed);
+    }
+
+    #[tokio::test]
+    async fn run_cycle_increments_cycle_count() {
+        let config = DeskOperatorConfig {
+            enabled: true,
+            autopilot_mode: AutopilotMode::Auto,
+            ..Default::default()
+        };
+        let loop_runner = OperatorLoop::from_config(config);
+        loop_runner.start().await.unwrap();
+        let ctx = StubContext;
+        let provider = StubLlmProvider;
+        let _ = loop_runner.run_cycle(&ctx, &provider).await.unwrap();
+        let _ = loop_runner.run_cycle(&ctx, &provider).await.unwrap();
+        assert_eq!(loop_runner.cycle_count().await, 2);
+    }
+
+    #[tokio::test]
+    async fn set_config_updates_guard() {
+        let loop_runner = OperatorLoop::new(
+            DeskOperatorConfig::default(),
+            AutopilotGuardMachine::default(),
+        );
+        let new_config = DeskOperatorConfig {
+            autopilot_mode: AutopilotMode::Auto,
+            ..Default::default()
+        };
+        loop_runner.set_config(new_config).await.unwrap();
+        let guard = loop_runner.guard.read().await;
+        assert_eq!(guard.config().mode, AutopilotMode::Auto);
+    }
+
+    #[tokio::test]
+    async fn activity_log_capacity_evicts() {
+        let log = OperatorActivityLog::new(3);
+        for i in 0..5 {
+            log.append(OperatorActivityEntry {
+                id: format!("e{i}"),
+                cycle: i as u64,
+                action_type: "log_analysis".to_string(),
+                rationale: "test".to_string(),
+                allowed: true,
+                denial_reason: None,
+                requires_confirmation: false,
+                timestamp: "2026-01-01T00:00:00Z".to_string(),
+            })
+            .await;
+        }
+        assert_eq!(log.len().await, 3);
+        let recent = log.recent(10).await;
+        assert_eq!(recent[0].id, "e4");
+    }
+
+    #[tokio::test]
+    async fn allowed_actions_extracts_allowed() {
+        let response = OperatorProposalResponse {
+            model: "test".to_string(),
+            raw_response: "[]".to_string(),
+            proposals: vec![
+                OperatorProposal {
+                    action_type: "log_analysis".to_string(),
+                    target_id: None,
+                    rationale: "test".to_string(),
+                    parameters: serde_json::json!({"severity": "low", "summary": "ok"}),
+                },
+            ],
+            decisions: vec![OperatorDecision {
+                proposal: OperatorProposal {
+                    action_type: "log_analysis".to_string(),
+                    target_id: None,
+                    rationale: "test".to_string(),
+                    parameters: serde_json::json!({"severity": "low", "summary": "ok"}),
+                },
+                allowed: true,
+                denial_reason: None,
+                requires_confirmation: false,
+            }],
+            allowed_count: 1,
+            denied_count: 0,
+            timestamp: "2026-01-01T00:00:00Z".to_string(),
+        };
+        let actions = OperatorLoop::allowed_actions(&response);
+        assert_eq!(actions.len(), 1);
+        match &actions[0] {
+            OperatorAction::LogAnalysis { severity, .. } => {
+                assert_eq!(severity, "low");
+            }
+            _ => panic!("wrong action"),
+        }
+    }
+}

--- a/crates/helix-operator/src/loop_runner.rs
+++ b/crates/helix-operator/src/loop_runner.rs
@@ -275,7 +275,7 @@ impl OperatorLoop {
                 content: user_prompt,
                 function_call: None,
             }],
-            max_tokens: Some(1024),
+            max_tokens: Some(4096),
             temperature: Some(0.0),
             top_p: Some(1.0),
             functions: None,

--- a/crates/helix-operator/src/loop_runner.rs
+++ b/crates/helix-operator/src/loop_runner.rs
@@ -13,7 +13,9 @@
 
 //! The operator loop: observe-think-act cycle with deterministic guardrails.
 
+use crate::collaboration::CollaborationBroadcaster;
 use crate::config::{DeskOperatorConfig, OperatorStatus};
+use crate::confirmation::{ConfirmationQueue, ConfirmationRequest};
 use crate::context::{format_context_for_llm, DeskContext};
 use crate::errors::OperatorError;
 use crate::proposals::{
@@ -100,6 +102,8 @@ pub struct OperatorLoop {
     guard: Arc<RwLock<AutopilotGuardMachine>>,
     activity_log: OperatorActivityLog,
     cycle_count: Arc<RwLock<u64>>,
+    confirmation_queue: ConfirmationQueue,
+    broadcaster: CollaborationBroadcaster,
 }
 
 impl OperatorLoop {
@@ -114,6 +118,8 @@ impl OperatorLoop {
             guard: Arc::new(RwLock::new(guard)),
             activity_log: OperatorActivityLog::new(200),
             cycle_count: Arc::new(RwLock::new(0)),
+            confirmation_queue: ConfirmationQueue::new(50),
+            broadcaster: CollaborationBroadcaster::default(),
         }
     }
 
@@ -157,6 +163,9 @@ impl OperatorLoop {
             },
         });
         *self.config.write().await = config;
+        drop(guard);
+        self.broadcaster
+            .broadcast(crate::collaboration::CollaborationEvent::config_changed());
         Ok(())
     }
 
@@ -172,6 +181,9 @@ impl OperatorLoop {
             return Err(OperatorError::AlreadyRunning);
         }
         *status = OperatorStatus::Running;
+        drop(status);
+        self.broadcaster
+            .broadcast(crate::collaboration::CollaborationEvent::loop_started());
         Ok(())
     }
 
@@ -179,6 +191,9 @@ impl OperatorLoop {
     pub async fn stop(&self) -> Result<(), OperatorError> {
         let mut status = self.status.write().await;
         *status = OperatorStatus::Stopped;
+        drop(status);
+        self.broadcaster
+            .broadcast(crate::collaboration::CollaborationEvent::loop_stopped());
         Ok(())
     }
 
@@ -186,6 +201,9 @@ impl OperatorLoop {
     pub async fn pause(&self) -> Result<(), OperatorError> {
         let mut status = self.status.write().await;
         *status = OperatorStatus::Paused;
+        drop(status);
+        self.broadcaster
+            .broadcast(crate::collaboration::CollaborationEvent::loop_paused());
         Ok(())
     }
 
@@ -197,6 +215,16 @@ impl OperatorLoop {
     /// Returns a reference to the activity log.
     pub fn activity_log(&self) -> &OperatorActivityLog {
         &self.activity_log
+    }
+
+    /// Returns a reference to the confirmation queue.
+    pub fn confirmation_queue(&self) -> &ConfirmationQueue {
+        &self.confirmation_queue
+    }
+
+    /// Returns a reference to the collaboration broadcaster.
+    pub fn broadcaster(&self) -> &CollaborationBroadcaster {
+        &self.broadcaster
     }
 
     /// Runs one observe-think-act cycle.
@@ -272,6 +300,7 @@ impl OperatorLoop {
         let mut decisions = Vec::new();
         let mut allowed_count = 0;
         let mut denied_count = 0;
+        let mut pending_confirmation_count = 0;
 
         for proposal in &proposals {
             // Scope check (first gate)
@@ -285,6 +314,9 @@ impl OperatorLoop {
                 if config.log_denied_proposals {
                     self.log_activity(cycle, &decision).await;
                 }
+                self.broadcaster.broadcast(
+                    crate::collaboration::CollaborationEvent::operator_decision(cycle, decision.clone()),
+                );
                 decisions.push(decision);
                 denied_count += 1;
                 continue;
@@ -300,35 +332,75 @@ impl OperatorLoop {
                 })
             };
 
-            let (allowed, denial_reason, requires_confirmation) = match guard_decision {
+            let decision = match guard_decision {
                 AutopilotGuardDecision::Allow {
                     requires_confirmation,
                 } => {
-                    allowed_count += 1;
-                    (true, None, requires_confirmation)
+                    if requires_confirmation {
+                        // CoPilot assist mode: enqueue for human review
+                        let conf_req = ConfirmationRequest::new(cycle, proposal.clone());
+                        self.confirmation_queue.enqueue(conf_req.clone()).await;
+                        pending_confirmation_count += 1;
+                        self.broadcaster.broadcast(
+                            crate::collaboration::CollaborationEvent::confirmation_requested(conf_req),
+                        );
+                        // Not allowed yet — pending human confirmation
+                        OperatorDecision {
+                            proposal: proposal.clone(),
+                            allowed: false,
+                            denial_reason: Some("pending_confirmation".to_string()),
+                            requires_confirmation: true,
+                        }
+                    } else {
+                        allowed_count += 1;
+                        OperatorDecision {
+                            proposal: proposal.clone(),
+                            allowed: true,
+                            denial_reason: None,
+                            requires_confirmation: false,
+                        }
+                    }
                 }
                 AutopilotGuardDecision::Deny { reason } => {
                     denied_count += 1;
-                    (false, Some(reason), false)
+                    OperatorDecision {
+                        proposal: proposal.clone(),
+                        allowed: false,
+                        denial_reason: Some(reason),
+                        requires_confirmation: false,
+                    }
                 }
                 AutopilotGuardDecision::ConfigUpdated => {
                     denied_count += 1;
-                    (false, Some("config_updated".to_string()), false)
+                    OperatorDecision {
+                        proposal: proposal.clone(),
+                        allowed: false,
+                        denial_reason: Some("config_updated".to_string()),
+                        requires_confirmation: false,
+                    }
                 }
-            };
-
-            let decision = OperatorDecision {
-                proposal: proposal.clone(),
-                allowed,
-                denial_reason: denial_reason.clone(),
-                requires_confirmation,
             };
 
             // Log all activities (both allowed and denied)
             self.log_activity(cycle, &decision).await;
 
+            // Broadcast the decision to all CoPilot participants
+            self.broadcaster.broadcast(
+                crate::collaboration::CollaborationEvent::operator_decision(cycle, decision.clone()),
+            );
+
             decisions.push(decision);
         }
+
+        // Broadcast cycle completion
+        self.broadcaster.broadcast(
+            crate::collaboration::CollaborationEvent::cycle_completed(
+                cycle,
+                allowed_count,
+                denied_count,
+                pending_confirmation_count,
+            ),
+        );
 
         Ok(OperatorProposalResponse {
             model: llm_response.model,

--- a/crates/helix-operator/src/proposals.rs
+++ b/crates/helix-operator/src/proposals.rs
@@ -1,0 +1,430 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Operator proposals: the action objects the LLM produces, and the parser
+//! that converts raw LLM output into structured proposals.
+
+use crate::errors::OperatorError;
+use serde::{Deserialize, Serialize};
+
+/// A single action proposed by the LLM operator.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OperatorProposal {
+    /// The action type (e.g. "escalate_case", "log_analysis").
+    #[serde(rename = "type")]
+    pub action_type: String,
+    /// Optional target id (case id, evidence id, claim id).
+    #[serde(default)]
+    pub target_id: Option<String>,
+    /// The LLM's rationale for this proposal.
+    #[serde(default)]
+    pub rationale: String,
+    /// Action-specific parameters.
+    #[serde(default)]
+    pub parameters: serde_json::Value,
+}
+
+/// The decision made by the guard for a proposal.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OperatorDecision {
+    /// The original proposal.
+    pub proposal: OperatorProposal,
+    /// Whether the action was allowed.
+    pub allowed: bool,
+    /// Denial reason if not allowed.
+    pub denial_reason: Option<String>,
+    /// Whether human confirmation is required.
+    pub requires_confirmation: bool,
+}
+
+/// The full response from one operator cycle: the LLM's raw output, parsed
+/// proposals, and guard decisions.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperatorProposalResponse {
+    /// The LLM model used.
+    pub model: String,
+    /// Raw LLM response text.
+    pub raw_response: String,
+    /// Parsed proposals.
+    pub proposals: Vec<OperatorProposal>,
+    /// Guard decisions for each proposal.
+    pub decisions: Vec<OperatorDecision>,
+    /// Number of proposals allowed.
+    pub allowed_count: usize,
+    /// Number of proposals denied.
+    pub denied_count: usize,
+    /// Cycle timestamp.
+    pub timestamp: String,
+}
+
+/// An action to execute, derived from an allowed proposal.
+///
+/// This is the output the operator loop hands to the execution layer.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum OperatorAction {
+    /// Log an analysis (no side effects).
+    LogAnalysis {
+        /// Severity level.
+        severity: String,
+        /// Analysis summary.
+        summary: String,
+        /// LLM rationale.
+        rationale: String,
+    },
+    /// Escalate a case.
+    EscalateCase {
+        /// Case id.
+        case_id: String,
+        /// Rationale.
+        rationale: String,
+    },
+    /// Open a new case from evidence.
+    OpenCase {
+        /// Evidence id.
+        evidence_id: String,
+        /// Case title.
+        title: String,
+        /// Watchlist id.
+        watchlist_id: String,
+        /// Rationale.
+        rationale: String,
+    },
+    /// Review a claim.
+    ReviewClaim {
+        /// Claim id.
+        claim_id: String,
+        /// New review status: "corroborated" or "rejected".
+        status: String,
+        /// Rationale.
+        rationale: String,
+    },
+    /// Broadcast to federation peers.
+    FederationBroadcast {
+        /// Broadcast title.
+        title: String,
+        /// Broadcast summary.
+        summary: String,
+        /// Broadcast content.
+        content: String,
+        /// Rationale.
+        rationale: String,
+    },
+    /// Run a policy simulation.
+    PolicySimulation {
+        /// Policy commands.
+        commands: serde_json::Value,
+        /// Rationale.
+        rationale: String,
+    },
+}
+
+impl OperatorAction {
+    /// The action type string for this action.
+    pub fn action_type(&self) -> &'static str {
+        match self {
+            Self::LogAnalysis { .. } => "log_analysis",
+            Self::EscalateCase { .. } => "escalate_case",
+            Self::OpenCase { .. } => "open_case",
+            Self::ReviewClaim { .. } => "review_claim",
+            Self::FederationBroadcast { .. } => "federation_broadcast",
+            Self::PolicySimulation { .. } => "policy_simulation",
+        }
+    }
+}
+
+/// Parses raw LLM output into a list of operator proposals.
+///
+/// The LLM is expected to return a JSON array of action objects. This parser
+/// is fail-closed: if the output cannot be parsed, an error is returned.
+/// Individual malformed entries are skipped (not fatal).
+pub fn parse_operator_proposals(raw: &str) -> Result<Vec<OperatorProposal>, OperatorError> {
+    let trimmed = raw.trim();
+
+    // Strip markdown code fences if present
+    let cleaned = if trimmed.starts_with("```") {
+        let inner = trimmed
+            .trim_start_matches("```json")
+            .trim_start_matches("```")
+            .trim_end_matches("```")
+            .trim();
+        inner
+    } else {
+        trimmed
+    };
+
+    // Try parsing as a JSON array first
+    let parsed: serde_json::Value = serde_json::from_str(cleaned)
+        .map_err(|e| OperatorError::ParseError(format!("invalid JSON: {e}")))?;
+
+    let array = match parsed {
+        serde_json::Value::Array(arr) => arr,
+        serde_json::Value::Object(_) => vec![parsed],
+        _ => return Err(OperatorError::ParseError("expected JSON array or object".to_string())),
+    };
+
+    let mut proposals = Vec::new();
+    for item in array {
+        match serde_json::from_value::<OperatorProposal>(item.clone()) {
+            Ok(proposal) => {
+                if !proposal.action_type.trim().is_empty() {
+                    proposals.push(proposal);
+                }
+            }
+            Err(_) => {
+                // Skip malformed entries — don't fail the entire parse
+                tracing::warn!(entry = %item, "skipping malformed operator proposal entry");
+            }
+        }
+    }
+
+    Ok(proposals)
+}
+
+/// Converts an allowed proposal into an [`OperatorAction`].
+///
+/// Returns `None` for action types that don't map to a concrete action
+/// (e.g. unknown types).
+pub fn proposal_to_action(proposal: &OperatorProposal) -> Option<OperatorAction> {
+    match proposal.action_type.as_str() {
+        "log_analysis" => {
+            let severity = proposal.parameters
+                .get("severity")
+                .and_then(|v| v.as_str())
+                .unwrap_or("low")
+                .to_string();
+            let summary = proposal.parameters
+                .get("summary")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some(OperatorAction::LogAnalysis {
+                severity,
+                summary,
+                rationale: proposal.rationale.clone(),
+            })
+        }
+        "escalate_case" => {
+            let case_id = proposal.target_id.clone().unwrap_or_default();
+            if case_id.is_empty() {
+                return None;
+            }
+            Some(OperatorAction::EscalateCase {
+                case_id,
+                rationale: proposal.rationale.clone(),
+            })
+        }
+        "open_case" => {
+            let evidence_id = proposal.target_id.clone().unwrap_or_default();
+            let title = proposal.parameters
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Operator-opened case")
+                .to_string();
+            let watchlist_id = proposal.parameters
+                .get("watchlist_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            if evidence_id.is_empty() || watchlist_id.is_empty() {
+                return None;
+            }
+            Some(OperatorAction::OpenCase {
+                evidence_id,
+                title,
+                watchlist_id,
+                rationale: proposal.rationale.clone(),
+            })
+        }
+        "review_claim" => {
+            let claim_id = proposal.target_id.clone().unwrap_or_default();
+            let status = proposal.parameters
+                .get("status")
+                .and_then(|v| v.as_str())
+                .unwrap_or("corroborated")
+                .to_string();
+            if claim_id.is_empty() {
+                return None;
+            }
+            Some(OperatorAction::ReviewClaim {
+                claim_id,
+                status,
+                rationale: proposal.rationale.clone(),
+            })
+        }
+        "federation_broadcast" => {
+            let title = proposal.parameters
+                .get("title")
+                .and_then(|v| v.as_str())
+                .unwrap_or("Operator broadcast")
+                .to_string();
+            let summary = proposal.parameters
+                .get("summary")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let content = proposal.parameters
+                .get("content")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Some(OperatorAction::FederationBroadcast {
+                title,
+                summary,
+                content,
+                rationale: proposal.rationale.clone(),
+            })
+        }
+        "policy_simulation" => {
+            let commands = proposal.parameters
+                .get("commands")
+                .cloned()
+                .unwrap_or(serde_json::Value::Array(vec![]));
+            Some(OperatorAction::PolicySimulation {
+                commands,
+                rationale: proposal.rationale.clone(),
+            })
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_array() {
+        let raw = r#"[
+            {"type": "escalate_case", "target_id": "case-1", "rationale": "High priority"},
+            {"type": "log_analysis", "rationale": "Monitoring", "parameters": {"severity": "high", "summary": "test"}}
+        ]"#;
+        let proposals = parse_operator_proposals(raw).unwrap();
+        assert_eq!(proposals.len(), 2);
+        assert_eq!(proposals[0].action_type, "escalate_case");
+        assert_eq!(proposals[1].action_type, "log_analysis");
+    }
+
+    #[test]
+    fn parse_strips_markdown_fences() {
+        let raw = r#"```json
+        [{"type": "log_analysis", "rationale": "test"}]
+        ```"#;
+        let proposals = parse_operator_proposals(raw).unwrap();
+        assert_eq!(proposals.len(), 1);
+    }
+
+    #[test]
+    fn parse_skips_malformed_entries() {
+        let raw = r#"[
+            {"type": "log_analysis", "rationale": "good"},
+            {"bad": "entry"},
+            {"type": "escalate_case", "target_id": "case-1", "rationale": "also good"}
+        ]"#;
+        let proposals = parse_operator_proposals(raw).unwrap();
+        assert_eq!(proposals.len(), 2);
+    }
+
+    #[test]
+    fn parse_rejects_non_json() {
+        let raw = "this is not json";
+        assert!(parse_operator_proposals(raw).is_err());
+    }
+
+    #[test]
+    fn parse_single_object_wraps_into_array() {
+        let raw = r#"{"type": "log_analysis", "rationale": "single"}"#;
+        let proposals = parse_operator_proposals(raw).unwrap();
+        assert_eq!(proposals.len(), 1);
+    }
+
+    #[test]
+    fn proposal_to_action_escalate_case() {
+        let proposal = OperatorProposal {
+            action_type: "escalate_case".to_string(),
+            target_id: Some("case-42".to_string()),
+            rationale: "Critical finding".to_string(),
+            parameters: serde_json::Value::Null,
+        };
+        let action = proposal_to_action(&proposal).unwrap();
+        match action {
+            OperatorAction::EscalateCase { case_id, rationale } => {
+                assert_eq!(case_id, "case-42");
+                assert_eq!(rationale, "Critical finding");
+            }
+            _ => panic!("wrong action type"),
+        }
+    }
+
+    #[test]
+    fn proposal_to_action_log_analysis() {
+        let proposal = OperatorProposal {
+            action_type: "log_analysis".to_string(),
+            target_id: None,
+            rationale: "Observing".to_string(),
+            parameters: serde_json::json!({"severity": "high", "summary": "test summary"}),
+        };
+        let action = proposal_to_action(&proposal).unwrap();
+        match action {
+            OperatorAction::LogAnalysis { severity, summary, .. } => {
+                assert_eq!(severity, "high");
+                assert_eq!(summary, "test summary");
+            }
+            _ => panic!("wrong action type"),
+        }
+    }
+
+    #[test]
+    fn proposal_to_action_escalate_without_target_returns_none() {
+        let proposal = OperatorProposal {
+            action_type: "escalate_case".to_string(),
+            target_id: None,
+            rationale: "test".to_string(),
+            parameters: serde_json::Value::Null,
+        };
+        assert!(proposal_to_action(&proposal).is_none());
+    }
+
+    #[test]
+    fn proposal_to_action_unknown_type_returns_none() {
+        let proposal = OperatorProposal {
+            action_type: "unknown_action".to_string(),
+            target_id: None,
+            rationale: "test".to_string(),
+            parameters: serde_json::Value::Null,
+        };
+        assert!(proposal_to_action(&proposal).is_none());
+    }
+
+    #[test]
+    fn proposal_to_action_federation_broadcast() {
+        let proposal = OperatorProposal {
+            action_type: "federation_broadcast".to_string(),
+            target_id: None,
+            rationale: "Share with peers".to_string(),
+            parameters: serde_json::json!({
+                "title": "Alert",
+                "summary": "Brief",
+                "content": "Details"
+            }),
+        };
+        let action = proposal_to_action(&proposal).unwrap();
+        match action {
+            OperatorAction::FederationBroadcast { title, summary, content, .. } => {
+                assert_eq!(title, "Alert");
+                assert_eq!(summary, "Brief");
+                assert_eq!(content, "Details");
+            }
+            _ => panic!("wrong action type"),
+        }
+    }
+}

--- a/crates/helix-operator/src/registry.rs
+++ b/crates/helix-operator/src/registry.rs
@@ -1,0 +1,317 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Session registry: tracks all active CoPilot participants with presence.
+
+use crate::session::{
+    OperatorSession, PresenceThresholds, SessionKind, SessionStatus,
+};
+use chrono::Utc;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Thread-safe registry of CoPilot sessions.
+#[derive(Debug, Clone)]
+pub struct OperatorRegistry {
+    inner: Arc<RwLock<HashMap<String, OperatorSession>>>,
+    thresholds: PresenceThresholds,
+}
+
+impl OperatorRegistry {
+    /// Creates a new empty registry with default presence thresholds.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            thresholds: PresenceThresholds::default(),
+        }
+    }
+
+    /// Creates a new registry with custom presence thresholds.
+    pub fn with_thresholds(thresholds: PresenceThresholds) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(HashMap::new())),
+            thresholds,
+        }
+    }
+
+    /// Adds a session to the registry.
+    pub async fn add(&self, session: OperatorSession) -> String {
+        let id = session.id.clone();
+        self.inner.write().await.insert(id.clone(), session);
+        id
+    }
+
+    /// Removes a session by id. Returns the removed session if it existed.
+    pub async fn remove(&self, session_id: &str) -> Option<OperatorSession> {
+        self.inner.write().await.remove(session_id)
+    }
+
+    /// Returns a session by id.
+    pub async fn get(&self, session_id: &str) -> Option<OperatorSession> {
+        self.inner.read().await.get(session_id).cloned()
+    }
+
+    /// Updates the heartbeat for a session. Returns false if session not found.
+    pub async fn heartbeat(&self, session_id: &str) -> bool {
+        let mut sessions = self.inner.write().await;
+        if let Some(session) = sessions.get_mut(session_id) {
+            session.heartbeat();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Lists all sessions, updating their computed status first.
+    pub async fn list(&self) -> Vec<OperatorSession> {
+        let now = Utc::now();
+        let mut sessions = self.inner.write().await;
+        for session in sessions.values_mut() {
+            session.status = session.compute_status(
+                now,
+                self.thresholds.idle_secs,
+                self.thresholds.disconnect_secs,
+            );
+        }
+        sessions.values().cloned().collect()
+    }
+
+    /// Lists only active (non-disconnected) sessions.
+    pub async fn list_active(&self) -> Vec<OperatorSession> {
+        let all = self.list().await;
+        all.into_iter()
+            .filter(|s| s.status != SessionStatus::Disconnected)
+            .collect()
+    }
+
+    /// Returns the count of sessions by kind.
+    pub async fn counts_by_kind(&self) -> (usize, usize) {
+        let sessions = self.inner.read().await;
+        let humans = sessions
+            .values()
+            .filter(|s| s.kind == SessionKind::Human)
+            .count();
+        let ais = sessions
+            .values()
+            .filter(|s| s.kind == SessionKind::Ai)
+            .count();
+        (humans, ais)
+    }
+
+    /// Prunes disconnected sessions. Returns the number removed.
+    pub async fn prune_stale(&self) -> usize {
+        let now = Utc::now();
+        let mut sessions = self.inner.write().await;
+        let to_remove: Vec<String> = sessions
+            .iter()
+            .filter(|(_, s)| {
+                s.compute_status(
+                    now,
+                    self.thresholds.idle_secs,
+                    self.thresholds.disconnect_secs,
+                ) == SessionStatus::Disconnected
+            })
+            .map(|(id, _)| id.clone())
+            .collect();
+        let count = to_remove.len();
+        for id in &to_remove {
+            sessions.remove(id);
+        }
+        count
+    }
+
+    /// Returns the total number of sessions.
+    pub async fn len(&self) -> usize {
+        self.inner.read().await.len()
+    }
+
+    /// Returns true if the registry is empty.
+    pub async fn is_empty(&self) -> bool {
+        self.inner.read().await.is_empty()
+    }
+}
+
+impl Default for OperatorRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::SessionRole;
+
+    #[tokio::test]
+    async fn add_and_get_session() {
+        let registry = OperatorRegistry::new();
+        let session = OperatorSession::new(
+            "Alice".to_string(),
+            SessionKind::Human,
+            SessionRole::Operator,
+            None,
+        );
+        let id = registry.add(session).await;
+        let retrieved = registry.get(&id).await;
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap().display_name, "Alice");
+    }
+
+    #[tokio::test]
+    async fn remove_session() {
+        let registry = OperatorRegistry::new();
+        let session = OperatorSession::new(
+            "Bob".to_string(),
+            SessionKind::Human,
+            SessionRole::Viewer,
+            None,
+        );
+        let id = registry.add(session).await;
+        assert_eq!(registry.len().await, 1);
+        let removed = registry.remove(&id).await;
+        assert!(removed.is_some());
+        assert_eq!(registry.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_updates_session() {
+        let registry = OperatorRegistry::new();
+        let session = OperatorSession::new(
+            "Carol".to_string(),
+            SessionKind::Human,
+            SessionRole::Operator,
+            None,
+        );
+        let id = registry.add(session).await;
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        assert!(registry.heartbeat(&id).await);
+        let updated = registry.get(&id).await.unwrap();
+        assert_eq!(updated.status, SessionStatus::Active);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_returns_false_for_missing() {
+        let registry = OperatorRegistry::new();
+        assert!(!registry.heartbeat("nonexistent").await);
+    }
+
+    #[tokio::test]
+    async fn counts_by_kind() {
+        let registry = OperatorRegistry::new();
+        registry
+            .add(OperatorSession::new(
+                "Alice".to_string(),
+                SessionKind::Human,
+                SessionRole::Operator,
+                None,
+            ))
+            .await;
+        registry
+            .add(OperatorSession::new(
+                "Bob".to_string(),
+                SessionKind::Human,
+                SessionRole::Viewer,
+                None,
+            ))
+            .await;
+        registry
+            .add(OperatorSession::new(
+                "Copilot".to_string(),
+                SessionKind::Ai,
+                SessionRole::Operator,
+                None,
+            ))
+            .await;
+        let (humans, ais) = registry.counts_by_kind().await;
+        assert_eq!(humans, 2);
+        assert_eq!(ais, 1);
+    }
+
+    #[tokio::test]
+    async fn prune_removes_disconnected() {
+        let thresholds = PresenceThresholds {
+            idle_secs: 1,
+            disconnect_secs: 2,
+        };
+        let registry = OperatorRegistry::with_thresholds(thresholds);
+        let mut stale = OperatorSession::new(
+            "Dave".to_string(),
+            SessionKind::Human,
+            SessionRole::Operator,
+            None,
+        );
+        stale.last_heartbeat = (Utc::now() - chrono::Duration::seconds(10)).to_rfc3339();
+        registry.add(stale).await;
+
+        let fresh = OperatorSession::new(
+            "Eve".to_string(),
+            SessionKind::Human,
+            SessionRole::Operator,
+            None,
+        );
+        registry.add(fresh).await;
+
+        assert_eq!(registry.len().await, 2);
+        let pruned = registry.prune_stale().await;
+        assert_eq!(pruned, 1);
+        assert_eq!(registry.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn list_returns_all_sessions() {
+        let registry = OperatorRegistry::new();
+        for i in 0..3 {
+            registry
+                .add(OperatorSession::new(
+                    format!("User{i}"),
+                    SessionKind::Human,
+                    SessionRole::Operator,
+                    None,
+                ))
+                .await;
+        }
+        let sessions = registry.list().await;
+        assert_eq!(sessions.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn list_active_excludes_disconnected() {
+        let thresholds = PresenceThresholds {
+            idle_secs: 1,
+            disconnect_secs: 2,
+        };
+        let registry = OperatorRegistry::with_thresholds(thresholds);
+        let mut stale = OperatorSession::new(
+            "Stale".to_string(),
+            SessionKind::Human,
+            SessionRole::Operator,
+            None,
+        );
+        stale.last_heartbeat = (Utc::now() - chrono::Duration::seconds(10)).to_rfc3339();
+        registry.add(stale).await;
+
+        registry
+            .add(OperatorSession::new(
+                "Fresh".to_string(),
+                SessionKind::Human,
+                SessionRole::Operator,
+                None,
+            ))
+            .await;
+
+        let active = registry.list_active().await;
+        assert_eq!(active.len(), 1);
+        assert_eq!(active[0].display_name, "Fresh");
+    }
+}

--- a/crates/helix-operator/src/session.rs
+++ b/crates/helix-operator/src/session.rs
@@ -1,0 +1,293 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! CoPilot sessions: participants (human or AI) connected to a shared desk.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// The kind of participant operating the desk.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionKind {
+    /// A human operator.
+    Human,
+    /// An AI copilot (the LLM desk operator).
+    Ai,
+}
+
+/// The role assigned to a session — controls what actions they can take.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionRole {
+    /// Can observe the desk and read all data, but cannot take actions
+    /// or confirm proposals.
+    Viewer,
+    /// Can take intelligence actions and confirm/deny AI proposals.
+    Operator,
+    /// Full control — can change operator config, start/stop the loop,
+    /// and manage other sessions.
+    Admin,
+}
+
+impl Default for SessionRole {
+    fn default() -> Self {
+        Self::Operator
+    }
+}
+
+impl SessionRole {
+    /// Whether this role can confirm or deny pending AI proposals.
+    pub fn can_confirm(&self) -> bool {
+        matches!(self, Self::Operator | Self::Admin)
+    }
+
+    /// Whether this role can change operator configuration.
+    pub fn can_configure(&self) -> bool {
+        matches!(self, Self::Admin)
+    }
+
+    /// Whether this role can start/stop the operator loop.
+    pub fn can_control_loop(&self) -> bool {
+        matches!(self, Self::Admin)
+    }
+
+    /// Whether this role can manage (remove) other sessions.
+    pub fn can_manage_sessions(&self) -> bool {
+        matches!(self, Self::Admin)
+    }
+}
+
+/// The presence status of a session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    /// Actively interacting (recent heartbeat).
+    Active,
+    /// Connected but no recent activity (idle threshold exceeded).
+    Idle,
+    /// Heartbeat timeout exceeded — will be pruned.
+    Disconnected,
+}
+
+impl Default for SessionStatus {
+    fn default() -> Self {
+        Self::Active
+    }
+}
+
+/// A participant in CoPilot mode — a human or AI connected to the shared desk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OperatorSession {
+    /// Unique session identifier.
+    pub id: String,
+    /// Human-readable display name.
+    pub display_name: String,
+    /// Whether this is a human or AI participant.
+    pub kind: SessionKind,
+    /// Permission level.
+    pub role: SessionRole,
+    /// Current presence status.
+    pub status: SessionStatus,
+    /// When the session was created (ISO-8601).
+    pub joined_at: String,
+    /// Timestamp of the last heartbeat (ISO-8601).
+    pub last_heartbeat: String,
+    /// Optional location/affiliation string (e.g. "Tokyo", "Desk Alpha").
+    pub location: Option<String>,
+}
+
+impl OperatorSession {
+    /// Creates a new session with the given parameters.
+    pub fn new(
+        display_name: String,
+        kind: SessionKind,
+        role: SessionRole,
+        location: Option<String>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: format!("sess-{}", uuid::Uuid::new_v4()),
+            display_name,
+            kind,
+            role,
+            status: SessionStatus::Active,
+            joined_at: now.to_rfc3339(),
+            last_heartbeat: now.to_rfc3339(),
+            location,
+        }
+    }
+
+    /// Updates the heartbeat timestamp to now.
+    pub fn heartbeat(&mut self) {
+        self.last_heartbeat = Utc::now().to_rfc3339();
+        self.status = SessionStatus::Active;
+    }
+
+    /// Computes the current status based on heartbeat age.
+    pub fn compute_status(&self, now: DateTime<Utc>, idle_secs: i64, disconnect_secs: i64) -> SessionStatus {
+        let last = DateTime::parse_from_rfc3339(&self.last_heartbeat)
+            .map(|dt| dt.with_timezone(&Utc))
+            .unwrap_or(now);
+        let age = (now - last).num_seconds();
+        if age >= disconnect_secs {
+            SessionStatus::Disconnected
+        } else if age >= idle_secs {
+            SessionStatus::Idle
+        } else {
+            SessionStatus::Active
+        }
+    }
+}
+
+/// Request to create a new session.
+#[derive(Debug, Clone, Deserialize)]
+pub struct JoinSessionRequest {
+    /// Display name for this operator.
+    pub display_name: String,
+    /// Whether this is a human or AI joining.
+    #[serde(default = "default_kind")]
+    pub kind: SessionKind,
+    /// Requested role.
+    #[serde(default)]
+    pub role: SessionRole,
+    /// Optional location/affiliation.
+    pub location: Option<String>,
+}
+
+fn default_kind() -> SessionKind {
+    SessionKind::Human
+}
+
+/// Thresholds for presence detection.
+#[derive(Debug, Clone, Copy)]
+pub struct PresenceThresholds {
+    /// Seconds without heartbeat before marking as idle.
+    pub idle_secs: i64,
+    /// Seconds without heartbeat before marking as disconnected.
+    pub disconnect_secs: i64,
+}
+
+impl Default for PresenceThresholds {
+    fn default() -> Self {
+        Self {
+            idle_secs: 30,
+            disconnect_secs: 90,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_new_has_active_status() {
+        let session = OperatorSession::new(
+            "Alice".to_string(),
+            SessionKind::Human,
+            SessionRole::Operator,
+            Some("Tokyo".to_string()),
+        );
+        assert_eq!(session.status, SessionStatus::Active);
+        assert_eq!(session.kind, SessionKind::Human);
+        assert_eq!(session.role, SessionRole::Operator);
+        assert!(session.id.starts_with("sess-"));
+    }
+
+    #[test]
+    fn heartbeat_updates_timestamp_and_status() {
+        let mut session = OperatorSession::new(
+            "Bob".to_string(),
+            SessionKind::Human,
+            SessionRole::Viewer,
+            None,
+        );
+        let original = session.last_heartbeat.clone();
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        session.heartbeat();
+        assert_ne!(session.last_heartbeat, original);
+        assert_eq!(session.status, SessionStatus::Active);
+    }
+
+    #[test]
+    fn compute_status_idle_after_threshold() {
+        let session = OperatorSession::new(
+            "Carol".to_string(),
+            SessionKind::Human,
+            SessionRole::Operator,
+            None,
+        );
+        let now = Utc::now();
+        // Simulate 45 seconds since last heartbeat
+        let old_time = now - chrono::Duration::seconds(45);
+        let mut session = session;
+        session.last_heartbeat = old_time.to_rfc3339();
+        let thresholds = PresenceThresholds::default();
+        assert_eq!(
+            session.compute_status(now, thresholds.idle_secs, thresholds.disconnect_secs),
+            SessionStatus::Idle
+        );
+    }
+
+    #[test]
+    fn compute_status_disconnected_after_timeout() {
+        let mut session = OperatorSession::new(
+            "Dave".to_string(),
+            SessionKind::Ai,
+            SessionRole::Operator,
+            None,
+        );
+        let now = Utc::now();
+        let old_time = now - chrono::Duration::seconds(120);
+        session.last_heartbeat = old_time.to_rfc3339();
+        let thresholds = PresenceThresholds::default();
+        assert_eq!(
+            session.compute_status(now, thresholds.idle_secs, thresholds.disconnect_secs),
+            SessionStatus::Disconnected
+        );
+    }
+
+    #[test]
+    fn role_permissions_are_correct() {
+        assert!(SessionRole::Admin.can_confirm());
+        assert!(SessionRole::Operator.can_confirm());
+        assert!(!SessionRole::Viewer.can_confirm());
+
+        assert!(SessionRole::Admin.can_configure());
+        assert!(!SessionRole::Operator.can_configure());
+        assert!(!SessionRole::Viewer.can_configure());
+
+        assert!(SessionRole::Admin.can_control_loop());
+        assert!(!SessionRole::Operator.can_control_loop());
+
+        assert!(SessionRole::Admin.can_manage_sessions());
+        assert!(!SessionRole::Operator.can_manage_sessions());
+    }
+
+    #[test]
+    fn join_request_deserializes_with_defaults() {
+        let json = r#"{"display_name": "Eve"}"#;
+        let req: JoinSessionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.display_name, "Eve");
+        assert_eq!(req.kind, SessionKind::Human);
+        assert_eq!(req.role, SessionRole::Operator);
+    }
+
+    #[test]
+    fn join_request_with_ai_kind() {
+        let json = r#"{"display_name": "Copilot", "kind": "ai", "role": "operator"}"#;
+        let req: JoinSessionRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.kind, SessionKind::Ai);
+    }
+}

--- a/crates/helix-operator/src/tests.rs
+++ b/crates/helix-operator/src/tests.rs
@@ -242,9 +242,14 @@ async fn assist_mode_requires_confirmation() {
     }
 
     let result = loop_runner.run_cycle(&StubContext, &StubLlmProvider).await.unwrap();
-    // In assist mode without human confirmation, guard denies
-    assert_eq!(result.denied_count, 1);
+    // In assist mode without human confirmation, proposals are allowed with
+    // requires_confirmation=true and enqueued to the confirmation queue.
+    // They are not "denied" — they're pending human review.
+    assert_eq!(result.denied_count, 0);
     assert_eq!(result.allowed_count, 0);
+    assert_eq!(result.proposals.len(), 1);
+    // The proposal should be pending confirmation
+    assert!(result.decisions.iter().all(|d| d.requires_confirmation));
 }
 
 #[test]

--- a/crates/helix-operator/src/tests.rs
+++ b/crates/helix-operator/src/tests.rs
@@ -1,0 +1,311 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Integration tests for the operator crate.
+
+use crate::{
+    config::{DeskOperatorConfig, OperatorActionScope, OperatorStatus},
+    context::{DeskContextSnapshot, EvidenceSummary, WatchlistSummary, DeskContextSummary, RecentDecisionSummary},
+    loop_runner::OperatorLoop,
+    proposals::{parse_operator_proposals, proposal_to_action, OperatorAction, OperatorProposal},
+};
+use helix_core::autopilot_guard::{AutopilotGuardMachine, AutopilotMode};
+
+#[tokio::test]
+async fn full_operator_cycle_flow() {
+    let config = DeskOperatorConfig {
+        enabled: true,
+        autopilot_mode: AutopilotMode::Auto,
+        action_scope: OperatorActionScope::Intelligence,
+        loop_interval_secs: 10,
+        max_actions_per_cycle: 5,
+        max_context_items: 10,
+        model: "test-model".to_string(),
+        rules_text: "Prioritize cases about entity X.".to_string(),
+        dispatch_to_peers: false,
+        log_denied_proposals: true,
+    };
+    config.validate().unwrap();
+
+    let loop_runner = OperatorLoop::from_config(config);
+
+    // Start
+    assert_eq!(loop_runner.status().await, OperatorStatus::Stopped);
+    loop_runner.start().await.unwrap();
+    assert_eq!(loop_runner.status().await, OperatorStatus::Running);
+
+    // Run a cycle with mock provider
+    struct StubContext;
+    impl crate::context::DeskContext for StubContext {
+        fn snapshot(&self, _max: usize) -> DeskContextSnapshot {
+            DeskContextSnapshot {
+                source_count: 3,
+                watchlist_count: 2,
+                evidence_count: 10,
+                claim_count: 5,
+                open_case_count: 2,
+                escalated_case_count: 1,
+                top_cases: vec![DeskContextSummary {
+                    id: "case-1".to_string(),
+                    title: "Entity X investigation".to_string(),
+                    status: "open".to_string(),
+                    watchlist_id: "wl-1".to_string(),
+                    primary_entity: Some("entity-x".to_string()),
+                    evidence_count: 3,
+                    claim_count: 2,
+                    latest_reason: "New evidence".to_string(),
+                    priority_total: 900,
+                }],
+                recent_evidence: vec![EvidenceSummary {
+                    id: "ev-1".to_string(),
+                    title: "Test evidence".to_string(),
+                    source_id: "src-1".to_string(),
+                    trust_score: 80,
+                    observed_at: "2026-01-01T00:00:00Z".to_string(),
+                    entity_labels: vec!["entity-x".to_string()],
+                    tags: vec!["osint".to_string()],
+                }],
+                active_watchlists: vec![WatchlistSummary {
+                    id: "wl-1".to_string(),
+                    name: "Entity X Watch".to_string(),
+                    severity: "high".to_string(),
+                    keywords: vec!["entity-x".to_string()],
+                    enabled: true,
+                }],
+                recent_decisions: vec![RecentDecisionSummary {
+                    action_type: "log_analysis".to_string(),
+                    decision: "allowed".to_string(),
+                    denial_reason: None,
+                    rationale: "Initial assessment".to_string(),
+                    timestamp: "2026-01-01T00:00:00Z".to_string(),
+                }],
+            }
+        }
+    }
+
+    struct StubLlmProvider;
+    #[async_trait::async_trait]
+    impl helix_llm::providers::LlmProvider for StubLlmProvider {
+        fn name(&self) -> &str { "mock" }
+        async fn get_models(&self) -> Result<Vec<helix_llm::providers::ModelConfig>, helix_llm::errors::LlmError> { Ok(vec![]) }
+        async fn complete(
+            &self,
+            _req: helix_llm::providers::LlmRequest,
+        ) -> Result<helix_llm::providers::LlmResponse, helix_llm::errors::LlmError> {
+            Ok(helix_llm::providers::LlmResponse {
+                content: r#"[
+                    {"type":"log_analysis","rationale":"Entity X case is high priority","parameters":{"severity":"high","summary":"Entity X requires attention"}},
+                    {"type":"escalate_case","target_id":"case-1","rationale":"Critical evidence found"}
+                ]"#.to_string(),
+                function_call: None,
+                usage: helix_llm::providers::TokenUsage {
+                    prompt_tokens: 100,
+                    completion_tokens: 50,
+                    total_tokens: 150,
+                },
+                model: "test-model".to_string(),
+                finish_reason: helix_llm::providers::FinishReason::Stop,
+                metadata: std::collections::HashMap::new(),
+            })
+        }
+        async fn stream_complete(
+            &self,
+            _req: helix_llm::providers::LlmRequest,
+        ) -> Result<Box<dyn futures::Stream<Item = Result<String, helix_llm::errors::LlmError>> + Unpin + Send>, helix_llm::errors::LlmError> {
+            unimplemented!()
+        }
+        async fn health_check(&self) -> Result<(), helix_llm::errors::LlmError> {
+            Ok(())
+        }
+    }
+
+    let ctx = StubContext;
+    let provider = StubLlmProvider;
+    let response = loop_runner.run_cycle(&ctx, &provider).await.unwrap();
+
+    assert_eq!(response.proposals.len(), 2);
+    assert_eq!(response.allowed_count, 2);
+    assert_eq!(response.denied_count, 0);
+
+    // Activity log should have 2 entries
+    assert_eq!(loop_runner.activity_log().len().await, 2);
+
+    // Extract allowed actions
+    let actions = OperatorLoop::allowed_actions(&response);
+    assert_eq!(actions.len(), 2);
+    assert_eq!(actions[0].action_type(), "log_analysis");
+    assert_eq!(actions[1].action_type(), "escalate_case");
+
+    // Cycle count should be 1
+    assert_eq!(loop_runner.cycle_count().await, 1);
+
+    // Stop
+    loop_runner.stop().await.unwrap();
+    assert_eq!(loop_runner.status().await, OperatorStatus::Stopped);
+}
+
+#[tokio::test]
+async fn observe_only_scope_denies_all() {
+    let config = DeskOperatorConfig {
+        enabled: true,
+        autopilot_mode: AutopilotMode::Auto,
+        action_scope: OperatorActionScope::ObserveOnly,
+        ..Default::default()
+    };
+    let loop_runner = OperatorLoop::from_config(config);
+    loop_runner.start().await.unwrap();
+
+    struct StubContext;
+    impl crate::context::DeskContext for StubContext {
+        fn snapshot(&self, _max: usize) -> DeskContextSnapshot {
+            DeskContextSnapshot {
+                source_count: 0, watchlist_count: 0, evidence_count: 0,
+                claim_count: 0, open_case_count: 0, escalated_case_count: 0,
+                top_cases: vec![], recent_evidence: vec![], active_watchlists: vec![], recent_decisions: vec![],
+            }
+        }
+    }
+
+    struct StubLlmProvider;
+    #[async_trait::async_trait]
+    impl helix_llm::providers::LlmProvider for StubLlmProvider {
+        fn name(&self) -> &str { "mock" }
+        async fn get_models(&self) -> Result<Vec<helix_llm::providers::ModelConfig>, helix_llm::errors::LlmError> { Ok(vec![]) }
+        async fn complete(&self, _req: helix_llm::providers::LlmRequest) -> Result<helix_llm::providers::LlmResponse, helix_llm::errors::LlmError> {
+            Ok(helix_llm::providers::LlmResponse {
+                content: r#"[{"type":"log_analysis","rationale":"test","parameters":{"severity":"low","summary":"ok"}}]"#.to_string(),
+                function_call: None,
+                usage: helix_llm::providers::TokenUsage { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+                model: "test".to_string(),
+                finish_reason: helix_llm::providers::FinishReason::Stop,
+                metadata: std::collections::HashMap::new(),
+            })
+        }
+        async fn stream_complete(&self, _req: helix_llm::providers::LlmRequest) -> Result<Box<dyn futures::Stream<Item = Result<String, helix_llm::errors::LlmError>> + Unpin + Send>, helix_llm::errors::LlmError> { unimplemented!() }
+        async fn health_check(&self) -> Result<(), helix_llm::errors::LlmError> { Ok(()) }
+    }
+
+    let result = loop_runner.run_cycle(&StubContext, &StubLlmProvider).await.unwrap();
+    assert_eq!(result.denied_count, 1);
+    assert_eq!(result.allowed_count, 0);
+    assert_eq!(result.decisions[0].denial_reason.as_deref(), Some("out_of_scope"));
+}
+
+#[tokio::test]
+async fn assist_mode_requires_confirmation() {
+    let config = DeskOperatorConfig {
+        enabled: true,
+        autopilot_mode: AutopilotMode::Assist,
+        ..Default::default()
+    };
+    let loop_runner = OperatorLoop::from_config(config);
+    loop_runner.start().await.unwrap();
+
+    struct StubContext;
+    impl crate::context::DeskContext for StubContext {
+        fn snapshot(&self, _max: usize) -> DeskContextSnapshot {
+            DeskContextSnapshot {
+                source_count: 0, watchlist_count: 0, evidence_count: 0,
+                claim_count: 0, open_case_count: 0, escalated_case_count: 0,
+                top_cases: vec![], recent_evidence: vec![], active_watchlists: vec![], recent_decisions: vec![],
+            }
+        }
+    }
+
+    struct StubLlmProvider;
+    #[async_trait::async_trait]
+    impl helix_llm::providers::LlmProvider for StubLlmProvider {
+        fn name(&self) -> &str { "mock" }
+        async fn get_models(&self) -> Result<Vec<helix_llm::providers::ModelConfig>, helix_llm::errors::LlmError> { Ok(vec![]) }
+        async fn complete(&self, _req: helix_llm::providers::LlmRequest) -> Result<helix_llm::providers::LlmResponse, helix_llm::errors::LlmError> {
+            Ok(helix_llm::providers::LlmResponse {
+                content: r#"[{"type":"log_analysis","rationale":"test","parameters":{"severity":"low","summary":"ok"}}]"#.to_string(),
+                function_call: None,
+                usage: helix_llm::providers::TokenUsage { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+                model: "test".to_string(),
+                finish_reason: helix_llm::providers::FinishReason::Stop,
+                metadata: std::collections::HashMap::new(),
+            })
+        }
+        async fn stream_complete(&self, _req: helix_llm::providers::LlmRequest) -> Result<Box<dyn futures::Stream<Item = Result<String, helix_llm::errors::LlmError>> + Unpin + Send>, helix_llm::errors::LlmError> { unimplemented!() }
+        async fn health_check(&self) -> Result<(), helix_llm::errors::LlmError> { Ok(()) }
+    }
+
+    let result = loop_runner.run_cycle(&StubContext, &StubLlmProvider).await.unwrap();
+    // In assist mode without human confirmation, guard denies
+    assert_eq!(result.denied_count, 1);
+    assert_eq!(result.allowed_count, 0);
+}
+
+#[test]
+fn parse_proposals_with_fenced_json() {
+    let raw = "```json\n[{\"type\":\"log_analysis\",\"rationale\":\"test\"}]\n```";
+    let proposals = parse_operator_proposals(raw).unwrap();
+    assert_eq!(proposals.len(), 1);
+}
+
+#[test]
+fn parse_proposals_empty_array() {
+    let proposals = parse_operator_proposals("[]").unwrap();
+    assert!(proposals.is_empty());
+}
+
+#[test]
+fn proposal_to_action_review_claim() {
+    let proposal = OperatorProposal {
+        action_type: "review_claim".to_string(),
+        target_id: Some("claim-1".to_string()),
+        rationale: "Evidence corroborates".to_string(),
+        parameters: serde_json::json!({"status": "corroborated"}),
+    };
+    let action = proposal_to_action(&proposal).unwrap();
+    match action {
+        OperatorAction::ReviewClaim { claim_id, status, .. } => {
+            assert_eq!(claim_id, "claim-1");
+            assert_eq!(status, "corroborated");
+        }
+        _ => panic!("wrong action"),
+    }
+}
+
+#[test]
+fn proposal_to_action_open_case() {
+    let proposal = OperatorProposal {
+        action_type: "open_case".to_string(),
+        target_id: Some("ev-1".to_string()),
+        rationale: "New investigation".to_string(),
+        parameters: serde_json::json!({"title": "New Case", "watchlist_id": "wl-1"}),
+    };
+    let action = proposal_to_action(&proposal).unwrap();
+    match action {
+        OperatorAction::OpenCase { evidence_id, title, watchlist_id, .. } => {
+            assert_eq!(evidence_id, "ev-1");
+            assert_eq!(title, "New Case");
+            assert_eq!(watchlist_id, "wl-1");
+        }
+        _ => panic!("wrong action"),
+    }
+}
+
+#[tokio::test]
+async fn pause_and_resume() {
+    let loop_runner = OperatorLoop::new(
+        DeskOperatorConfig::default(),
+        AutopilotGuardMachine::default(),
+    );
+    loop_runner.start().await.unwrap();
+    loop_runner.pause().await.unwrap();
+    assert_eq!(loop_runner.status().await, OperatorStatus::Paused);
+    loop_runner.start().await.unwrap();
+    assert_eq!(loop_runner.status().await, OperatorStatus::Running);
+}

--- a/crates/helix-rule-engine/src/rules.rs
+++ b/crates/helix-rule-engine/src/rules.rs
@@ -1,0 +1,900 @@
+// Copyright 2026 DarkLightX
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Deterministic rule model and evaluation kernel for Helix automation.
+//!
+//! Rules are pure data: a condition tree over event fields plus a list of
+//! actions. Evaluation is total and deterministic. The kernel never panics on
+//! malformed input; missing fields or type mismatches simply fail the
+//! condition (fail-closed).
+
+use chrono::{DateTime, Utc};
+use helix_core::event::Event;
+use helix_core::types::RecipeId;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+/// A deterministic automation rule.
+///
+/// Rules are evaluated against incoming events. When the condition matches,
+/// each action produces a [`RecipeTriggerPlan`] that the imperative shell may
+/// execute.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Rule {
+    /// Stable unique identifier for the rule.
+    pub id: Uuid,
+    /// Human-readable name.
+    pub name: String,
+    /// Optional long-form description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Semantic version of the rule definition.
+    #[serde(default = "default_version")]
+    pub version: String,
+    /// Optional author attribution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+    /// Whether the rule is active. Disabled rules never produce plans.
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+    /// Free-form tags for grouping and filtering.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Arbitrary metadata preserved verbatim.
+    #[serde(default)]
+    pub metadata: HashMap<String, Value>,
+    /// The condition tree evaluated against an event.
+    pub condition: Condition,
+    /// Actions to take when the condition matches.
+    #[serde(default)]
+    pub actions: Vec<Action>,
+    /// Creation timestamp (set by the persistence layer).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub created_at: Option<DateTime<Utc>>,
+    /// Last update timestamp (set by the persistence layer).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<DateTime<Utc>>,
+}
+
+fn default_version() -> String {
+    "1.0.0".to_string()
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+/// A condition tree over event fields.
+///
+/// Serializes as an untagged enum so the JSON shape mirrors the field
+/// condition object (`{"field": ..., "operator": ..., "value": ...}`) or a
+/// logical combinator (`{"and": [...]}`, `{"or": [...]}`, `{"not": ...}`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Condition {
+    /// A leaf condition testing a single event field.
+    Field(Box<FieldCondition>),
+    /// Logical AND over a list of sub-conditions.
+    And(ConditionList),
+    /// Logical OR over a list of sub-conditions.
+    Or(ConditionList),
+    /// Logical NOT over a single sub-condition.
+    Not(Box<Condition>),
+}
+
+/// Wrapper for the logical combinator variants so the JSON shape is
+/// `{"and": [...]}` / `{"or": [...]}` with a single key.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConditionList {
+    /// The list of sub-conditions under the `and` key.
+    #[serde(rename = "and", default)]
+    pub and: Vec<Condition>,
+    /// The list of sub-conditions under the `or` key.
+    #[serde(rename = "or", default)]
+    pub or: Vec<Condition>,
+}
+
+/// A leaf condition testing a single event field against a value.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FieldCondition {
+    /// Dotted path into the event, e.g. `event.data.severity` or `event.source`.
+    pub field: String,
+    /// Comparison operator.
+    pub operator: Operator,
+    /// Literal comparison value. Ignored for existence/null/boolean/empty
+    /// operators.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+    /// Pull the comparison value from the event at the given path instead of
+    /// using a literal `value`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value_from_event: Option<String>,
+    /// Whether string comparisons are case-sensitive. Defaults to `true`.
+    #[serde(default = "default_case_sensitive")]
+    pub case_sensitive: bool,
+}
+
+fn default_case_sensitive() -> bool {
+    true
+}
+
+/// Comparison operators supported by [`FieldCondition`].
+///
+/// Serializes as the lowercase snake_case name (e.g. `equals`,
+/// `greater_than_or_equals`, `regex_matches`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Operator {
+    Equals,
+    NotEquals,
+    GreaterThan,
+    GreaterThanOrEquals,
+    LessThan,
+    LessThanOrEquals,
+    Contains,
+    NotContains,
+    StartsWith,
+    EndsWith,
+    RegexMatches,
+    Exists,
+    NotExists,
+    IsNull,
+    IsNotNull,
+    IsTrue,
+    IsFalse,
+    IsEmpty,
+    IsNotEmpty,
+    In,
+    NotIn,
+    TypeIs,
+}
+
+/// A parameter value for a rule action: either a literal JSON value or a
+/// reference to a path in the triggering event.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ParameterValue {
+    /// A literal JSON value.
+    Literal(Value),
+    /// Pull the value from the triggering event at the given dotted path.
+    FromEvent(String),
+}
+
+/// An action to take when a rule's condition matches.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Action {
+    /// The action type. Currently only `trigger_recipe` is supported.
+    #[serde(rename = "type")]
+    pub r#type: String,
+    /// Target recipe by id.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipe_id: Option<RecipeId>,
+    /// Target recipe by name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipe_name: Option<String>,
+    /// Parameters to pass to the recipe.
+    #[serde(default)]
+    pub parameters: HashMap<String, ParameterValue>,
+    /// Optional delay before executing the action (ISO 8601 duration).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delay: Option<String>,
+    /// What to do on failure: `log`, `retry`, or `escalate`. Defaults to `log`.
+    #[serde(default = "default_on_failure")]
+    pub on_failure: String,
+    /// Optional stable id for correlating trigger plans back to a specific
+    /// action within a rule.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action_id: Option<String>,
+}
+
+fn default_on_failure() -> String {
+    "log".to_string()
+}
+
+/// A deterministic plan to trigger a recipe, produced when a rule matches.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecipeTriggerPlan {
+    /// The id of the rule that produced this plan.
+    pub rule_id: Uuid,
+    /// The name of the rule that produced this plan.
+    pub rule_name: String,
+    /// The action id, if the source action specified one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub action_id: Option<String>,
+    /// The target recipe id, if the action specified one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipe_id: Option<RecipeId>,
+    /// The target recipe name, if the action specified one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recipe_name: Option<String>,
+    /// Resolved parameter values (literals or values pulled from the event).
+    #[serde(default)]
+    pub parameters: HashMap<String, Value>,
+}
+
+/// Evaluate a single rule's condition against an event.
+///
+/// Disabled rules never match. The evaluation is total: any error in path
+/// resolution or type coercion fails the condition (fail-closed).
+pub fn evaluate_rule(event: &Event, rule: &Rule) -> bool {
+    if !rule.enabled {
+        return false;
+    }
+    evaluate_condition(event, &rule.condition)
+}
+
+/// Evaluate a condition tree against an event.
+pub fn evaluate_condition(event: &Event, condition: &Condition) -> bool {
+    match condition {
+        Condition::Field(field) => evaluate_field(event, field),
+        Condition::And(list) => list.and.iter().all(|c| evaluate_condition(event, c)),
+        Condition::Or(list) => list.or.iter().any(|c| evaluate_condition(event, c)),
+        Condition::Not(inner) => !evaluate_condition(event, inner),
+    }
+}
+
+/// Evaluate a leaf field condition against an event.
+pub fn evaluate_field(event: &Event, cond: &FieldCondition) -> bool {
+    let actual = resolve_event_path(event, &cond.field);
+    let expected = cond
+        .value_from_event
+        .as_deref()
+        .and_then(|path| resolve_event_path(event, path))
+        .or(cond.value.clone());
+
+    match cond.operator {
+        Operator::Exists => actual.is_some(),
+        Operator::NotExists => actual.is_none(),
+        Operator::IsNull => matches!(actual.as_ref(), Some(Value::Null) | None),
+        Operator::IsNotNull => !matches!(actual.as_ref(), Some(Value::Null) | None),
+        Operator::IsTrue => actual.as_ref() == Some(&Value::Bool(true)),
+        Operator::IsFalse => actual.as_ref() == Some(&Value::Bool(false)),
+        Operator::IsEmpty => match actual.as_ref() {
+            Some(Value::String(s)) => s.is_empty(),
+            Some(Value::Array(a)) => a.is_empty(),
+            Some(Value::Object(o)) => o.is_empty(),
+            Some(Value::Null) | None => true,
+            _ => false,
+        },
+        Operator::IsNotEmpty => match actual.as_ref() {
+            Some(Value::String(s)) => !s.is_empty(),
+            Some(Value::Array(a)) => !a.is_empty(),
+            Some(Value::Object(o)) => !o.is_empty(),
+            Some(Value::Null) | None => false,
+            _ => true,
+        },
+        Operator::TypeIs => match (actual.as_ref(), expected.as_ref()) {
+            (Some(actual_val), Some(expected_val)) => type_matches(actual_val, expected_val),
+            _ => false,
+        },
+        Operator::In => match (actual.as_ref(), expected.as_ref()) {
+            (Some(actual_val), Some(Value::Array(items))) => items
+                .iter()
+                .any(|item| values_equal(actual_val, item, cond.case_sensitive)),
+            _ => false,
+        },
+        Operator::NotIn => match (actual.as_ref(), expected.as_ref()) {
+            (Some(actual_val), Some(Value::Array(items))) => !items
+                .iter()
+                .any(|item| values_equal(actual_val, item, cond.case_sensitive)),
+            _ => false,
+        },
+        Operator::Equals => match (actual.as_ref(), expected.as_ref()) {
+            (Some(a), Some(b)) => values_equal(a, b, cond.case_sensitive),
+            _ => false,
+        },
+        Operator::NotEquals => match (actual.as_ref(), expected.as_ref()) {
+            (Some(a), Some(b)) => !values_equal(a, b, cond.case_sensitive),
+            _ => true,
+        },
+        Operator::GreaterThan
+        | Operator::GreaterThanOrEquals
+        | Operator::LessThan
+        | Operator::LessThanOrEquals => match (actual.as_ref(), expected.as_ref()) {
+            (Some(a), Some(b)) => compare_numbers(a, b, cond.operator),
+            _ => false,
+        },
+        Operator::Contains => match (actual.as_ref(), expected.as_ref()) {
+            (Some(Value::String(haystack)), Some(Value::String(needle))) => {
+                string_contains(haystack, needle, cond.case_sensitive)
+            }
+            (Some(Value::Array(haystack)), Some(needle)) => haystack
+                .iter()
+                .any(|item| values_equal(item, needle, cond.case_sensitive)),
+            _ => false,
+        },
+        Operator::NotContains => match (actual.as_ref(), expected.as_ref()) {
+            (Some(Value::String(haystack)), Some(Value::String(needle))) => {
+                !string_contains(haystack, needle, cond.case_sensitive)
+            }
+            (Some(Value::Array(haystack)), Some(needle)) => !haystack
+                .iter()
+                .any(|item| values_equal(item, needle, cond.case_sensitive)),
+            _ => true,
+        },
+        Operator::StartsWith => match (actual.as_ref(), expected.as_ref()) {
+            (Some(Value::String(haystack)), Some(Value::String(needle))) => {
+                string_starts_with(haystack, needle, cond.case_sensitive)
+            }
+            _ => false,
+        },
+        Operator::EndsWith => match (actual.as_ref(), expected.as_ref()) {
+            (Some(Value::String(haystack)), Some(Value::String(needle))) => {
+                string_ends_with(haystack, needle, cond.case_sensitive)
+            }
+            _ => false,
+        },
+        Operator::RegexMatches => match (actual.as_ref(), expected.as_ref()) {
+            (Some(Value::String(haystack)), Some(Value::String(pattern))) => {
+                regex_matches(haystack, pattern)
+            }
+            _ => false,
+        },
+    }
+}
+
+/// Resolve a dotted path like `event.data.severity` against an event.
+///
+/// Returns `None` if any segment is missing or the path cannot be traversed.
+/// The leading `event.` prefix is optional.
+pub fn resolve_event_path(event: &Event, path: &str) -> Option<Value> {
+    let trimmed = path.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut segments: Vec<&str> = trimmed.split('.').collect();
+    if segments.first().is_some_and(|s| *s == "event") {
+        segments.remove(0);
+    }
+
+    let Some(first) = segments.first() else {
+        return None;
+    };
+    let mut current = match *first {
+        "id" => Some(Value::String(event.id.to_string())),
+        "source" => Some(Value::String(event.source.clone())),
+        "type" => Some(Value::String(event.r#type.clone())),
+        "specversion" => Some(Value::String(event.specversion.clone())),
+        "datacontenttype" => event.datacontenttype.clone().map(Value::String),
+        "subject" => event.subject.clone().map(Value::String),
+        "time" => Some(Value::String(event.time.to_rfc3339())),
+        "correlation_id" => event.correlation_id.map(|id| Value::String(id.to_string())),
+        "causation_id" => event.causation_id.map(|id| Value::String(id.to_string())),
+        "data" => event.data.clone(),
+        other => event
+            .data
+            .as_ref()
+            .and_then(|data| data.get(other).cloned()),
+    };
+
+    for segment in segments.iter().skip(1) {
+        current = current.and_then(|value| value.get(segment).cloned());
+    }
+
+    current
+}
+
+/// Compare two JSON values for equality, with optional case-insensitivity for
+/// strings.
+fn values_equal(a: &Value, b: &Value, case_sensitive: bool) -> bool {
+    match (a, b) {
+        (Value::String(a), Value::String(b)) => {
+            if case_sensitive {
+                a == b
+            } else {
+                a.eq_ignore_ascii_case(b)
+            }
+        }
+        (Value::Number(a), Value::Number(b)) => {
+            a.as_f64().zip(b.as_f64()).is_some_and(|(x, y)| x == y)
+        }
+        _ => a == b,
+    }
+}
+
+/// Compare two JSON values as numbers with a relational operator.
+fn compare_numbers(a: &Value, b: &Value, op: Operator) -> bool {
+    let Some(a) = value_as_f64(a) else {
+        return false;
+    };
+    let Some(b) = value_as_f64(b) else {
+        return false;
+    };
+    match op {
+        Operator::GreaterThan => a > b,
+        Operator::GreaterThanOrEquals => a >= b,
+        Operator::LessThan => a < b,
+        Operator::LessThanOrEquals => a <= b,
+        _ => false,
+    }
+}
+
+/// Coerce a JSON value to an f64, supporting numbers and numeric strings.
+fn value_as_f64(value: &Value) -> Option<f64> {
+    match value {
+        Value::Number(n) => n.as_f64(),
+        Value::String(s) => s.trim().parse::<f64>().ok(),
+        Value::Bool(b) => Some(if *b { 1.0 } else { 0.0 }),
+        _ => None,
+    }
+}
+
+/// Case-aware string containment check.
+fn string_contains(haystack: &str, needle: &str, case_sensitive: bool) -> bool {
+    if case_sensitive {
+        haystack.contains(needle)
+    } else {
+        haystack
+            .to_ascii_lowercase()
+            .contains(&needle.to_ascii_lowercase())
+    }
+}
+
+/// Case-aware string prefix check.
+fn string_starts_with(haystack: &str, needle: &str, case_sensitive: bool) -> bool {
+    if case_sensitive {
+        haystack.starts_with(needle)
+    } else {
+        haystack
+            .to_ascii_lowercase()
+            .starts_with(&needle.to_ascii_lowercase())
+    }
+}
+
+/// Case-aware string suffix check.
+fn string_ends_with(haystack: &str, needle: &str, case_sensitive: bool) -> bool {
+    if case_sensitive {
+        haystack.ends_with(needle)
+    } else {
+        haystack
+            .to_ascii_lowercase()
+            .ends_with(&needle.to_ascii_lowercase())
+    }
+}
+
+/// Check whether the actual JSON value matches a named type.
+///
+/// The expected value is a string naming the type: `string`, `number`,
+/// `boolean`, `array`, `object`, `null`, `integer`.
+fn type_matches(actual: &Value, expected: &Value) -> bool {
+    let Some(type_name) = expected.as_str() else {
+        return false;
+    };
+    match type_name {
+        "string" => actual.is_string(),
+        "number" => actual.is_number(),
+        "integer" => actual.as_number().and_then(serde_json::Number::as_i64).is_some(),
+        "boolean" => actual.is_boolean(),
+        "array" => actual.is_array(),
+        "object" => actual.is_object(),
+        "null" => actual.is_null(),
+        _ => false,
+    }
+}
+
+/// Compile and match a regex pattern. Returns `false` on invalid patterns
+/// (fail-closed).
+fn regex_matches(haystack: &str, pattern: &str) -> bool {
+    match Regex::new(pattern) {
+        Ok(re) => re.is_match(haystack),
+        Err(_) => false,
+    }
+}
+
+/// Resolve a parameter value against an event.
+pub fn resolve_parameter(event: &Event, value: &ParameterValue) -> Value {
+    match value {
+        ParameterValue::Literal(v) => v.clone(),
+        ParameterValue::FromEvent(path) => {
+            resolve_event_path(event, path).unwrap_or(Value::Null)
+        }
+    }
+}
+
+/// Produce deterministic recipe trigger plans for all matching rules.
+///
+/// Rules are evaluated in order. Each matching action produces a separate
+/// plan. Disabled rules are skipped.
+pub fn plan_recipe_triggers(event: &Event, rules: &[Rule]) -> Vec<RecipeTriggerPlan> {
+    let mut plans = Vec::new();
+    for rule in rules {
+        if !rule.enabled {
+            continue;
+        }
+        if !evaluate_condition(event, &rule.condition) {
+            continue;
+        }
+        for action in &rule.actions {
+            if action.r#type != "trigger_recipe" {
+                continue;
+            }
+            let parameters = action
+                .parameters
+                .iter()
+                .map(|(key, value)| (key.clone(), resolve_parameter(event, value)))
+                .collect();
+            plans.push(RecipeTriggerPlan {
+                rule_id: rule.id,
+                rule_name: rule.name.clone(),
+                action_id: action.action_id.clone(),
+                recipe_id: action.recipe_id,
+                recipe_name: action.recipe_name.clone(),
+                parameters,
+            });
+        }
+    }
+    plans
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+    use uuid::Uuid;
+
+    fn make_event(data: Value) -> Event {
+        Event::new("intel".to_string(), "intel.case.opened".to_string(), Some(data))
+    }
+
+    fn field_condition(field: &str, operator: Operator, value: Option<Value>) -> Condition {
+        Condition::Field(Box::new(FieldCondition {
+            field: field.to_string(),
+            operator,
+            value,
+            value_from_event: None,
+            case_sensitive: true,
+        }))
+    }
+
+    fn make_rule(condition: Condition) -> Rule {
+        Rule {
+            id: Uuid::new_v4(),
+            name: "test".to_string(),
+            description: None,
+            version: "1.0.0".to_string(),
+            author: None,
+            enabled: true,
+            tags: Vec::new(),
+            metadata: HashMap::new(),
+            condition,
+            actions: Vec::new(),
+            created_at: None,
+            updated_at: None,
+        }
+    }
+
+    #[test]
+    fn evaluate_rule_returns_false_for_disabled_rule() {
+        let event = make_event(json!({ "severity": "critical" }));
+        let mut rule = make_rule(field_condition(
+            "event.data.severity",
+            Operator::Equals,
+            Some(json!("critical")),
+        ));
+        rule.enabled = false;
+        assert!(!evaluate_rule(&event, &rule));
+    }
+
+    #[test]
+    fn evaluate_rule_matches_equals_on_string() {
+        let event = make_event(json!({ "severity": "critical" }));
+        let rule = make_rule(field_condition(
+            "event.data.severity",
+            Operator::Equals,
+            Some(json!("critical")),
+        ));
+        assert!(evaluate_rule(&event, &rule));
+    }
+
+    #[test]
+    fn resolve_event_path_supports_top_level_fields() {
+        let event = make_event(json!({ "severity": "critical" }));
+        assert_eq!(
+            resolve_event_path(&event, "event.source"),
+            Some(Value::String("intel".to_string()))
+        );
+        assert_eq!(
+            resolve_event_path(&event, "event.type"),
+            Some(Value::String("intel.case.opened".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_event_path_supports_data_without_prefix() {
+        let event = make_event(json!({ "severity": "critical" }));
+        assert_eq!(
+            resolve_event_path(&event, "severity"),
+            Some(Value::String("critical".to_string()))
+        );
+    }
+
+    #[test]
+    fn resolve_event_path_returns_none_for_missing() {
+        let event = make_event(json!({ "severity": "critical" }));
+        assert_eq!(resolve_event_path(&event, "event.data.missing"), None);
+    }
+
+    #[test]
+    fn operator_exists_and_not_exists() {
+        let event = make_event(json!({ "severity": "critical" }));
+        let exists = field_condition("event.data.severity", Operator::Exists, None);
+        let missing = field_condition("event.data.missing", Operator::Exists, None);
+        assert!(evaluate_condition(&event, &exists));
+        assert!(!evaluate_condition(&event, &missing));
+
+        let not_exists = field_condition("event.data.missing", Operator::NotExists, None);
+        assert!(evaluate_condition(&event, &not_exists));
+    }
+
+    #[test]
+    fn operator_greater_than_compares_numbers() {
+        let event = make_event(json!({ "score": 75 }));
+        let gt = field_condition("event.data.score", Operator::GreaterThan, Some(json!(50)));
+        let lt = field_condition("event.data.score", Operator::LessThan, Some(json!(50)));
+        assert!(evaluate_condition(&event, &gt));
+        assert!(!evaluate_condition(&event, &lt));
+    }
+
+    #[test]
+    fn operator_greater_than_compares_numeric_strings() {
+        let event = make_event(json!({ "score": "75" }));
+        let gt = field_condition("event.data.score", Operator::GreaterThan, Some(json!(50)));
+        assert!(evaluate_condition(&event, &gt));
+    }
+
+    #[test]
+    fn operator_contains_on_string() {
+        let event = make_event(json!({ "message": "hello world" }));
+        let contains =
+            field_condition("event.data.message", Operator::Contains, Some(json!("world")));
+        assert!(evaluate_condition(&event, &contains));
+    }
+
+    #[test]
+    fn operator_contains_case_insensitive() {
+        let event = make_event(json!({ "message": "Hello World" }));
+        let cond = Condition::Field(Box::new(FieldCondition {
+            field: "event.data.message".to_string(),
+            operator: Operator::Contains,
+            value: Some(json!("world")),
+            value_from_event: None,
+            case_sensitive: false,
+        }));
+        assert!(evaluate_condition(&event, &cond));
+    }
+
+    #[test]
+    fn operator_regex_matches() {
+        let event = make_event(json!({ "email": "user@example.com" }));
+        let regex = field_condition(
+            "event.data.email",
+            Operator::RegexMatches,
+            Some(json!("^[^@]+@[^@]+$")),
+        );
+        assert!(evaluate_condition(&event, &regex));
+    }
+
+    #[test]
+    fn operator_in_array() {
+        let event = make_event(json!({ "status": "open" }));
+        let cond = field_condition(
+            "event.data.status",
+            Operator::In,
+            Some(json!(["open", "pending"])),
+        );
+        assert!(evaluate_condition(&event, &cond));
+    }
+
+    #[test]
+    fn operator_type_is() {
+        let event = make_event(json!({ "count": 42, "name": "test" }));
+        let is_number =
+            field_condition("event.data.count", Operator::TypeIs, Some(json!("number")));
+        let is_string =
+            field_condition("event.data.count", Operator::TypeIs, Some(json!("string")));
+        assert!(evaluate_condition(&event, &is_number));
+        assert!(!evaluate_condition(&event, &is_string));
+    }
+
+    #[test]
+    fn logical_and_or_not() {
+        let event = make_event(json!({ "severity": "critical", "source": "intel" }));
+
+        let and = Condition::And(ConditionList {
+            and: vec![
+                field_condition("event.data.severity", Operator::Equals, Some(json!("critical"))),
+                field_condition("event.data.source", Operator::Equals, Some(json!("intel"))),
+            ],
+            or: Vec::new(),
+        });
+        assert!(evaluate_condition(&event, &and));
+
+        let or = Condition::Or(ConditionList {
+            and: Vec::new(),
+            or: vec![
+                field_condition("event.data.severity", Operator::Equals, Some(json!("low"))),
+                field_condition("event.data.source", Operator::Equals, Some(json!("intel"))),
+            ],
+        });
+        assert!(evaluate_condition(&event, &or));
+
+        let not = Condition::Not(Box::new(field_condition(
+            "event.data.severity",
+            Operator::Equals,
+            Some(json!("low")),
+        )));
+        assert!(evaluate_condition(&event, &not));
+    }
+
+    #[test]
+    fn plan_recipe_triggers_produces_plans_for_matching_rules() {
+        let recipe_id: RecipeId =
+            Uuid::parse_str("30000000-0000-0000-0000-000000000001").unwrap();
+        let event = make_event(json!({ "severity": "critical", "case_id": "case_42" }));
+
+        let mut parameters = HashMap::new();
+        parameters.insert(
+            "case_id".to_string(),
+            ParameterValue::FromEvent("event.data.case_id".to_string()),
+        );
+        parameters.insert(
+            "mode".to_string(),
+            ParameterValue::Literal(json!("prepare_brief")),
+        );
+
+        let mut rule = make_rule(field_condition(
+            "event.data.severity",
+            Operator::Equals,
+            Some(json!("critical")),
+        ));
+        rule.actions = vec![Action {
+            r#type: "trigger_recipe".to_string(),
+            recipe_id: Some(recipe_id),
+            recipe_name: None,
+            parameters,
+            delay: None,
+            on_failure: "log".to_string(),
+            action_id: None,
+        }];
+
+        let plans = plan_recipe_triggers(&event, &[rule]);
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].recipe_id, Some(recipe_id));
+        assert_eq!(plans[0].parameters.get("case_id"), Some(&json!("case_42")));
+        assert_eq!(plans[0].parameters.get("mode"), Some(&json!("prepare_brief")));
+    }
+
+    #[test]
+    fn rule_deserializes_from_compact_json() {
+        let json = serde_json::json!({
+            "id": "50000000-0000-0000-0000-000000000001",
+            "name": "Critical case automation",
+            "condition": {
+                "field": "event.data.severity",
+                "operator": "equals",
+                "value": "critical"
+            },
+            "actions": [
+                {
+                    "type": "trigger_recipe",
+                    "recipe_id": "50000000-0000-0000-0000-000000000002",
+                    "parameters": {
+                        "case_id": { "from_event": "event.data.case_id" },
+                        "mode": { "literal": "prepare_brief" }
+                    }
+                }
+            ]
+        });
+        let rule: Rule = serde_json::from_value(json).unwrap();
+        assert_eq!(rule.name, "Critical case automation");
+        assert_eq!(rule.version, "1.0.0");
+        assert!(rule.enabled);
+        assert_eq!(rule.actions.len(), 1);
+        assert_eq!(rule.actions[0].on_failure, "log");
+    }
+
+    #[test]
+    fn rule_serializes_and_round_trips() {
+        let rule = make_rule(field_condition(
+            "event.data.severity",
+            Operator::Equals,
+            Some(json!("critical")),
+        ));
+        let serialized = serde_json::to_string(&rule).unwrap();
+        let deserialized: Rule = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.id, rule.id);
+        assert_eq!(deserialized.name, rule.name);
+    }
+
+    #[test]
+    fn logical_condition_deserializes_from_json() {
+        let json = serde_json::json!({
+            "and": [
+                {
+                    "field": "event.data.severity",
+                    "operator": "equals",
+                    "value": "critical"
+                },
+                {
+                    "or": [
+                        {
+                            "field": "event.data.source",
+                            "operator": "equals",
+                            "value": "intel"
+                        },
+                        {
+                            "field": "event.data.source",
+                            "operator": "equals",
+                            "value": "osint"
+                        }
+                    ]
+                }
+            ]
+        });
+        let condition: Condition = serde_json::from_value(json).unwrap();
+        let event = make_event(json!({ "severity": "critical", "source": "osint" }));
+        assert!(evaluate_condition(&event, &condition));
+    }
+
+    #[test]
+    fn value_from_event_resolves_dynamically() {
+        let event = make_event(json!({ "severity": "critical", "expected": "critical" }));
+        let cond = Condition::Field(Box::new(FieldCondition {
+            field: "event.data.severity".to_string(),
+            operator: Operator::Equals,
+            value: None,
+            value_from_event: Some("event.data.expected".to_string()),
+            case_sensitive: true,
+        }));
+        assert!(evaluate_condition(&event, &cond));
+    }
+
+    #[test]
+    fn operator_is_null_and_is_not_null() {
+        let event = make_event(json!({ "present": "value", "absent": null }));
+        let is_null = field_condition("event.data.absent", Operator::IsNull, None);
+        let is_not_null = field_condition("event.data.present", Operator::IsNotNull, None);
+        assert!(evaluate_condition(&event, &is_null));
+        assert!(evaluate_condition(&event, &is_not_null));
+    }
+
+    #[test]
+    fn operator_is_empty_and_is_not_empty() {
+        let event = make_event(json!({ "empty_str": "", "items": [1, 2] }));
+        let is_empty = field_condition("event.data.empty_str", Operator::IsEmpty, None);
+        let is_not_empty = field_condition("event.data.items", Operator::IsNotEmpty, None);
+        assert!(evaluate_condition(&event, &is_empty));
+        assert!(evaluate_condition(&event, &is_not_empty));
+    }
+
+    #[test]
+    fn operator_starts_with_and_ends_with() {
+        let event = make_event(json!({ "path": "/api/v1/cases" }));
+        let starts = field_condition("event.data.path", Operator::StartsWith, Some(json!("/api")));
+        let ends = field_condition("event.data.path", Operator::EndsWith, Some(json!("cases")));
+        assert!(evaluate_condition(&event, &starts));
+        assert!(evaluate_condition(&event, &ends));
+    }
+
+    #[test]
+    fn invalid_regex_fails_closed() {
+        let event = make_event(json!({ "value": "test" }));
+        let cond = field_condition("event.data.value", Operator::RegexMatches, Some(json!("(")));
+        assert!(!evaluate_condition(&event, &cond));
+    }
+}

--- a/scripts/install_helix.ps1
+++ b/scripts/install_helix.ps1
@@ -10,7 +10,10 @@ if (-not [Environment]::Is64BitOperatingSystem) {
   throw "Only 64-bit Windows release assets are currently published."
 }
 
-$asset = "helix-api-windows-x64.tar.gz"
+$osArch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+$arch = if ($osArch -eq "Arm64") { "arm64" } else { "x64" }
+
+$asset = "helix-api-windows-$arch.tar.gz"
 if ($Version -eq "latest") {
   $url = "https://github.com/$Repo/releases/latest/download/$asset"
 } else {

--- a/ui/src/components/Badge.tsx
+++ b/ui/src/components/Badge.tsx
@@ -1,0 +1,41 @@
+type BadgeTone = "default" | "ok" | "warn" | "danger" | "info" | "neutral" | "accent";
+
+const toneClass: Record<BadgeTone, string> = {
+  default: "hx-badge--default",
+  ok: "hx-badge--ok",
+  warn: "hx-badge--warn",
+  danger: "hx-badge--danger",
+  info: "hx-badge--info",
+  neutral: "hx-badge--neutral",
+  accent: "hx-badge--default",
+};
+
+type BadgeProps = {
+  tone?: BadgeTone;
+  children: React.ReactNode;
+  title?: string;
+};
+
+export function Badge({ tone = "default", children, title }: BadgeProps) {
+  return (
+    <span className={`hx-badge ${toneClass[tone]}`} title={title}>
+      {children}
+    </span>
+  );
+}
+
+type TagProps = {
+  children: React.ReactNode;
+};
+
+export function Tag({ children }: TagProps) {
+  return <span className="hx-tag">{children}</span>;
+}
+
+export function severityTone(severity: string): BadgeTone {
+  const s = severity.toLowerCase();
+  if (s === "critical" || s === "high") return "danger";
+  if (s === "medium") return "warn";
+  if (s === "low") return "ok";
+  return "neutral";
+}

--- a/ui/src/components/Button.tsx
+++ b/ui/src/components/Button.tsx
@@ -1,0 +1,28 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+
+type Variant = "primary" | "secondary" | "ghost" | "danger";
+
+const variantClass: Record<Variant, string> = {
+  primary: "hx-btn--primary",
+  secondary: "hx-btn--secondary",
+  ghost: "hx-btn--ghost",
+  danger: "hx-btn--danger",
+};
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: Variant;
+  children: ReactNode;
+};
+
+export function Button({
+  variant = "primary",
+  children,
+  className = "",
+  ...rest
+}: ButtonProps) {
+  return (
+    <button className={`hx-btn ${variantClass[variant]} ${className}`} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/ui/src/components/CodeBlock.tsx
+++ b/ui/src/components/CodeBlock.tsx
@@ -1,0 +1,16 @@
+type CodeBlockProps = {
+  children: string;
+  maxHeight?: string;
+  label?: string;
+};
+
+export function CodeBlock({ children, maxHeight = "320px", label }: CodeBlockProps) {
+  return (
+    <div className="hx-code-block">
+      {label && <span className="hx-code-label">{label}</span>}
+      <pre className="hx-code-pre" style={{ maxHeight }}>
+        {children}
+      </pre>
+    </div>
+  );
+}

--- a/ui/src/components/DataTable.tsx
+++ b/ui/src/components/DataTable.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+type Column<T> = {
+  key: string;
+  header: string;
+  render: (row: T) => ReactNode;
+  width?: string;
+};
+
+type DataTableProps<T> = {
+  columns: Column<T>[];
+  rows: T[];
+  rowKey: (row: T) => string;
+  emptyMessage?: string;
+  minWidth?: string;
+};
+
+export function DataTable<T>({
+  columns,
+  rows,
+  rowKey,
+  emptyMessage = "No data available",
+  minWidth = "720px",
+}: DataTableProps<T>) {
+  if (rows.length === 0) {
+    return (
+      <div className="hx-table-empty">
+        <p>{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="hx-table-wrap">
+      <table className="hx-table" style={{ minWidth }}>
+        <thead>
+          <tr>
+            {columns.map((col) => (
+              <th key={col.key} style={col.width ? { width: col.width } : undefined}>
+                {col.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={rowKey(row)}>
+              {columns.map((col) => (
+                <td key={col.key}>{col.render(row)}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ui/src/components/FormField.tsx
+++ b/ui/src/components/FormField.tsx
@@ -1,0 +1,71 @@
+import type { InputHTMLAttributes, SelectHTMLAttributes, TextareaHTMLAttributes, ReactNode } from "react";
+
+type FieldWrapperProps = {
+  label: string;
+  full?: boolean;
+  hint?: string;
+  children: ReactNode;
+};
+
+export function FormField({ label, full = false, hint, children }: FieldWrapperProps) {
+  return (
+    <label className={`hx-field ${full ? "hx-field--full" : ""}`}>
+      <span className="hx-field-label">{label}</span>
+      {children}
+      {hint && <span className="hx-field-hint">{hint}</span>}
+    </label>
+  );
+}
+
+type InputProps = InputHTMLAttributes<HTMLInputElement>;
+
+export function Input(props: InputProps) {
+  return <input className="hx-input" {...props} />;
+}
+
+type SelectProps = SelectHTMLAttributes<HTMLSelectElement> & {
+  children: ReactNode;
+};
+
+export function Select({ children, ...rest }: SelectProps) {
+  return (
+    <select className="hx-select" {...rest}>
+      {children}
+    </select>
+  );
+}
+
+type TextareaProps = TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+export function Textarea(props: TextareaProps) {
+  return <textarea className="hx-textarea" {...props} />;
+}
+
+type CheckboxFieldProps = {
+  label: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  full?: boolean;
+};
+
+export function CheckboxField({ label, checked, onChange, full = false }: CheckboxFieldProps) {
+  return (
+    <label className={`hx-field hx-field--row ${full ? "hx-field--full" : ""}`}>
+      <input
+        type="checkbox"
+        className="hx-checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      <span className="hx-field-label">{label}</span>
+    </label>
+  );
+}
+
+type FormGridProps = {
+  children: ReactNode;
+};
+
+export function FormGrid({ children }: FormGridProps) {
+  return <div className="hx-form-grid">{children}</div>;
+}

--- a/ui/src/components/Panel.tsx
+++ b/ui/src/components/Panel.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+type PanelSpan = 3 | 4 | 5 | 6 | 7 | 8 | 12;
+
+const spanClass: Record<PanelSpan, string> = {
+  3: "col-span-3",
+  4: "col-span-4",
+  5: "col-span-5",
+  6: "col-span-6",
+  7: "col-span-7",
+  8: "col-span-8",
+  12: "col-span-12",
+};
+
+type PanelProps = {
+  title?: string;
+  eyebrow?: string;
+  span?: PanelSpan;
+  hero?: boolean;
+  actions?: ReactNode;
+  children: ReactNode;
+  className?: string;
+};
+
+export function Panel({
+  title,
+  eyebrow,
+  span = 6,
+  hero = false,
+  actions,
+  children,
+  className = "",
+}: PanelProps) {
+  const classes = [
+    "hx-panel",
+    spanClass[span],
+    hero ? "hx-panel-hero" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <article className={classes}>
+      {(title || eyebrow || actions) && (
+        <header className="hx-panel-header">
+          <div className="hx-panel-heading">
+            {eyebrow && <span className="hx-eyebrow">{eyebrow}</span>}
+            {title && <h3 className="hx-panel-title">{title}</h3>}
+          </div>
+          {actions && <div className="hx-panel-actions">{actions}</div>}
+        </header>
+      )}
+      <div className="hx-panel-body">{children}</div>
+    </article>
+  );
+}

--- a/ui/src/components/StatCard.tsx
+++ b/ui/src/components/StatCard.tsx
@@ -1,0 +1,35 @@
+type Tone = "default" | "accent" | "ok" | "warn" | "danger" | "info";
+
+const toneClass: Record<Tone, string> = {
+  default: "",
+  accent: "hx-stat--accent",
+  ok: "hx-stat--ok",
+  warn: "hx-stat--warn",
+  danger: "hx-stat--danger",
+  info: "hx-stat--info",
+};
+
+type StatCardProps = {
+  label: string;
+  value: string | number;
+  sublabel?: string;
+  tone?: Tone;
+};
+
+export function StatCard({ label, value, sublabel, tone = "default" }: StatCardProps) {
+  return (
+    <div className={`hx-stat ${toneClass[tone]}`}>
+      <span className="hx-stat-label">{label}</span>
+      <span className="hx-stat-value">{value}</span>
+      {sublabel && <span className="hx-stat-sub">{sublabel}</span>}
+    </div>
+  );
+}
+
+type StatGridProps = {
+  children: React.ReactNode;
+};
+
+export function StatGrid({ children }: StatGridProps) {
+  return <div className="hx-stat-grid">{children}</div>;
+}

--- a/ui/src/components/StateMessage.tsx
+++ b/ui/src/components/StateMessage.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from "react";
+
+type StateMessageProps = {
+  icon?: string;
+  title: string;
+  description?: string;
+  children?: ReactNode;
+};
+
+export function EmptyState({ icon = "empty", title, description, children }: StateMessageProps) {
+  return (
+    <div className="hx-state hx-state--empty">
+      <span className="hx-state-icon" aria-hidden>{icon}</span>
+      <p className="hx-state-title">{title}</p>
+      {description && <p className="hx-state-desc">{description}</p>}
+      {children}
+    </div>
+  );
+}
+
+export function LoadingState({ title = "Loading...", description }: { title?: string; description?: string }) {
+  return (
+    <div className="hx-state hx-state--loading">
+      <span className="hx-spinner" aria-hidden />
+      <p className="hx-state-title">{title}</p>
+      {description && <p className="hx-state-desc">{description}</p>}
+    </div>
+  );
+}
+
+export function ErrorState({ title = "Something went wrong", description, children }: StateMessageProps) {
+  return (
+    <div className="hx-state hx-state--error">
+      <span className="hx-state-icon" aria-hidden>!</span>
+      <p className="hx-state-title">{title}</p>
+      {description && <p className="hx-state-desc">{description}</p>}
+      {children}
+    </div>
+  );
+}
+
+type StatusLineProps = {
+  children: ReactNode;
+  tone?: "default" | "ok" | "warn" | "danger";
+};
+
+export function StatusLine({ children, tone = "default" }: StatusLineProps) {
+  const toneClass =
+    tone === "ok"
+      ? "hx-status--ok"
+      : tone === "warn"
+        ? "hx-status--warn"
+        : tone === "danger"
+          ? "hx-status--danger"
+          : "";
+  return <p className={`hx-status-line ${toneClass}`.trim()}>{children}</p>;
+}

--- a/ui/src/components/index.ts
+++ b/ui/src/components/index.ts
@@ -1,0 +1,8 @@
+export { Panel } from "./Panel";
+export { StatCard, StatGrid } from "./StatCard";
+export { Badge, Tag, severityTone } from "./Badge";
+export { Button } from "./Button";
+export { FormField, Input, Select, Textarea, CheckboxField, FormGrid } from "./FormField";
+export { EmptyState, LoadingState, ErrorState, StatusLine } from "./StateMessage";
+export { DataTable } from "./DataTable";
+export { CodeBlock } from "./CodeBlock";

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1564,3 +1564,147 @@ export async function manualBroadcast(
     { retry: false }
   );
 }
+
+// ---- Operator API ----
+
+export type OperatorStatus = "stopped" | "running" | "paused";
+export type OperatorActionScope =
+  | "observe_only"
+  | "intelligence"
+  | "policy"
+  | "full";
+
+export type DeskOperatorConfig = {
+  enabled: boolean;
+  autopilot_mode: AutopilotMode;
+  action_scope: OperatorActionScope;
+  loop_interval_secs: number;
+  max_actions_per_cycle: number;
+  max_context_items: number;
+  model: string;
+  rules_text: string;
+  dispatch_to_peers: boolean;
+  log_denied_proposals: boolean;
+};
+
+export type OperatorStatusResponse = {
+  status: OperatorStatus;
+  enabled: boolean;
+  autopilot_mode: AutopilotMode;
+  action_scope: OperatorActionScope;
+  loop_interval_secs: number;
+  model: string;
+  cycle_count: number;
+  activity_log_count: number;
+};
+
+export type OperatorConfigResponse = {
+  config: DeskOperatorConfig;
+};
+
+export type UpdateOperatorConfigRequest = {
+  enabled?: boolean;
+  autopilot_mode?: AutopilotMode;
+  action_scope?: OperatorActionScope;
+  loop_interval_secs?: number;
+  max_actions_per_cycle?: number;
+  max_context_items?: number;
+  model?: string;
+  rules_text?: string;
+  dispatch_to_peers?: boolean;
+  log_denied_proposals?: boolean;
+};
+
+export type OperatorControlResponse = {
+  status: OperatorStatus;
+};
+
+export type OperatorActivityEntry = {
+  id: string;
+  cycle: number;
+  action_type: string;
+  rationale: string;
+  allowed: boolean;
+  denial_reason: string | null;
+  requires_confirmation: boolean;
+  timestamp: string;
+};
+
+export type OperatorActivityResponse = {
+  entries: OperatorActivityEntry[];
+};
+
+export async function fetchOperatorStatus(): Promise<OperatorStatusResponse> {
+  return requestJson<OperatorStatusResponse>(
+    API_BASE,
+    "/api/v1/operator/status",
+    { method: "GET" },
+    { retry: true }
+  );
+}
+
+export async function fetchOperatorConfig(): Promise<DeskOperatorConfig> {
+  const payload = await requestJson<OperatorConfigResponse>(
+    API_BASE,
+    "/api/v1/operator/config",
+    { method: "GET" },
+    { retry: true }
+  );
+  return payload.config;
+}
+
+export async function updateOperatorConfig(
+  request: UpdateOperatorConfigRequest
+): Promise<DeskOperatorConfig> {
+  const payload = await requestJson<OperatorConfigResponse>(
+    API_BASE,
+    "/api/v1/operator/config",
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    },
+    { retry: false }
+  );
+  return payload.config;
+}
+
+export async function startOperator(): Promise<OperatorControlResponse> {
+  return requestJson<OperatorControlResponse>(
+    API_BASE,
+    "/api/v1/operator/start",
+    { method: "POST" },
+    { retry: false }
+  );
+}
+
+export async function stopOperator(): Promise<OperatorControlResponse> {
+  return requestJson<OperatorControlResponse>(
+    API_BASE,
+    "/api/v1/operator/stop",
+    { method: "POST" },
+    { retry: false }
+  );
+}
+
+export async function pauseOperator(): Promise<OperatorControlResponse> {
+  return requestJson<OperatorControlResponse>(
+    API_BASE,
+    "/api/v1/operator/pause",
+    { method: "POST" },
+    { retry: false }
+  );
+}
+
+export async function fetchOperatorActivity(
+  limit?: number
+): Promise<OperatorActivityEntry[]> {
+  const query = limit ? `?limit=${limit}` : "";
+  const payload = await requestJson<OperatorActivityResponse>(
+    API_BASE,
+    `/api/v1/operator/activity${query}`,
+    { method: "GET" },
+    { retry: true }
+  );
+  return payload.entries;
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1401,3 +1401,166 @@ export async function deleteCredential(
     { retry: false }
   );
 }
+
+// --- Federation ---
+
+export type FederationEventKind =
+  | "case_escalated"
+  | "case_opened"
+  | "watchlist_hit"
+  | "evidence_ingested"
+  | "claim_reviewed"
+  | "autopilot_proposal"
+  | "manual_broadcast";
+
+export type DispatchStatus = "delivered" | "failed" | "unreachable";
+
+export type PeerDesk = {
+  id: string;
+  name: string;
+  endpoint_url: string;
+  auth_token: string;
+  trust_score: number;
+  enabled: boolean;
+  tags: string[];
+  created_at: string;
+  updated_at: string;
+};
+
+export type FederationStatus = {
+  desk_id: string;
+  peer_count: number;
+  enabled_peer_count: number;
+  total_dispatches: number;
+  successful_dispatches: number;
+  failed_dispatches: number;
+  federation_enabled: boolean;
+};
+
+export type FederationOverview = {
+  desk_id: string;
+  peers: PeerDesk[];
+  status: FederationStatus;
+};
+
+export type DispatchLogEntry = {
+  id: string;
+  event_id: string;
+  peer_id: string;
+  peer_endpoint: string;
+  event_kind: string;
+  event_title: string;
+  status: DispatchStatus;
+  http_status: number | null;
+  error_message: string | null;
+  latency_ms: number;
+  dispatched_at: string;
+};
+
+export type DispatchLogResponse = {
+  entries: DispatchLogEntry[];
+};
+
+export type PeerListResponse = {
+  peers: PeerDesk[];
+};
+
+export type UpsertPeerRequest = {
+  id: string;
+  name: string;
+  endpoint_url: string;
+  auth_token: string;
+  trust_score: number;
+  enabled: boolean;
+  tags: string[];
+};
+
+export type ManualBroadcastRequest = {
+  title: string;
+  summary: string;
+  content: string;
+  url?: string | null;
+  entity_labels?: string[];
+  tags?: string[];
+};
+
+export type ManualBroadcastResponse = {
+  event_id: string;
+  dispatch_count: number;
+  results: DispatchLogEntry[];
+};
+
+export type FederationReceiveResponse = {
+  accepted: boolean;
+  evidence_id: string | null;
+  message: string;
+};
+
+export async function fetchFederationOverview(): Promise<FederationOverview> {
+  return requestJson<FederationOverview>(
+    API_BASE,
+    "/api/v1/federation/overview",
+    { method: "GET" },
+    { retry: true }
+  );
+}
+
+export async function fetchPeers(): Promise<PeerDesk[]> {
+  const payload = await requestJson<PeerListResponse>(
+    API_BASE,
+    "/api/v1/federation/peers",
+    { method: "GET" },
+    { retry: true }
+  );
+  return payload.peers;
+}
+
+export async function upsertPeer(request: UpsertPeerRequest): Promise<PeerDesk> {
+  const payload = await requestJson<{ peer: PeerDesk }>(
+    API_BASE,
+    "/api/v1/federation/peers",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    },
+    { retry: false }
+  );
+  return payload.peer;
+}
+
+export async function deletePeer(peerId: string): Promise<PeerDesk> {
+  const payload = await requestJson<{ peer: PeerDesk }>(
+    API_BASE,
+    `/api/v1/federation/peers/${encodeURIComponent(peerId)}`,
+    { method: "DELETE" },
+    { retry: false }
+  );
+  return payload.peer;
+}
+
+export async function fetchDispatchLog(limit?: number): Promise<DispatchLogEntry[]> {
+  const query = limit ? `?limit=${limit}` : "";
+  const payload = await requestJson<DispatchLogResponse>(
+    API_BASE,
+    `/api/v1/federation/dispatch-log${query}`,
+    { method: "GET" },
+    { retry: true }
+  );
+  return payload.entries;
+}
+
+export async function manualBroadcast(
+  request: ManualBroadcastRequest
+): Promise<ManualBroadcastResponse> {
+  return requestJson<ManualBroadcastResponse>(
+    API_BASE,
+    "/api/v1/federation/broadcast",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    },
+    { retry: false }
+  );
+}

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -1708,3 +1708,169 @@ export async function fetchOperatorActivity(
   );
   return payload.entries;
 }
+
+// ---- CoPilot mode API ----
+
+export type SessionKind = "human" | "ai";
+export type SessionRole = "viewer" | "operator" | "admin";
+export type SessionStatus = "active" | "idle" | "disconnected";
+
+export type OperatorSession = {
+  id: string;
+  display_name: string;
+  kind: SessionKind;
+  role: SessionRole;
+  status: SessionStatus;
+  joined_at: string;
+  last_heartbeat: string;
+  location: string | null;
+};
+
+export type JoinSessionRequest = {
+  display_name: string;
+  kind?: SessionKind;
+  role?: SessionRole;
+  location?: string;
+};
+
+export type JoinSessionResponse = {
+  session: OperatorSession;
+};
+
+export type SessionListResponse = {
+  sessions: OperatorSession[];
+  human_count: number;
+  ai_count: number;
+};
+
+export type ConfirmationStatus = "pending" | "confirmed" | "denied" | "expired";
+
+export type OperatorProposal = {
+  type: string;
+  target_id: string | null;
+  rationale: string;
+  parameters: unknown;
+};
+
+export type ConfirmationRequest = {
+  id: string;
+  cycle: number;
+  proposal: OperatorProposal;
+  rationale: string;
+  requested_at: string;
+  status: ConfirmationStatus;
+  resolved_by: string | null;
+  resolved_by_name: string | null;
+  resolved_at: string | null;
+  denial_reason: string | null;
+};
+
+export type ConfirmationListResponse = {
+  pending: ConfirmationRequest[];
+  recent: ConfirmationRequest[];
+};
+
+export type ResolveConfirmationRequest = {
+  session_id: string;
+  denial_reason?: string;
+};
+
+export type ResolveConfirmationResponse = {
+  request: ConfirmationRequest;
+};
+
+export async function joinSession(
+  request: JoinSessionRequest
+): Promise<OperatorSession> {
+  const payload = await requestJson<JoinSessionResponse>(
+    API_BASE,
+    "/api/v1/operator/sessions",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(request),
+    },
+    { retry: false }
+  );
+  return payload.session;
+}
+
+export async function leaveSession(sessionId: string): Promise<void> {
+  await requestJson(
+    API_BASE,
+    `/api/v1/operator/sessions/${encodeURIComponent(sessionId)}`,
+    { method: "DELETE" },
+    { retry: false }
+  );
+}
+
+export async function listSessions(): Promise<SessionListResponse> {
+  return requestJson<SessionListResponse>(
+    API_BASE,
+    "/api/v1/operator/sessions",
+    { method: "GET" },
+    { retry: true }
+  );
+}
+
+export async function sessionHeartbeat(sessionId: string): Promise<void> {
+  await requestJson(
+    API_BASE,
+    `/api/v1/operator/sessions/${encodeURIComponent(sessionId)}/heartbeat`,
+    { method: "POST" },
+    { retry: false }
+  );
+}
+
+export async function listConfirmations(): Promise<ConfirmationListResponse> {
+  return requestJson<ConfirmationListResponse>(
+    API_BASE,
+    "/api/v1/operator/confirmations",
+    { method: "GET" },
+    { retry: true }
+  );
+}
+
+export async function confirmProposal(
+  confirmationId: string,
+  sessionId: string
+): Promise<ConfirmationRequest> {
+  const payload = await requestJson<ResolveConfirmationResponse>(
+    API_BASE,
+    `/api/v1/operator/confirmations/${encodeURIComponent(confirmationId)}/confirm`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ session_id: sessionId }),
+    },
+    { retry: false }
+  );
+  return payload.request;
+}
+
+export async function denyProposal(
+  confirmationId: string,
+  sessionId: string,
+  denialReason?: string
+): Promise<ConfirmationRequest> {
+  const payload = await requestJson<ResolveConfirmationResponse>(
+    API_BASE,
+    `/api/v1/operator/confirmations/${encodeURIComponent(confirmationId)}/deny`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        session_id: sessionId,
+        denial_reason: denialReason,
+      }),
+    },
+    { retry: false }
+  );
+  return payload.request;
+}
+
+/// Creates an SSE connection to the operator event stream.
+/// Returns the EventSource (caller is responsible for closing it).
+export function operatorEventStreamUrl(): string {
+  return `${API_BASE}/api/v1/operator/stream`;
+}

--- a/ui/src/lib/operatorPreferences.ts
+++ b/ui/src/lib/operatorPreferences.ts
@@ -14,6 +14,7 @@ const VALID_LANDING_ROUTES = [
   "/rules",
   "/audit",
   "/onchain",
+  "/federation",
 ] as const;
 
 export type OperatorLandingRoute = (typeof VALID_LANDING_ROUTES)[number];

--- a/ui/src/lib/operatorPreferences.ts
+++ b/ui/src/lib/operatorPreferences.ts
@@ -15,6 +15,7 @@ const VALID_LANDING_ROUTES = [
   "/audit",
   "/onchain",
   "/federation",
+  "/operator",
 ] as const;
 
 export type OperatorLandingRoute = (typeof VALID_LANDING_ROUTES)[number];

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -14,6 +14,7 @@ import { CasesPage } from "./screens/CasesPage";
 import { CredentialsPage } from "./screens/CredentialsPage";
 import { DashboardPage } from "./screens/DashboardPage";
 import { EvidencePage } from "./screens/EvidencePage";
+import { FederationPage } from "./screens/FederationPage";
 import { MarketIntelPage } from "./screens/MarketIntelPage";
 import { OnchainPage } from "./screens/OnchainPage";
 import { PolicyWorkbenchPage } from "./screens/PolicyWorkbenchPage";
@@ -54,6 +55,12 @@ const NAV_GROUPS = [
       { to: "/rules" as const, label: "Automation", icon: "⟲" },
       { to: "/audit" as const, label: "Audit Log", icon: "≡" },
       { to: "/onchain" as const, label: "Onchain", icon: "⟡" },
+    ],
+  },
+  {
+    name: "Network",
+    items: [
+      { to: "/federation" as const, label: "Federation", icon: "⬡" },
     ],
   },
 ];
@@ -330,6 +337,12 @@ const autopilotRoute = createRoute({
   component: AutopilotPage,
 });
 
+const federationRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/federation",
+  component: FederationPage,
+});
+
 const routeTree = rootRoute.addChildren([
   dashboardRoute,
   marketIntelRoute,
@@ -344,6 +357,7 @@ const routeTree = rootRoute.addChildren([
   auditRoute,
   onchainRoute,
   autopilotRoute,
+  federationRoute,
 ]);
 
 export const router = createRouter({

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -16,6 +16,7 @@ import { DashboardPage } from "./screens/DashboardPage";
 import { EvidencePage } from "./screens/EvidencePage";
 import { FederationPage } from "./screens/FederationPage";
 import { MarketIntelPage } from "./screens/MarketIntelPage";
+import { OperatorPage } from "./screens/OperatorPage";
 import { OnchainPage } from "./screens/OnchainPage";
 import { PolicyWorkbenchPage } from "./screens/PolicyWorkbenchPage";
 import { RulesPage } from "./screens/RulesPage";
@@ -61,6 +62,7 @@ const NAV_GROUPS = [
     name: "Network",
     items: [
       { to: "/federation" as const, label: "Federation", icon: "⬡" },
+      { to: "/operator" as const, label: "Operator", icon: "⊕" },
     ],
   },
 ];
@@ -343,6 +345,12 @@ const federationRoute = createRoute({
   component: FederationPage,
 });
 
+const operatorRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/operator",
+  component: OperatorPage,
+});
+
 const routeTree = rootRoute.addChildren([
   dashboardRoute,
   marketIntelRoute,
@@ -358,6 +366,7 @@ const routeTree = rootRoute.addChildren([
   onchainRoute,
   autopilotRoute,
   federationRoute,
+  operatorRoute,
 ]);
 
 export const router = createRouter({

--- a/ui/src/router.tsx
+++ b/ui/src/router.tsx
@@ -29,31 +29,31 @@ import {
 
 const NAV_GROUPS = [
   {
-    name: "Command & Control",
+    name: "Command",
     items: [
-      { to: "/" as const, label: "SYS.DASHBOARD", icon: "❖" },
-      { to: "/market-intel" as const, label: "MARKET.INTEL", icon: "◒" },
-      { to: "/autopilot" as const, label: "AUTOPILOT.AI", icon: "⌾" },
+      { to: "/" as const, label: "Dashboard", icon: "◆" },
+      { to: "/market-intel" as const, label: "Market Intel", icon: "◐" },
+      { to: "/autopilot" as const, label: "Autopilot", icon: "◎" },
     ],
   },
   {
-    name: "Data Substrate",
+    name: "Intelligence",
     items: [
-      { to: "/sources" as const, label: "NET.SOURCES", icon: "⏚" },
-      { to: "/evidence" as const, label: "RAW.EVIDENCE", icon: "▤" },
-      { to: "/watchlists" as const, label: "WATCH.RULES", icon: "⎈" },
+      { to: "/sources" as const, label: "Sources", icon: "▸" },
+      { to: "/evidence" as const, label: "Evidence", icon: "▤" },
+      { to: "/watchlists" as const, label: "Watchlists", icon: "⚑" },
     ],
   },
   {
-    name: "Execution & Logic",
+    name: "Operations",
     items: [
-      { to: "/cases" as const, label: "ACTIVE.CASES", icon: "⊡" },
-      { to: "/agents" as const, label: "AGENT.NODES", icon: "⎍" },
-      { to: "/policies" as const, label: "POLICY.GATE", icon: "⍜" },
-      { to: "/credentials" as const, label: "KEYS.VAULT", icon: "K" },
-      { to: "/rules" as const, label: "AUTO.RULES", icon: "⟲" },
-      { to: "/audit" as const, label: "AUDIT.LOG", icon: "⌁" },
-      { to: "/onchain" as const, label: "EVM.SHELL", icon: "⟡" },
+      { to: "/cases" as const, label: "Cases", icon: "⊡" },
+      { to: "/agents" as const, label: "Agents", icon: "⎌" },
+      { to: "/policies" as const, label: "Policy", icon: "⌥" },
+      { to: "/credentials" as const, label: "Credentials", icon: "⚿" },
+      { to: "/rules" as const, label: "Automation", icon: "⟲" },
+      { to: "/audit" as const, label: "Audit Log", icon: "≡" },
+      { to: "/onchain" as const, label: "Onchain", icon: "⟡" },
     ],
   },
 ];
@@ -101,130 +101,129 @@ function RootLayout() {
   }
 
   return (
-    <div className="tac-root">
-      <div className="tac-scanlines"></div>
-      <div className="tac-glow-orbs"></div>
+    <div className="hx-root">
+      <div className="hx-bg-grid" />
 
-      <div className="tac-layout">
-        <header className="tac-topbar">
-          <div className="topbar-brand">
+      <div className="hx-layout">
+        <header className="hx-topbar">
+          <div className="hx-topbar-brand">
             <button
               type="button"
-              className="topbar-menu"
+              className="hx-topbar-menu"
               aria-label={sidebarOpen ? "Close navigation" : "Open navigation"}
               aria-expanded={sidebarOpen}
               aria-controls="helix-sidebar"
               onClick={() => setSidebarOpen((open) => !open)}
             >
-              NAV
+              MENU
             </button>
-            <span className="brand-icon">⎈</span>
-            <span className="brand-name">HELIX</span>
-            <span className="brand-version">v2.0.4 - TACTICAL OSINT</span>
+            <span className="hx-brand-icon">⎈</span>
+            <span className="hx-brand-name">HELIX</span>
+            <span className="hx-brand-version">v2.1 · Intelligence Desk</span>
             <button
               type="button"
-              className="topbar-collapse"
+              className="hx-topbar-collapse"
               aria-label={preferences.sidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
               aria-pressed={preferences.sidebarCollapsed}
               onClick={toggleSidebarCollapsed}
             >
-              {preferences.sidebarCollapsed ? "EXPAND" : "COLLAPSE"}
+              {preferences.sidebarCollapsed ? "▸" : "◂"}
             </button>
           </div>
-          <div className="topbar-telemetry">
-            <div className="telemetry-block">
-              <span className="t-label">NET</span>
-              <span className="t-val ok">SECURE</span>
+          <div className="hx-topbar-meta">
+            <div className="hx-meta-chip">
+              <span className="hx-meta-label">NET</span>
+              <span className="hx-meta-value is-ok">SECURE</span>
             </div>
-            <div className="telemetry-block">
-              <span className="t-label">RPC</span>
-              <span className="t-val">127.0.0.1:3000</span>
+            <div className="hx-meta-chip">
+              <span className="hx-meta-label">RPC</span>
+              <span className="hx-meta-value">127.0.0.1:3000</span>
             </div>
-            <div className="telemetry-block">
-              <span className="t-label">UI_SYNC</span>
-              <span className="t-val ok">SYNCED</span>
+            <div className="hx-meta-chip">
+              <span className="hx-meta-label">SYNC</span>
+              <span className="hx-meta-value is-ok">ONLINE</span>
             </div>
-            <label className="telemetry-auth">
-              <span className="t-label">API_AUTH</span>
+            <label className="hx-meta-auth">
+              <span className="hx-meta-label">TOKEN</span>
               <input
                 aria-label="API bearer token"
-                className="topbar-token"
+                className="hx-token-input"
                 type="password"
                 autoComplete="off"
-                placeholder="token"
+                placeholder="bearer token"
                 value={apiTokenInput}
                 onChange={(event) => updateApiToken(event.target.value)}
               />
               {hasApiToken ? (
-                <button type="button" className="topbar-token-clear" onClick={resetApiToken}>
+                <button type="button" className="hx-token-clear" onClick={resetApiToken}>
                   CLEAR
                 </button>
               ) : (
-                <span className="t-val">LOCAL</span>
+                <span className="hx-meta-value">LOCAL</span>
               )}
             </label>
           </div>
         </header>
 
         <div
-          className={`tac-main-grid${preferences.sidebarCollapsed ? " sidebar-collapsed" : ""}`}
+          className={`hx-main-grid${preferences.sidebarCollapsed ? " is-collapsed" : ""}`}
         >
           <aside
             id="helix-sidebar"
-            className={`tac-sidebar${sidebarOpen ? " is-open" : ""}${
+            className={`hx-sidebar${sidebarOpen ? " is-open" : ""}${
               preferences.sidebarCollapsed ? " is-collapsed" : ""
             }`}
           >
-            <nav className="tac-nav">
+            <nav className="hx-nav">
               {NAV_GROUPS.map((group) => (
-                <div key={group.name} className="nav-group">
-                  <span className="group-label">[{group.name}]</span>
-                  <div className="group-items">
+                <div key={group.name} className="hx-nav-group">
+                  <span className="hx-nav-group-label">{group.name}</span>
+                  <div className="hx-nav-group-items">
                     {group.items.map((item) => (
                       <Link
                         key={item.to}
                         to={item.to}
-                        activeProps={{ className: "tac-nav-link active" }}
-                        inactiveProps={{ className: "tac-nav-link" }}
+                        activeProps={{ className: "hx-nav-link active" }}
+                        inactiveProps={{ className: "hx-nav-link" }}
                         title={item.label}
                         onClick={() => setSidebarOpen(false)}
                       >
-                        <span className="nav-icon">{item.icon}</span>
-                        <span className="nav-text">{item.label}</span>
-                        <span className="nav-caret">⟩</span>
+                        <span className="hx-nav-icon">{item.icon}</span>
+                        <span className="hx-nav-text">{item.label}</span>
+                        <span className="hx-nav-caret">›</span>
                       </Link>
                     ))}
                   </div>
                 </div>
               ))}
             </nav>
-            <div className="sidebar-footer">
-              <label className="sidebar-pref">
-                <span className="group-label">[Default Landing]</span>
+            <div className="hx-sidebar-footer">
+              <label className="hx-sidebar-pref">
+                <span className="hx-nav-group-label">Default Landing</span>
                 <select
                   value={preferences.defaultLandingRoute}
                   onChange={(event) =>
                     updateDefaultLandingRoute(event.target.value as OperatorLandingRoute)
                   }
                 >
-                  <option value="/">SYS.DASHBOARD</option>
-                  <option value="/market-intel">MARKET.INTEL</option>
-                  <option value="/autopilot">AUTOPILOT.AI</option>
-                  <option value="/sources">NET.SOURCES</option>
-                  <option value="/evidence">RAW.EVIDENCE</option>
-                  <option value="/watchlists">WATCH.RULES</option>
-                  <option value="/cases">ACTIVE.CASES</option>
-                  <option value="/agents">AGENT.NODES</option>
-                  <option value="/policies">POLICY.GATE</option>
-                  <option value="/credentials">KEYS.VAULT</option>
-                  <option value="/rules">AUTO.RULES</option>
-                  <option value="/audit">AUDIT.LOG</option>
-                  <option value="/onchain">EVM.SHELL</option>
+                  <option value="/">Dashboard</option>
+                  <option value="/market-intel">Market Intel</option>
+                  <option value="/autopilot">Autopilot</option>
+                  <option value="/sources">Sources</option>
+                  <option value="/evidence">Evidence</option>
+                  <option value="/watchlists">Watchlists</option>
+                  <option value="/cases">Cases</option>
+                  <option value="/agents">Agents</option>
+                  <option value="/policies">Policy</option>
+                  <option value="/credentials">Credentials</option>
+                  <option value="/rules">Automation</option>
+                  <option value="/audit">Audit Log</option>
+                  <option value="/onchain">Onchain</option>
                 </select>
               </label>
-              <div className="status-indicator">
-                <span className="pulse-dot ok"></span>
-                <span>SYS_NOMINAL</span>
+              <div className="hx-sidebar-status">
+                <span className="hx-pulse-dot" />
+                <span>SYS NOMINAL</span>
               </div>
             </div>
           </aside>
@@ -232,14 +231,14 @@ function RootLayout() {
           {sidebarOpen ? (
             <button
               type="button"
-              className="sidebar-scrim"
+              className="hx-sidebar-scrim"
               aria-label="Close navigation"
               onClick={() => setSidebarOpen(false)}
             />
           ) : null}
 
-          <main className="tac-workspace">
-            <div className="workspace-frame">
+          <main className="hx-workspace">
+            <div className="hx-workspace-frame">
               <Outlet />
             </div>
           </main>

--- a/ui/src/screens/AgentCatalogPage.tsx
+++ b/ui/src/screens/AgentCatalogPage.tsx
@@ -6,6 +6,14 @@ import {
   fetchAgentCatalog,
   fetchAgentTemplates,
 } from "../lib/api";
+import {
+  Panel,
+  Button,
+  Badge,
+  StatusLine,
+  CodeBlock,
+  Tag,
+} from "../components";
 
 const verificationCommands = [
   "cargo test --manifest-path crates/helix-api/Cargo.toml",
@@ -53,7 +61,6 @@ export function AgentCatalogPage() {
       setTemplateStatus("Clipboard is not available in this browser context.");
       return;
     }
-
     try {
       await navigator.clipboard.writeText(value);
       setTemplateStatus(`${label} copied to clipboard.`);
@@ -63,10 +70,7 @@ export function AgentCatalogPage() {
   }
 
   async function applySelectedTemplate() {
-    if (!selectedTemplate) {
-      return;
-    }
-
+    if (!selectedTemplate) return;
     setApplyStatus(`Applying ${selectedTemplate.name}...`);
     try {
       const response = await applyAgentTemplate(selectedTemplate.id, true);
@@ -80,121 +84,103 @@ export function AgentCatalogPage() {
   }
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel panel-hero panel-span-12">
-        <p className="mono-label">Agent Catalog</p>
-        <h2>High-ROI Deterministic State Machines</h2>
-        <p>
-          These kernels are pure and replayable. Each includes formal model coverage for fail-closed
-          verification.
+    <section className="hx-page-grid">
+      <Panel hero span={12} eyebrow="Agent Catalog" title="High-ROI Deterministic State Machines">
+        <p className="hx-description">
+          These kernels are pure and replayable. Each includes formal model coverage
+          for fail-closed verification.
         </p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-5">
-        <p className="mono-label">Verification Commands</p>
-        <div className="command-stack">
+      <Panel span={5} eyebrow="Verify" title="Verification Commands">
+        <div className="hx-list">
           {verificationCommands.map((command) => (
-            <code key={command} className="command-inline">
-              {command}
-            </code>
-          ))}
-        </div>
-        <p className="status-line">{status}</p>
-      </article>
-
-      <article className="panel panel-span-7">
-        <p className="mono-label">Implemented Agents</p>
-        <div className="agent-grid">
-          {agents.map((agent) => (
-            <div key={agent.id} className="agent-card">
-              <div className="agent-card-head">
-                <h3>{agent.name}</h3>
-                <span className="status-pill ok">Implemented</span>
-              </div>
-              <p>{agent.roi_rationale}</p>
-              <p className="mono-detail">{agent.id}</p>
-              <code className="command-inline">{agent.kernel_module}</code>
-              <code className="command-inline">formal_model: available</code>
+            <div key={command} className="hx-row">
+              <code className="hx-mono-detail">{command}</code>
             </div>
           ))}
         </div>
-      </article>
+        <StatusLine>{status}</StatusLine>
+      </Panel>
 
-      <article className="panel panel-span-6">
-        <p className="mono-label">Deployment Templates</p>
-        <div className="agent-grid">
-          {templates.map((template) => (
-            <div key={template.id} className="agent-card">
-              <div className="agent-card-head">
-                <h3>{template.name}</h3>
-                <span className="status-pill ok">Template</span>
+      <Panel span={7} eyebrow="Implemented" title="Agents" actions={<Badge tone="accent">{agents.length}</Badge>}>
+        {agents.length === 0 ? (
+          <div className="hx-table-empty"><p>No agents loaded.</p></div>
+        ) : (
+          <div className="hx-card-grid">
+            {agents.map((agent) => (
+              <div key={agent.id} className="hx-card">
+                <div className="hx-card-head">
+                  <h3>{agent.name}</h3>
+                  <Badge tone="ok">Implemented</Badge>
+                </div>
+                <p className="hx-row-secondary">{agent.roi_rationale}</p>
+                <p className="hx-mono-detail">{agent.id}</p>
+                <div className="hx-tag-row">
+                  <Tag>{agent.kernel_module}</Tag>
+                  <Tag>formal model: available</Tag>
+                </div>
               </div>
-              <p>{template.summary}</p>
-              <p className="mono-detail">{template.id}</p>
-              <p>Use for: {template.recommended_for}</p>
-              <code className="command-inline">
-                required_agents=[{template.required_agents.join(", ")}]
-              </code>
-              <div className="button-row">
-                <button
-                  className={template.id === selectedTemplateId ? "btn-primary" : "btn-secondary"}
+            ))}
+          </div>
+        )}
+      </Panel>
+
+      <Panel span={6} eyebrow="Deploy" title="Templates" actions={<Badge tone="info">{templates.length}</Badge>}>
+        {templates.length === 0 ? (
+          <div className="hx-table-empty"><p>No templates loaded.</p></div>
+        ) : (
+          <div className="hx-card-grid">
+            {templates.map((template) => (
+              <div key={template.id} className="hx-card">
+                <div className="hx-card-head">
+                  <h3>{template.name}</h3>
+                  <Badge tone={template.id === selectedTemplateId ? "accent" : "neutral"}>Template</Badge>
+                </div>
+                <p className="hx-row-secondary">{template.summary}</p>
+                <p className="hx-mono-detail">{template.id}</p>
+                <p className="hx-row-secondary">Use for: {template.recommended_for}</p>
+                <div className="hx-tag-row">
+                  <Tag>required: {template.required_agents.join(", ")}</Tag>
+                </div>
+                <Button
+                  variant={template.id === selectedTemplateId ? "primary" : "secondary"}
                   onClick={() => setSelectedTemplateId(template.id)}
                 >
-                  {template.id === selectedTemplateId ? "Selected" : "Select Template"}
-                </button>
+                  {template.id === selectedTemplateId ? "Selected" : "Select"}
+                </Button>
               </div>
-            </div>
-          ))}
-        </div>
-        <p className="status-line">{templateStatus}</p>
-      </article>
-
-      <article className="panel panel-span-6">
-        <p className="mono-label">Template Details</p>
-        {selectedTemplate ? (
-          <>
-            <h3>{selectedTemplate.name}</h3>
-            <p>{selectedTemplate.summary}</p>
-            <p className="status-line">{selectedTemplate.recommended_for}</p>
-
-            <p className="mono-label">Config JSON</p>
-            <pre className="json-output">{JSON.stringify(selectedTemplate.config, null, 2)}</pre>
-
-            <p className="mono-label">Bootstrap Commands</p>
-            <pre className="json-output">
-              {JSON.stringify(selectedTemplate.bootstrap_commands, null, 2)}
-            </pre>
-
-            <div className="button-row">
-              <button
-                className="btn-secondary"
-                onClick={() =>
-                  void copyToClipboard("Config JSON", JSON.stringify(selectedTemplate.config, null, 2))
-                }
-              >
-                Copy Config
-              </button>
-              <button
-                className="btn-secondary"
-                onClick={() =>
-                  void copyToClipboard(
-                    "Bootstrap Commands",
-                    JSON.stringify(selectedTemplate.bootstrap_commands, null, 2)
-                  )
-                }
-              >
-                Copy Commands
-              </button>
-              <button className="btn-primary" onClick={() => void applySelectedTemplate()}>
-                Apply Template
-              </button>
-            </div>
-            <p className="status-line">{applyStatus}</p>
-          </>
-        ) : (
-          <p>Select a template to inspect deterministic config and bootstrap commands.</p>
+            ))}
+          </div>
         )}
-      </article>
+        <StatusLine>{templateStatus}</StatusLine>
+      </Panel>
+
+      <Panel span={6} eyebrow="Details" title="Template Config">
+        {selectedTemplate ? (
+          <div className="hx-list">
+            <div className="hx-card-head">
+              <h3>{selectedTemplate.name}</h3>
+            </div>
+            <p className="hx-row-secondary">{selectedTemplate.summary}</p>
+            <StatusLine>{selectedTemplate.recommended_for}</StatusLine>
+            <CodeBlock label="Config JSON">{JSON.stringify(selectedTemplate.config, null, 2)}</CodeBlock>
+            <CodeBlock label="Bootstrap Commands">{JSON.stringify(selectedTemplate.bootstrap_commands, null, 2)}</CodeBlock>
+            <div className="hx-cluster">
+              <Button variant="secondary" onClick={() => void copyToClipboard("Config JSON", JSON.stringify(selectedTemplate.config, null, 2))}>
+                Copy Config
+              </Button>
+              <Button variant="secondary" onClick={() => void copyToClipboard("Bootstrap Commands", JSON.stringify(selectedTemplate.bootstrap_commands, null, 2))}>
+                Copy Commands
+              </Button>
+              <Button onClick={() => void applySelectedTemplate()}>Apply Template</Button>
+            </div>
+            <StatusLine>{applyStatus}</StatusLine>
+          </div>
+        ) : (
+          <div className="hx-table-empty"><p>Select a template to inspect deterministic config and bootstrap commands.</p></div>
+        )}
+      </Panel>
     </section>
   );
 }

--- a/ui/src/screens/AuditPage.tsx
+++ b/ui/src/screens/AuditPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { AuditLogEntry, fetchAuditLog } from "../lib/api";
+import { Panel, Badge, Button, StatusLine, CodeBlock, Tag } from "../components";
 
 function metadataPreview(metadata: unknown): string {
   try {
@@ -34,58 +35,52 @@ export function AuditPage() {
   }, []);
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel panel-hero panel-span-12">
-        <p className="mono-label">Audit Timeline</p>
-        <h2>Durable Operator Decisions</h2>
-        <p>
-          Review persisted source collection, evidence, policy, and autopilot guard decisions from
-          the Postgres audit log.
+    <section className="hx-page-grid">
+      <Panel hero span={12} eyebrow="Audit Timeline" title="Durable Operator Decisions">
+        <p className="hx-description">
+          Review persisted source collection, evidence, policy, and autopilot guard
+          decisions from the Postgres audit log.
         </p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <div className="panel-toolbar">
-          <div>
-            <p className="mono-label">Audit Store</p>
-            <p className="status-line">{status}</p>
-          </div>
-          <div className="toolbar-actions">
-            <span className={`status-pill ${persistenceEnabled ? "ok" : "warn"}`}>
-              {persistenceEnabled ? "durable" : "in-memory mode"}
-            </span>
-            <button className="btn-secondary" type="button" onClick={() => void loadAuditLog()}>
+      <Panel
+        span={12}
+        eyebrow="Store"
+        title="Audit Log"
+        actions={
+          <>
+            <Badge tone={persistenceEnabled ? "ok" : "warn"}>
+              {persistenceEnabled ? "durable" : "in-memory"}
+            </Badge>
+            <Button variant="secondary" type="button" onClick={() => void loadAuditLog()}>
               Refresh
-            </button>
-          </div>
-        </div>
-
-        <div className="command-list">
-          {entries.length === 0 ? (
-            <p className="panel-note">No audit records are available for the current store.</p>
-          ) : (
-            entries.map((entry) => (
-              <div key={entry.id} className="command-row">
-                <div>
-                  <div className="command-row-head">
-                    <h3>{entry.action}</h3>
-                    <span className={`status-pill ${entry.decision === "allow" ? "ok" : "warn"}`}>
-                      {entry.decision}
-                    </span>
-                  </div>
-                  <p>{entry.resource}</p>
-                  <div className="pill-row">
-                    <span className="info-pill">subject: {entry.subject}</span>
-                    <span className="info-pill">created: {entry.created_at}</span>
-                    {entry.reason ? <span className="info-pill">reason: {entry.reason}</span> : null}
-                  </div>
-                  <pre className="json-block">{metadataPreview(entry.metadata)}</pre>
+            </Button>
+          </>
+        }
+      >
+        <StatusLine>{status}</StatusLine>
+        {entries.length === 0 ? (
+          <div className="hx-table-empty"><p>No audit records available for the current store.</p></div>
+        ) : (
+          <div className="hx-list">
+            {entries.map((entry) => (
+              <div key={entry.id} className="hx-card">
+                <div className="hx-card-head">
+                  <h3>{entry.action}</h3>
+                  <Badge tone={entry.decision === "allow" ? "ok" : "warn"}>{entry.decision}</Badge>
                 </div>
+                <p className="hx-row-secondary">{entry.resource}</p>
+                <div className="hx-tag-row">
+                  <Tag>subject: {entry.subject}</Tag>
+                  <Tag>created: {entry.created_at}</Tag>
+                  {entry.reason && <Tag>reason: {entry.reason}</Tag>}
+                </div>
+                <CodeBlock label="metadata" maxHeight="180px">{metadataPreview(entry.metadata)}</CodeBlock>
               </div>
-            ))
-          )}
-        </div>
-      </article>
+            ))}
+          </div>
+        )}
+      </Panel>
     </section>
   );
 }

--- a/ui/src/screens/AutopilotPage.tsx
+++ b/ui/src/screens/AutopilotPage.tsx
@@ -20,6 +20,21 @@ import {
   loadAutopilotWorkspaceState,
   saveAutopilotWorkspaceState,
 } from "../lib/autopilotWorkspace";
+import {
+  Badge,
+  Button,
+  CheckboxField,
+  CodeBlock,
+  EmptyState,
+  FormField,
+  FormGrid,
+  Input,
+  Panel,
+  Select,
+  StatusLine,
+  Tag,
+  Textarea,
+} from "../components";
 
 const DEFAULT_POLICY_ACTION = JSON.stringify(
   {
@@ -413,25 +428,21 @@ export function AutopilotPage() {
   }
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel panel-hero panel-span-12">
-        <p className="mono-label">Autopilot</p>
-        <h2>LLM-Operable Helix With Deterministic Guardrails</h2>
-        <p>
+    <section className="hx-page-grid">
+      <Panel hero span={12} eyebrow="Autopilot" title="LLM-Operable Helix With Deterministic Guardrails">
+        <p className="hx-description">
           Use assist or auto mode to let an LLM operate Helix through bounded actions, while policy
           and on-chain commands remain fail-closed. The review queue below is deterministic: cases,
           claims, and evidence are merged into one guarded worklist before any proposal is drafted.
         </p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-4">
-        <p className="mono-label">Autopilot Config</p>
-        <form className="form-grid" onSubmit={onSaveConfig}>
+      <Panel span={4} eyebrow="Autopilot Config">
+        <form className="hx-form-grid" onSubmit={onSaveConfig}>
           {config ? (
             <>
-              <label className="field">
-                <span>mode</span>
-                <select
+              <FormField label="mode">
+                <Select
                   value={config.mode}
                   onChange={(e) =>
                     setConfig({
@@ -443,43 +454,33 @@ export function AutopilotPage() {
                   <option value="off">off</option>
                   <option value="assist">assist</option>
                   <option value="auto">auto</option>
-                </select>
-              </label>
+                </Select>
+              </FormField>
 
-              <label className="field checkbox-field">
-                <input
-                  type="checkbox"
-                  checked={config.allow_onchain}
-                  onChange={(e) => setConfig({ ...config, allow_onchain: e.target.checked })}
-                />
-                <span>allow_onchain</span>
-              </label>
+              <CheckboxField
+                label="allow_onchain"
+                checked={config.allow_onchain}
+                onChange={(checked) => setConfig({ ...config, allow_onchain: checked })}
+              />
 
-              <label className="field checkbox-field">
-                <input
-                  type="checkbox"
-                  checked={config.require_onchain_confirmation}
-                  onChange={(e) =>
-                    setConfig({ ...config, require_onchain_confirmation: e.target.checked })
-                  }
-                />
-                <span>require_onchain_confirmation</span>
-              </label>
+              <CheckboxField
+                label="require_onchain_confirmation"
+                checked={config.require_onchain_confirmation}
+                onChange={(checked) =>
+                  setConfig({ ...config, require_onchain_confirmation: checked })
+                }
+              />
 
-              <label className="field checkbox-field">
-                <input
-                  type="checkbox"
-                  checked={config.require_onchain_dry_run}
-                  onChange={(e) =>
-                    setConfig({ ...config, require_onchain_dry_run: e.target.checked })
-                  }
-                />
-                <span>require_onchain_dry_run</span>
-              </label>
+              <CheckboxField
+                label="require_onchain_dry_run"
+                checked={config.require_onchain_dry_run}
+                onChange={(checked) =>
+                  setConfig({ ...config, require_onchain_dry_run: checked })
+                }
+              />
 
-              <label className="field">
-                <span>max_policy_commands</span>
-                <input
+              <FormField label="max_policy_commands">
+                <Input
                   type="number"
                   min={1}
                   value={config.max_policy_commands}
@@ -487,100 +488,92 @@ export function AutopilotPage() {
                     setConfig({ ...config, max_policy_commands: Number(e.target.value) })
                   }
                 />
-              </label>
+              </FormField>
 
-              <button className="btn-primary" type="submit">
+              <Button variant="primary" type="submit">
                 Save Autopilot Config
-              </button>
+              </Button>
             </>
           ) : (
-            <p>Loading...</p>
+            <p className="hx-description">Loading...</p>
           )}
         </form>
-        <p className="status-line">{statusLine}</p>
-        <p className="status-line">{statsLine}</p>
-      </article>
+        <StatusLine>{statusLine}</StatusLine>
+        <StatusLine>{statsLine}</StatusLine>
+      </Panel>
 
-      <article className="panel panel-span-4">
-        <p className="mono-label">Policy Action</p>
-        <label className="field">
-          <span>proposal_goal</span>
-          <input
+      <Panel span={4} eyebrow="Policy Action">
+        <FormField label="proposal_goal">
+          <Input
             type="text"
             value={policyGoal}
             onChange={(e) => setPolicyGoal(e.target.value)}
             placeholder="e.g. simulate allowlist and fee quote before broadcast"
           />
-        </label>
-        <div className="button-row">
-          <button className="btn-secondary" onClick={onProposePolicyAction}>
+        </FormField>
+        <div className="hx-cluster">
+          <Button variant="secondary" onClick={onProposePolicyAction}>
             Propose Policy Action
-          </button>
+          </Button>
         </div>
-        <textarea
-          className="command-editor"
+        <Textarea
           rows={16}
           value={policyActionText}
           onChange={(e) => setPolicyActionText(e.target.value)}
         />
-        <div className="button-row">
-          <button className="btn-primary" onClick={onRunPolicyAction}>
+        <div className="hx-cluster">
+          <Button variant="primary" onClick={onRunPolicyAction}>
             Run Policy Action
-          </button>
-          <button className="btn-secondary" onClick={() => setPolicyActionText(DEFAULT_POLICY_ACTION)}>
+          </Button>
+          <Button variant="secondary" onClick={() => setPolicyActionText(DEFAULT_POLICY_ACTION)}>
             Reset Example
-          </button>
+          </Button>
         </div>
-        <pre className="json-output">{policyResult}</pre>
-      </article>
+        <CodeBlock label="result">{policyResult}</CodeBlock>
+      </Panel>
 
-      <article className="panel panel-span-4">
-        <p className="mono-label">Onchain Action</p>
-        <label className="field">
-          <span>proposal_goal</span>
-          <input
+      <Panel span={4} eyebrow="Onchain Action">
+        <FormField label="proposal_goal">
+          <Input
             type="text"
             value={onchainGoal}
             onChange={(e) => setOnchainGoal(e.target.value)}
             placeholder="e.g. propose a safe dry-run broadcast payload"
           />
-        </label>
-        <div className="button-row">
-          <button className="btn-secondary" onClick={onProposeOnchainAction}>
+        </FormField>
+        <div className="hx-cluster">
+          <Button variant="secondary" onClick={onProposeOnchainAction}>
             Propose Onchain Action
-          </button>
+          </Button>
         </div>
-        <textarea
-          className="command-editor"
+        <Textarea
           rows={16}
           value={onchainActionText}
           onChange={(e) => setOnchainActionText(e.target.value)}
         />
-        <div className="button-row">
-          <button className="btn-primary" onClick={onRunOnchainAction}>
+        <div className="hx-cluster">
+          <Button variant="primary" onClick={onRunOnchainAction}>
             Run Onchain Action
-          </button>
-          <button className="btn-secondary" onClick={() => setOnchainActionText(DEFAULT_ONCHAIN_ACTION)}>
+          </Button>
+          <Button variant="secondary" onClick={() => setOnchainActionText(DEFAULT_ONCHAIN_ACTION)}>
             Reset Example
-          </button>
+          </Button>
         </div>
-        <pre className="json-output">{onchainResult}</pre>
-      </article>
+        <CodeBlock label="result">{onchainResult}</CodeBlock>
+      </Panel>
 
-      <article className="panel panel-span-5">
-        <p className="mono-label">Review Filters</p>
-        <div className="pill-row">
-          <span className="info-pill">
+      <Panel span={5} eyebrow="Review Filters">
+        <div className="hx-tag-row">
+          <Tag>
             priority = attention &gt; severity &gt; corroboration &gt; freshness &gt; trust &gt;
             density
-          </span>
-          <span className="info-pill">ties break on latest signal, then kind, then item id</span>
-          <span className="info-pill">active_view: {activeView?.name ?? "none"}</span>
+          </Tag>
+          <Tag>ties break on latest signal, then kind, then item id</Tag>
+          <Tag>active_view: {activeView?.name ?? "none"}</Tag>
         </div>
-        <div className="form-grid">
-          <label className="field">
-            <span>kind</span>
-            <select
+        <FormGrid>
+          <FormField label="kind">
+            <Select
               value={reviewKindFilter}
               onChange={(event) => {
                 setActiveViewId(null);
@@ -591,11 +584,10 @@ export function AutopilotPage() {
               <option value="case">case</option>
               <option value="claim">claim</option>
               <option value="evidence">evidence</option>
-            </select>
-          </label>
-          <label className="field">
-            <span>limit</span>
-            <select
+            </Select>
+          </FormField>
+          <FormField label="limit">
+            <Select
               value={reviewLimitFilter}
               onChange={(event) => {
                 setActiveViewId(null);
@@ -608,150 +600,150 @@ export function AutopilotPage() {
               <option value="50">50</option>
               <option value="100">100</option>
               <option value="all">all</option>
-            </select>
-          </label>
-        </div>
-        <div className="button-row">
-          <button className="btn-secondary" type="button" onClick={applyReviewFilters}>
+            </Select>
+          </FormField>
+        </FormGrid>
+        <div className="hx-cluster">
+          <Button variant="secondary" type="button" onClick={applyReviewFilters}>
             Apply Filters
-          </button>
-          <button className="btn-secondary" type="button" onClick={resetReviewFilters}>
+          </Button>
+          <Button variant="secondary" type="button" onClick={resetReviewFilters}>
             Reset
-          </button>
+          </Button>
         </div>
-        <p className="status-line">{reviewStatus}</p>
-      </article>
+        <StatusLine>{reviewStatus}</StatusLine>
+      </Panel>
 
-      <article className="panel panel-span-7">
-        <p className="mono-label">Saved Views</p>
-        <label className="field">
-          <span>view_name</span>
-          <input
+      <Panel span={7} eyebrow="Saved Views">
+        <FormField label="view_name">
+          <Input
             type="text"
             value={savedViewName}
             onChange={(event) => setSavedViewName(event.target.value)}
             placeholder="e.g. claim-review-focus"
           />
-        </label>
-        <div className="button-row">
-          <button className="btn-secondary" type="button" onClick={saveCurrentView}>
+        </FormField>
+        <div className="hx-cluster">
+          <Button variant="secondary" type="button" onClick={saveCurrentView}>
             Save Current View
-          </button>
-          <button className="btn-secondary" type="button" onClick={clearWorkspace}>
+          </Button>
+          <Button variant="secondary" type="button" onClick={clearWorkspace}>
             Clear Workspace
-          </button>
+          </Button>
         </div>
-        <div className="agent-grid">
+        <div className="hx-card-grid">
           {savedViews.length > 0 ? (
             savedViews.map((view) => (
-              <div key={view.id} className="agent-card">
-                <div className="agent-card-head">
+              <div key={view.id} className="hx-card">
+                <div className="hx-card-head">
                   <h3>{view.name}</h3>
-                  <span className={`status-pill ${activeViewId === view.id ? "ok" : "info"}`}>
+                  <Badge tone={activeViewId === view.id ? "ok" : "info"}>
                     {activeViewId === view.id ? "active" : "saved"}
-                  </span>
+                  </Badge>
                 </div>
-                <div className="pill-row">
-                  <span className="info-pill">{describeReviewFilters(view.filters)}</span>
-                  <span className="info-pill">view_id: {view.id}</span>
+                <div className="hx-tag-row">
+                  <Tag>{describeReviewFilters(view.filters)}</Tag>
+                  <Tag>view_id: {view.id}</Tag>
                 </div>
-                <div className="button-row">
-                  <button
-                    className="btn-primary"
-                    type="button"
-                    onClick={() => applySavedView(view)}
-                  >
+                <div className="hx-cluster">
+                  <Button variant="primary" type="button" onClick={() => applySavedView(view)}>
                     Apply View
-                  </button>
-                  <button
-                    className="btn-secondary"
-                    type="button"
-                    onClick={() => deleteSavedView(view)}
-                  >
+                  </Button>
+                  <Button variant="secondary" type="button" onClick={() => deleteSavedView(view)}>
                     Delete
-                  </button>
+                  </Button>
                 </div>
               </div>
             ))
           ) : (
-            <div className="agent-card">
-              <div className="agent-card-head">
+            <div className="hx-card">
+              <div className="hx-card-head">
                 <h3>No Saved Views</h3>
-                <span className="status-pill info">local</span>
+                <Badge tone="info">local</Badge>
               </div>
-              <p>
+              <p className="hx-description">
                 Save the current review filters to return to the same ranked autopilot worklist
                 after a reload.
               </p>
             </div>
           )}
         </div>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <p className="mono-label">Review Queue</p>
-        <div className="pill-row">
-          <span className="info-pill">top item: {reviewQueue[0]?.item_id ?? "none"}</span>
-          <span className="info-pill">filters: {describeReviewFilters(currentReviewFilters())}</span>
+      <Panel span={12} eyebrow="Review Queue">
+        <div className="hx-tag-row">
+          <Tag>top item: {reviewQueue[0]?.item_id ?? "none"}</Tag>
+          <Tag>filters: {describeReviewFilters(currentReviewFilters())}</Tag>
         </div>
-        <div className="agent-grid">
-          {reviewQueue.map((item, index) => (
-            <div key={`${item.kind}:${item.item_id}`} className="agent-card">
-              <div className="agent-card-head">
-                <h3>
-                  #{index + 1} {item.title}
-                </h3>
-                <span className={`status-pill ${reviewStateClass(item)}`}>
-                  {reviewStateLabel(item)}
-                </span>
+        {reviewQueue.length > 0 ? (
+          <div className="hx-card-grid">
+            {reviewQueue.map((item, index) => (
+              <div key={`${item.kind}:${item.item_id}`} className="hx-card">
+                <div className="hx-card-head">
+                  <h3>
+                    #{index + 1} {item.title}
+                  </h3>
+                  <Badge tone={reviewStateClass(item) as "ok" | "warn" | "danger" | "info"}>
+                    {reviewStateLabel(item)}
+                  </Badge>
+                </div>
+                <p className="hx-description">{item.summary}</p>
+                <div className="hx-tag-row">
+                  <Tag>{item.kind}</Tag>
+                  <Tag>{priorityLabel(item.priority)}</Tag>
+                  <Tag>context: {item.context_label}</Tag>
+                  <Tag>route: {item.route}</Tag>
+                </div>
+                <div className="hx-tag-row">
+                  <Tag>latest: {item.latest_signal_at ?? "unknown"}</Tag>
+                  <Tag>item_id: {item.item_id}</Tag>
+                  {item.severity ? (
+                    <Badge tone={reviewStateClass(item) as "ok" | "warn" | "danger" | "info"}>
+                      {item.severity}
+                    </Badge>
+                  ) : null}
+                </div>
+                <code className="hx-mono-detail">{item.goal_hint}</code>
+                <div className="hx-cluster">
+                  <Button
+                    variant="primary"
+                    type="button"
+                    onClick={() => void draftPolicyFromReviewItem(item)}
+                  >
+                    Draft Policy Proposal
+                  </Button>
+                  <Button variant="secondary" type="button" onClick={() => useGoalHint(item)}>
+                    Use Goal Hint
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    type="button"
+                    onClick={() => void exportReviewPacket(item)}
+                  >
+                    Export Packet
+                  </Button>
+                </div>
               </div>
-              <p>{item.summary}</p>
-              <div className="pill-row">
-                <span className="info-pill">{item.kind}</span>
-                <span className="info-pill">{priorityLabel(item.priority)}</span>
-                <span className="info-pill">context: {item.context_label}</span>
-                <span className="info-pill">route: {item.route}</span>
-              </div>
-              <div className="pill-row">
-                <span className="info-pill">latest: {item.latest_signal_at ?? "unknown"}</span>
-                <span className="info-pill">item_id: {item.item_id}</span>
-                {item.severity ? (
-                  <span className={`status-pill ${reviewStateClass(item)}`}>{item.severity}</span>
-                ) : null}
-              </div>
-              <code className="command-inline">{item.goal_hint}</code>
-              <div className="button-row">
-                <button
-                  className="btn-primary"
-                  type="button"
-                  onClick={() => void draftPolicyFromReviewItem(item)}
-                >
-                  Draft Policy Proposal
-                </button>
-                <button className="btn-secondary" type="button" onClick={() => useGoalHint(item)}>
-                  Use Goal Hint
-                </button>
-                <button
-                  className="btn-secondary"
-                  type="button"
-                  onClick={() => void exportReviewPacket(item)}
-                >
-                  Export Packet
-                </button>
-              </div>
-            </div>
-          ))}
-        </div>
-      </article>
-
-      <article className="panel panel-span-12">
-        <p className="mono-label">Latest Review Export</p>
-        {lastReviewExport ? (
-          <pre className="json-output">{JSON.stringify(lastReviewExport, null, 2)}</pre>
+            ))}
+          </div>
         ) : (
-          <p>No review export packet has been generated in this session.</p>
+          <EmptyState
+            title="No Review Items"
+            description="The review queue is empty for the current filters."
+          />
         )}
-      </article>
+      </Panel>
+
+      <Panel span={12} eyebrow="Latest Review Export">
+        {lastReviewExport ? (
+          <CodeBlock label="export packet">{JSON.stringify(lastReviewExport, null, 2)}</CodeBlock>
+        ) : (
+          <EmptyState
+            title="No Export Packet"
+            description="No review export packet has been generated in this session."
+          />
+        )}
+      </Panel>
     </section>
   );
 }

--- a/ui/src/screens/CasesPage.tsx
+++ b/ui/src/screens/CasesPage.tsx
@@ -18,6 +18,19 @@ import {
   makeSavedViewId,
   saveCasesWorkspaceState,
 } from "../lib/intelDeskWorkspace";
+import {
+  Badge,
+  Button,
+  FormField,
+  FormGrid,
+  Input,
+  Panel,
+  Select,
+  StatCard,
+  StatGrid,
+  StatusLine,
+  Tag,
+} from "../components";
 
 const DEFAULT_CASE_LIMIT = "25";
 type CaseStatusSelection = CaseStatus | "all";
@@ -193,64 +206,40 @@ export function CasesPage() {
   }
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel panel-hero panel-span-12">
-        <p className="mono-label">Cases</p>
-        <h2>Dossiers and Escalations</h2>
-        <p>
+    <section className="hx-page-grid">
+      <Panel hero span={12} eyebrow="Cases" title="Dossiers and Escalations">
+        <p className="hx-description">
           Cases are deterministic dossiers created by watchlist hits. Operators can move them
           through monitoring, brief-ready, escalated, closed, and reopened states without bypassing
           the lifecycle kernel. Queue order is now a deterministic mixed-radix priority, not
           incidental insertion order.
         </p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <p className="mono-label">Case Metrics</p>
-        <div className="metrics-grid">
-          <div className="metric-card">
-            <p className="metric-label">Sources</p>
-            <p className="metric-value">{overview?.source_count ?? 0}</p>
-          </div>
-          <div className="metric-card">
-            <p className="metric-label">Watchlists</p>
-            <p className="metric-value">{overview?.watchlist_count ?? 0}</p>
-          </div>
-          <div className="metric-card">
-            <p className="metric-label">Evidence</p>
-            <p className="metric-value">{overview?.evidence_count ?? 0}</p>
-          </div>
-          <div className="metric-card">
-            <p className="metric-label">Claims</p>
-            <p className="metric-value">{overview?.claim_count ?? 0}</p>
-          </div>
-          <div className="metric-card">
-            <p className="metric-label">Open Cases</p>
-            <p className="metric-value">{overview?.open_case_count ?? 0}</p>
-          </div>
-          <div className="metric-card">
-            <p className="metric-label">Escalated</p>
-            <p className="metric-value">{overview?.escalated_case_count ?? 0}</p>
-          </div>
+      <Panel span={12} eyebrow="Case Metrics">
+        <StatGrid>
+          <StatCard label="Sources" value={overview?.source_count ?? 0} />
+          <StatCard label="Watchlists" value={overview?.watchlist_count ?? 0} />
+          <StatCard label="Evidence" value={overview?.evidence_count ?? 0} />
+          <StatCard label="Claims" value={overview?.claim_count ?? 0} />
+          <StatCard label="Open Cases" value={overview?.open_case_count ?? 0} tone="info" />
+          <StatCard label="Escalated" value={overview?.escalated_case_count ?? 0} tone="danger" />
+        </StatGrid>
+        <StatusLine>{status}</StatusLine>
+      </Panel>
+
+      <Panel span={12} eyebrow="Queue Discipline">
+        <div className="hx-tag-row">
+          <Tag>priority = attention &gt; severity &gt; corroboration &gt; freshness &gt; trust &gt; density</Tag>
+          <Tag>ties break on latest signal, then case id</Tag>
+          <Tag>top case: {cases[0]?.case.id ?? "none"}</Tag>
         </div>
-        <p className="status-line">{status}</p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <p className="mono-label">Queue Discipline</p>
-        <div className="pill-row">
-          <span className="info-pill">priority = attention &gt; severity &gt; corroboration &gt; freshness &gt; trust &gt; density</span>
-          <span className="info-pill">ties break on latest signal, then case id</span>
-          <span className="info-pill">top case: {cases[0]?.case.id ?? "none"}</span>
-        </div>
-      </article>
-
-      <article className="panel panel-span-12">
-        <p className="mono-label">Queue Filters</p>
-        <div className="form-grid">
-          <label className="field">
-            <span>Status</span>
-            <select
+      <Panel span={12} eyebrow="Queue Filters">
+        <FormGrid>
+          <FormField label="Status">
+            <Select
               value={statusFilter}
               onChange={(event) => setStatusFilter(event.target.value as CaseStatus | "all")}
             >
@@ -260,11 +249,10 @@ export function CasesPage() {
               <option value="brief_ready">brief_ready</option>
               <option value="escalated">escalated</option>
               <option value="closed">closed</option>
-            </select>
-          </label>
-          <label className="field">
-            <span>Severity</span>
-            <select
+            </Select>
+          </FormField>
+          <FormField label="Severity">
+            <Select
               value={severityFilter}
               onChange={(event) =>
                 setSeverityFilter(event.target.value as WatchlistSeverity | "all")
@@ -275,27 +263,24 @@ export function CasesPage() {
               <option value="high">high</option>
               <option value="medium">medium</option>
               <option value="low">low</option>
-            </select>
-          </label>
-          <label className="field">
-            <span>Watchlist Id</span>
-            <input
+            </Select>
+          </FormField>
+          <FormField label="Watchlist Id">
+            <Input
               value={watchlistFilter}
               onChange={(event) => setWatchlistFilter(event.target.value)}
               placeholder="watch_pricing_competitors"
             />
-          </label>
-          <label className="field">
-            <span>Primary Entity</span>
-            <input
+          </FormField>
+          <FormField label="Primary Entity">
+            <Input
               value={entityFilter}
               onChange={(event) => setEntityFilter(event.target.value)}
               placeholder="orion dynamics"
             />
-          </label>
-          <label className="field">
-            <span>Limit</span>
-            <select
+          </FormField>
+          <FormField label="Limit">
+            <Select
               value={limitFilter}
               onChange={(event) => setLimitFilter(event.target.value)}
             >
@@ -304,113 +289,114 @@ export function CasesPage() {
               <option value="50">50</option>
               <option value="100">100</option>
               <option value="all">all</option>
-            </select>
-          </label>
-        </div>
-        <div className="button-row">
-          <button className="btn-secondary" type="button" onClick={applyFilters}>
+            </Select>
+          </FormField>
+        </FormGrid>
+        <div className="hx-cluster">
+          <Button variant="secondary" type="button" onClick={applyFilters}>
             Apply Filters
-          </button>
-          <button className="btn-secondary" type="button" onClick={resetFilters}>
+          </Button>
+          <Button variant="secondary" type="button" onClick={resetFilters}>
             Reset
-          </button>
+          </Button>
         </div>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <p className="mono-label">Saved Views</p>
-        <div className="form-grid">
-          <label className="field field-full">
-            <span>view_name</span>
-            <input
+      <Panel span={12} eyebrow="Saved Views">
+        <FormGrid>
+          <FormField label="view_name" full>
+            <Input
               value={savedViewName}
               onChange={(event) => setSavedViewName(event.target.value)}
               placeholder="critical-watchlists"
             />
-          </label>
-        </div>
-        <div className="button-row">
-          <button className="btn-secondary" type="button" onClick={saveCurrentView}>
+          </FormField>
+        </FormGrid>
+        <div className="hx-cluster">
+          <Button variant="secondary" type="button" onClick={saveCurrentView}>
             Save Current View
-          </button>
-          <button className="btn-secondary" type="button" onClick={clearWorkspace}>
+          </Button>
+          <Button variant="secondary" type="button" onClick={clearWorkspace}>
             Clear Local Workspace
-          </button>
+          </Button>
         </div>
         {savedViews.length === 0 ? (
-          <p className="panel-note">No saved case views yet.</p>
+          <p className="hx-table-empty">No saved case views yet.</p>
         ) : (
-          <div className="command-stack">
+          <div className="hx-list">
             {savedViews.map((view) => (
-              <div key={view.id} className="command-row">
-                <div className="agent-card-head">
+              <div key={view.id} className="hx-row">
+                <div className="hx-card-head">
                   <h3>{view.name}</h3>
-                  <span className={`status-pill ${activeViewId === view.id ? "ok" : "info"}`}>
+                  <Badge tone={activeViewId === view.id ? "ok" : "info"}>
                     {activeViewId === view.id ? "active" : "saved"}
-                  </span>
+                  </Badge>
                 </div>
-                <code>{describeFilters(view.filters)}</code>
-                <div className="button-row">
-                  <button
-                    className="btn-secondary"
+                <code className="hx-mono-detail">{describeFilters(view.filters)}</code>
+                <div className="hx-cluster">
+                  <Button
+                    variant="secondary"
                     type="button"
                     onClick={() => applySavedView(view)}
                   >
                     Apply
-                  </button>
-                  <button
-                    className="btn-secondary"
+                  </Button>
+                  <Button
+                    variant="secondary"
                     type="button"
                     onClick={() => deleteSavedView(view)}
                   >
                     Delete
-                  </button>
+                  </Button>
                 </div>
               </div>
             ))}
           </div>
         )}
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <p className="mono-label">Case Files</p>
-        <div className="agent-grid">
+      <Panel span={12} eyebrow="Case Files">
+        <div className="hx-card-grid">
           {cases.map((entry, index) => (
-            <div key={entry.case.id} className="agent-card">
-              <div className="agent-card-head">
+            <div key={entry.case.id} className="hx-card">
+              <div className="hx-card-head">
                 <h3>
                   #{index + 1} {entry.case.title}
                 </h3>
-                <span className={`status-pill ${statusClass(entry.case.status)}`}>{entry.case.status}</span>
+                <Badge tone={statusClass(entry.case.status) as "ok" | "warn" | "danger"}>
+                  {entry.case.status}
+                </Badge>
               </div>
-              <p>{entry.case.latest_reason}</p>
-              <div className="pill-row">
-                <span className="info-pill">{priorityLabel(entry.priority)}</span>
-                <span className={`status-pill ${severityClass(entry.severity)}`}>{entry.severity}</span>
-                <span className="info-pill">{entry.watchlist_name}</span>
-                <span className="info-pill">latest: {entry.latest_signal_at ?? "unknown"}</span>
+              <p className="hx-description">{entry.case.latest_reason}</p>
+              <div className="hx-tag-row">
+                <Tag>{priorityLabel(entry.priority)}</Tag>
+                <Badge tone={severityClass(entry.severity) as "ok" | "warn" | "danger" | "info"}>
+                  {entry.severity}
+                </Badge>
+                <Tag>{entry.watchlist_name}</Tag>
+                <Tag>latest: {entry.latest_signal_at ?? "unknown"}</Tag>
               </div>
-              <p className="mono-detail">{entry.case.id}</p>
-              <div className="command-stack">
-                <code className="command-inline">watchlist_id: {entry.case.watchlist_id}</code>
-                <code className="command-inline">primary_entity: {entry.case.primary_entity ?? "none"}</code>
-                <code className="command-inline">evidence_ids: {entry.case.evidence_ids.join(", ")}</code>
-                <code className="command-inline">claim_ids: {entry.case.claim_ids.join(", ")}</code>
-                <code className="command-inline">
+              <p className="hx-mono-detail">{entry.case.id}</p>
+              <div className="hx-stack">
+                <code className="hx-mono-detail">watchlist_id: {entry.case.watchlist_id}</code>
+                <code className="hx-mono-detail">primary_entity: {entry.case.primary_entity ?? "none"}</code>
+                <code className="hx-mono-detail">evidence_ids: {entry.case.evidence_ids.join(", ")}</code>
+                <code className="hx-mono-detail">claim_ids: {entry.case.claim_ids.join(", ")}</code>
+                <code className="hx-mono-detail">
                   briefing_summary: {entry.case.briefing_summary ?? "not attached"}
                 </code>
               </div>
-              <div className="button-row">
-                <button
-                  className="btn-secondary"
+              <div className="hx-cluster">
+                <Button
+                  variant="secondary"
                   onClick={() =>
                     void applyTransition(entry.case.id, { type: "mark_monitoring" }, "Marking")
                   }
                 >
                   Monitoring
-                </button>
-                <button
-                  className="btn-secondary"
+                </Button>
+                <Button
+                  variant="secondary"
                   onClick={() =>
                     void applyTransition(
                       entry.case.id,
@@ -420,9 +406,9 @@ export function CasesPage() {
                   }
                 >
                   Attach Brief
-                </button>
-                <button
-                  className="btn-secondary"
+                </Button>
+                <Button
+                  variant="secondary"
                   onClick={() =>
                     void applyTransition(
                       entry.case.id,
@@ -432,15 +418,15 @@ export function CasesPage() {
                   }
                 >
                   Escalate
-                </button>
-                <button
-                  className="btn-secondary"
+                </Button>
+                <Button
+                  variant="secondary"
                   onClick={() => void applyTransition(entry.case.id, { type: "close" }, "Closing")}
                 >
                   Close
-                </button>
-                <button
-                  className="btn-secondary"
+                </Button>
+                <Button
+                  variant="secondary"
                   onClick={() =>
                     void applyTransition(
                       entry.case.id,
@@ -450,12 +436,12 @@ export function CasesPage() {
                   }
                 >
                   Reopen
-                </button>
+                </Button>
               </div>
             </div>
           ))}
         </div>
-      </article>
+      </Panel>
     </section>
   );
 }

--- a/ui/src/screens/CredentialsPage.tsx
+++ b/ui/src/screens/CredentialsPage.tsx
@@ -5,6 +5,17 @@ import {
   fetchCredentials,
   upsertCredential,
 } from "../lib/api";
+import {
+  Panel,
+  FormField,
+  Input,
+  Textarea,
+  Select,
+  Button,
+  Badge,
+  Tag,
+  StatusLine,
+} from "../components";
 
 const DEFAULT_PROFILE_ID = "50000000-0000-0000-0000-000000000010";
 const DEFAULT_METADATA = JSON.stringify({ provider: "github", scope: "repo:read" }, null, 2);
@@ -16,7 +27,6 @@ function parseMetadata(value: string): Record<string, string> {
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
     throw new Error("metadata must be a JSON object");
   }
-
   const metadata: Record<string, string> = {};
   for (const [key, item] of Object.entries(parsed)) {
     if (typeof item !== "string") {
@@ -124,142 +134,118 @@ export function CredentialsPage() {
   }
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel panel-hero panel-span-12">
-        <p className="mono-label">Credential Vault</p>
-        <h2>Encrypted Access Material With Redacted Operator Views</h2>
-        <p>
-          Store connector credentials behind the same profile boundary used by recipes, agents, and
-          deterministic automation.
+    <section className="hx-page-grid">
+      <Panel hero span={12} eyebrow="Credential Vault" title="Encrypted Access Material With Redacted Operator Views">
+        <p className="hx-description">
+          Store connector credentials behind the same profile boundary used by recipes,
+          agents, and deterministic automation.
         </p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-5">
-        <div className="panel-toolbar">
-          <div>
-            <p className="mono-label">Vault Write</p>
-            <p className="status-line">{status}</p>
-          </div>
-          <span className={`status-pill ${persistenceEnabled ? "ok" : "warn"}`}>
-            {persistenceEnabled ? "durable" : "disabled"}
-          </span>
-        </div>
+      <Panel
+        span={5}
+        eyebrow="Vault Write"
+        title="Save Credential"
+        actions={<Badge tone={persistenceEnabled ? "ok" : "warn"}>{persistenceEnabled ? "durable" : "disabled"}</Badge>}
+      >
+        <form className="hx-form-grid" onSubmit={onSubmit}>
+          <FormField label="Profile ID" full>
+            <Input value={profileId} onChange={(e) => setProfileId(e.target.value)} />
+          </FormField>
 
-        <form className="form-grid" onSubmit={onSubmit}>
-          <label className="field field-full">
-            <span>profile_id</span>
-            <input value={profileId} onChange={(event) => setProfileId(event.target.value)} />
-          </label>
+          <FormField label="Name">
+            <Input value={name} onChange={(e) => setName(e.target.value)} />
+          </FormField>
 
-          <label className="field">
-            <span>name</span>
-            <input value={name} onChange={(event) => setName(event.target.value)} />
-          </label>
-
-          <label className="field">
-            <span>kind</span>
-            <select value={kind} onChange={(event) => setKind(event.target.value)}>
+          <FormField label="Kind">
+            <Select value={kind} onChange={(e) => setKind(e.target.value)}>
               <option value="api_key">api_key</option>
               <option value="oauth2">oauth2</option>
               <option value="bearer_token">bearer_token</option>
               <option value="webhook_secret">webhook_secret</option>
-            </select>
-          </label>
+            </Select>
+          </FormField>
 
-          <label className="field field-full">
-            <span>secret</span>
-            <input
+          <FormField label="Secret" full>
+            <Input
               type="password"
               autoComplete="off"
               value={secret}
-              onChange={(event) => setSecret(event.target.value)}
+              onChange={(e) => setSecret(e.target.value)}
+              placeholder="paste secret"
             />
-          </label>
+          </FormField>
 
-          <label className="field field-full">
-            <span>metadata_json</span>
-            <textarea
-              rows={5}
-              value={metadataText}
-              onChange={(event) => setMetadataText(event.target.value)}
-            />
-          </label>
+          <FormField label="Metadata JSON" full>
+            <Textarea rows={5} value={metadataText} onChange={(e) => setMetadataText(e.target.value)} />
+          </FormField>
 
-          <div className="button-row field-full">
-            <button className="btn-primary" type="submit" disabled={submitting}>
-              {submitting ? "Saving" : "Save Credential"}
-            </button>
-            <button
-              className="btn-secondary"
-              type="button"
-              onClick={() => void loadCredentials(profileId)}
-            >
+          <div className="hx-cluster" style={{ gridColumn: "1 / -1" }}>
+            <Button type="submit" disabled={submitting}>
+              {submitting ? "Saving..." : "Save Credential"}
+            </Button>
+            <Button variant="secondary" type="button" onClick={() => void loadCredentials(profileId)}>
               Refresh
-            </button>
+            </Button>
           </div>
         </form>
 
-        <div className="pill-row">
+        <div className="hx-tag-row" style={{ marginTop: "var(--hx-space-3)" }}>
           {metadataKeys.length === 0 ? (
-            <span className="info-pill">metadata: none</span>
+            <Tag>metadata: none</Tag>
           ) : (
             metadataKeys.map((key) => (
-              <span key={key} className="info-pill">
-                metadata: {key}
-              </span>
+              <Tag key={key}>metadata: {key}</Tag>
             ))
           )}
         </div>
-      </article>
+        <StatusLine>{status}</StatusLine>
+      </Panel>
 
-      <article className="panel panel-span-7">
-        <div className="panel-toolbar">
-          <div>
-            <p className="mono-label">Redacted Credentials</p>
-            <p className="status-line">profile: {profileId || "unset"}</p>
-          </div>
-          <span className="status-pill info">{credentials.length} record(s)</span>
-        </div>
-
-        <div className="agent-grid">
-          {credentials.length === 0 ? (
-            <p className="panel-note">No credential metadata is available for this profile.</p>
-          ) : (
-            credentials.map((entry) => (
-              <div key={entry.id} className="agent-card">
-                <div className="agent-card-head">
+      <Panel
+        span={7}
+        eyebrow="Stored"
+        title="Redacted Credentials"
+        actions={<Badge tone="info">{credentials.length} record(s)</Badge>}
+      >
+        <StatusLine>profile: {profileId || "unset"}</StatusLine>
+        {credentials.length === 0 ? (
+          <div className="hx-table-empty"><p>No credential metadata is available for this profile.</p></div>
+        ) : (
+          <div className="hx-card-grid">
+            {credentials.map((entry) => (
+              <div key={entry.id} className="hx-card">
+                <div className="hx-card-head">
                   <h3>{entry.name}</h3>
-                  <span className="status-pill ok">redacted</span>
+                  <Badge tone="ok">redacted</Badge>
                 </div>
-                <p className="mono-detail">{entry.id}</p>
-                <div className="pill-row">
-                  <span className="info-pill">kind: {entry.kind}</span>
-                  <span className="info-pill">{createdLabel(entry)}</span>
+                <p className="hx-mono-detail">{entry.id}</p>
+                <div className="hx-tag-row">
+                  <Tag>kind: {entry.kind}</Tag>
+                  <Tag>{createdLabel(entry)}</Tag>
                 </div>
-                <div className="pill-row">
+                <div className="hx-tag-row">
                   {Object.keys(entry.metadata).length === 0 ? (
-                    <span className="tag-chip">metadata: none</span>
+                    <Tag>metadata: none</Tag>
                   ) : (
                     Object.entries(entry.metadata).map(([key, value]) => (
-                      <span key={key} className="tag-chip">
-                        {key}: {value}
-                      </span>
+                      <Tag key={key}>{key}: {value}</Tag>
                     ))
                   )}
                 </div>
-                <button
-                  className="btn-secondary"
+                <Button
+                  variant="danger"
                   type="button"
                   disabled={deletingId === entry.id}
                   onClick={() => void onDelete(entry)}
                 >
-                  {deletingId === entry.id ? "Deleting" : "Delete"}
-                </button>
+                  {deletingId === entry.id ? "Deleting..." : "Delete"}
+                </Button>
               </div>
-            ))
-          )}
-        </div>
-      </article>
+            ))}
+          </div>
+        )}
+      </Panel>
     </section>
   );
 }

--- a/ui/src/screens/DashboardPage.tsx
+++ b/ui/src/screens/DashboardPage.tsx
@@ -7,41 +7,46 @@ import {
   fetchIntelOverview,
   fetchMarketIntelOverview,
 } from "../lib/api";
+import { Panel, StatCard, StatGrid, Badge } from "../components";
 
 const lanes = [
-  { name: "Formal Kernel", status: "NOMINAL", note: "FSM transitions + invariants" },
-  { name: "Imperative Shell", status: "NOMINAL", note: "Effects behind execution port" },
-  { name: "Source Registry", status: "NOMINAL", note: "Trust-scored collectors" },
-  { name: "Evidence Pipeline", status: "DEGRADED", note: "High latency detected", classOverride: "warning" },
-  { name: "Case Lifecycle", status: "NOMINAL", note: "Deterministic state flow" },
-  { name: "Market Intel View", status: "NOMINAL", note: "Pricing & launch metrics" },
-  { name: "Onchain Shell", status: "NOMINAL", note: "EVM intent side-effects" },
-  { name: "Autopilot Guard", status: "NOMINAL", note: "LLM fail-closed gate" },
-];
+  { name: "Formal Kernel", status: "NOMINAL", note: "FSM transitions + invariants", tone: "ok" },
+  { name: "Imperative Shell", status: "NOMINAL", note: "Effects behind execution port", tone: "ok" },
+  { name: "Source Registry", status: "NOMINAL", note: "Trust-scored collectors", tone: "ok" },
+  { name: "Evidence Pipeline", status: "DEGRADED", note: "High latency detected", tone: "warn" },
+  { name: "Case Lifecycle", status: "NOMINAL", note: "Deterministic state flow", tone: "ok" },
+  { name: "Market Intel View", status: "NOMINAL", note: "Pricing & launch metrics", tone: "ok" },
+  { name: "Onchain Shell", status: "NOMINAL", note: "EVM intent side-effects", tone: "ok" },
+  { name: "Autopilot Guard", status: "NOMINAL", note: "LLM fail-closed gate", tone: "ok" },
+] as const;
 
 const controls = [
-  { title: "VERIFY_CORE", command: "./scripts/verify_formal_core.sh" },
-  { title: "VERIFY_AGENTS", command: "./scripts/verify_formal_agents.sh" },
-  { title: "SYNC_SOURCES", command: "GET /api/v1/sources" },
-  { title: "INGEST_EVIDENCE", command: "POST /api/v1/evidence/ingest" },
-  { title: "POLL_CASES", command: "GET /api/v1/cases" },
-  { title: "DRY_RUN", command: "POST /api/v1/onchain/send_raw ?dry_run=1" },
+  { title: "Verify Core", command: "./scripts/verify_formal_core.sh" },
+  { title: "Verify Agents", command: "./scripts/verify_formal_agents.sh" },
+  { title: "Sync Sources", command: "GET /api/v1/sources" },
+  { title: "Ingest Evidence", command: "POST /api/v1/evidence/ingest" },
+  { title: "Poll Cases", command: "GET /api/v1/cases" },
+  { title: "Dry Run Tx", command: "POST /api/v1/onchain/send_raw?dry_run=1" },
 ];
 
-const fallbackAgents = [
-  { name: "Dedup Window", value: "Dup stream suppression" },
-  { name: "Token Bucket", value: "Rate limit admissions" },
-  { name: "Circuit Breaker", value: "TRIPPED: Auth rate exceeded", classOverride: "danger" },
-  { name: "Retry Budget", value: "Bounded loop control" },
-  { name: "Approval Gate", value: "Quorum auth gate" },
-  { name: "Backpressure", value: "Queue shedder" },
-  { name: "SLA Deadline", value: "Track expiry ticks" },
-  { name: "DLQ Budget", value: "Dead-letter router" },
-  { name: "Tx Intent", value: "EVM submission intent" },
-  { name: "Nonce Manager", value: "Collision / replay guard" },
-  { name: "Fee Bidding", value: "Deterministic EVM bump" },
-  { name: "Finality Guard", value: "Reorg / depth gate" },
-  { name: "Allowlist Guard", value: "Contract access wall" },
+type AgentTone = "ok" | "danger";
+
+type FeaturedAgent = { name: string; value: string; tone: AgentTone };
+
+const fallbackAgents: FeaturedAgent[] = [
+  { name: "Dedup Window", value: "Dup stream suppression", tone: "ok" },
+  { name: "Token Bucket", value: "Rate limit admissions", tone: "ok" },
+  { name: "Circuit Breaker", value: "Tripped: auth rate exceeded", tone: "danger" },
+  { name: "Retry Budget", value: "Bounded loop control", tone: "ok" },
+  { name: "Approval Gate", value: "Quorum auth gate", tone: "ok" },
+  { name: "Backpressure", value: "Queue shedder", tone: "ok" },
+  { name: "SLA Deadline", value: "Track expiry ticks", tone: "ok" },
+  { name: "DLQ Budget", value: "Dead-letter router", tone: "ok" },
+  { name: "Tx Intent", value: "EVM submission intent", tone: "ok" },
+  { name: "Nonce Manager", value: "Collision / replay guard", tone: "ok" },
+  { name: "Fee Bidding", value: "Deterministic EVM bump", tone: "ok" },
+  { name: "Finality Guard", value: "Reorg / depth gate", tone: "ok" },
+  { name: "Allowlist Guard", value: "Contract access wall", tone: "ok" },
 ];
 
 const reasoningModes = [
@@ -51,20 +56,20 @@ const reasoningModes = [
   { name: "Neuro-Symbolic", note: "Fused logic gate" },
 ];
 
-function pickFeaturedAgents(catalog: DeterministicAgentSpec[]) {
+function pickFeaturedAgents(catalog: DeterministicAgentSpec[]): FeaturedAgent[] {
   if (catalog.length >= 10) {
     return catalog.slice(0, 13).map((agent) => ({
       name: agent.name,
       value: agent.roi_rationale,
-      classOverride: undefined
+      tone: "ok" as AgentTone,
     }));
   }
-  return fallbackAgents as any[];
+  return fallbackAgents;
 }
 
 export function DashboardPage() {
   const [agentClassCount, setAgentClassCount] = useState<number>(fallbackAgents.length);
-  const [featuredAgents, setFeaturedAgents] = useState(fallbackAgents);
+  const [featuredAgents, setFeaturedAgents] = useState<typeof fallbackAgents>(fallbackAgents);
   const [topCases, setTopCases] = useState<CaseQueueEntry[]>([]);
   const [huginnBaseline, setHuginnBaseline] = useState<number>(68);
   const [sourceCount, setSourceCount] = useState<number>(0);
@@ -105,139 +110,109 @@ export function DashboardPage() {
   }, []);
 
   return (
-    <section className="hud-grid">
+    <section className="hx-page-grid">
+      <Panel hero span={12} eyebrow="Overview" title="System Readout">
+        <p className="hx-description">
+          Helix is a self-hosted intelligence desk with deterministic policy gates,
+          replayable evidence, and guarded autopilot. LLMs propose; deterministic
+          kernels decide.
+        </p>
+        <StatGrid>
+          <StatCard label="Sources" value={sourceCount} />
+          <StatCard label="Evidence" value={evidenceCount} />
+          <StatCard label="Watchlists" value={watchlistCount} />
+          <StatCard label="Open Cases" value={openCaseCount} tone="accent" />
+          <StatCard label="Escalated" value={escalatedCaseCount} tone="danger" />
+          <StatCard label="Agent Classes" value={agentClassCount} />
+          <StatCard label="Market Tracked" value={trackedCompanyCount} />
+          <StatCard label="vs Huginn" value={`${superiorityRatio}x`} tone="info" sublabel={`${huginnBaseline} baseline`} />
+        </StatGrid>
+      </Panel>
 
-      {/* GLOBAL TELEMETRY BAR */}
-      <article className="tac-panel span-12">
-        <div className="panel-header">
-          <span className="panel-title">SYS.OVERVIEW [GLOBAL_READOUT]</span>
-        </div>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', gap: '8px' }}>
-          <div className="data-block">
-            <span className="d-label">NET.SOURCES</span>
-            <span className="d-value">{sourceCount}</span>
-          </div>
-          <div className="data-block">
-            <span className="d-label">EVIDENCE.VOL</span>
-            <span className="d-value">{evidenceCount}</span>
-          </div>
-          <div className="data-block">
-            <span className="d-label">WATCH.RULES</span>
-            <span className="d-value">{watchlistCount}</span>
-          </div>
-          <div className="data-block">
-            <span className="d-label">CASES.OPEN</span>
-            <span className="d-value highlight">{openCaseCount}</span>
-          </div>
-          <div className="data-block">
-            <span className="d-label">CASES.ESCALATED</span>
-            <span className="d-value danger">{escalatedCaseCount}</span>
-          </div>
-          <div className="data-block">
-            <span className="d-label">AGENT.CLASSES</span>
-            <span className="d-value">{agentClassCount}</span>
-          </div>
-          <div className="data-block">
-            <span className="d-label">MKT.TRACKED</span>
-            <span className="d-value">{trackedCompanyCount}</span>
-          </div>
-          <div className="data-block">
-            <span className="d-label">SUPERIORITY_RX</span>
-            <span className="d-value alert">{superiorityRatio}x</span>
-          </div>
-        </div>
-      </article>
-
-      {/* SYSTEM LANES */}
-      <article className="tac-panel span-4">
-        <div className="panel-header">
-          <span className="panel-title">SYS.LANES [RTE]</span>
-        </div>
-        <div className="tac-list">
-          {lanes.map((lane: any) => (
-            <div key={lane.name} className={`tac-row ${lane.classOverride || 'healthy'}`}>
-              <span className="row-primary">{lane.name}</span>
-              <span className="row-secondary">[{lane.status}]</span>
-            </div>
-          ))}
-        </div>
-      </article>
-
-      {/* REASONING BACKENDS */}
-      <article className="tac-panel span-4">
-        <div className="panel-header">
-          <span className="panel-title">SYS.REASONING [MODES]</span>
-        </div>
-        <div className="tac-list">
-          {reasoningModes.map((mode) => (
-            <div key={mode.name} className="tac-row healthy">
-              <span className="row-primary">{mode.name}</span>
-              <span className="row-secondary">DETERMINISTIC</span>
-            </div>
-          ))}
-        </div>
-        <br />
-        <p>Models are strictly gated. All evaluations must pass the explicit threshold boundaries without hidden prompt drift.</p>
-      </article>
-
-      {/* CONTROL EXEC */}
-      <article className="tac-panel span-4">
-        <div className="panel-header">
-          <span className="panel-title">SYS.CMD [QUICK_EXEC]</span>
-        </div>
-        <div className="tac-list" style={{ gap: '8px' }}>
-          {controls.map((item) => (
-            <div key={item.title}>
-              <span className="d-label" style={{ display: 'block', marginBottom: '2px' }}>&gt; {item.title}</span>
-              <pre className="tac-term">{item.command}</pre>
-            </div>
-          ))}
-        </div>
-      </article>
-
-      <article className="tac-panel span-12">
-        <div className="panel-header">
-          <span className="panel-title">SYS.CASES [TRIAGE_QUEUE]</span>
-        </div>
-        <div className="tac-list">
-          {topCases.length > 0 ? (
-            topCases.map((entry, index) => (
-              <div key={entry.case.id} className="tac-row alert" style={{ flexDirection: "column", alignItems: "flex-start", gap: "4px" }}>
-                <span className="row-primary">
-                  #{index + 1} {entry.case.title}
-                </span>
-                <span className="row-secondary">
-                  {entry.case.status} | {entry.severity} | score {entry.priority.total}
-                </span>
-                <span className="row-secondary">
-                  {entry.watchlist_name} | latest {entry.latest_signal_at ?? "unknown"}
-                </span>
+      <Panel span={4} eyebrow="Runtime" title="System Lanes">
+        <div className="hx-list">
+          {lanes.map((lane) => (
+            <div key={lane.name} className={`hx-row hx-row--${lane.tone}`}>
+              <div className="hx-row-stack">
+                <span className="hx-row-primary">{lane.name}</span>
+                <span className="hx-row-secondary">{lane.note}</span>
               </div>
-            ))
-          ) : (
-            <div className="tac-row healthy">
-              <span className="row-primary">CASE.QUEUE</span>
-              <span className="row-secondary">No ranked cases available</span>
-            </div>
-          )}
-        </div>
-      </article>
-
-      {/* FEATURED AGENT SUBSTRATE */}
-      <article className="tac-panel span-12">
-        <div className="panel-header">
-          <span className="panel-title">SYS.AGENTS [ROI_KERNELS]</span>
-        </div>
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '8px' }}>
-          {featuredAgents.map((agent: any) => (
-            <div key={agent.name} className={`tac-row ${agent.classOverride || 'healthy'}`} style={{ flexDirection: 'column', alignItems: 'flex-start', borderLeftWidth: '4px' }}>
-              <span className="row-primary">{agent.name}</span>
-              <span className="row-secondary" style={{ marginTop: '4px' }}>{agent.value}</span>
+              <Badge tone={lane.tone === "warn" ? "warn" : "ok"}>{lane.status}</Badge>
             </div>
           ))}
         </div>
-      </article>
+      </Panel>
 
+      <Panel span={4} eyebrow="Backends" title="Reasoning Modes">
+        <div className="hx-list">
+          {reasoningModes.map((mode) => (
+            <div key={mode.name} className="hx-row hx-row--ok">
+              <div className="hx-row-stack">
+                <span className="hx-row-primary">{mode.name}</span>
+                <span className="hx-row-secondary">{mode.note}</span>
+              </div>
+              <Badge tone="info">DETERMINISTIC</Badge>
+            </div>
+          ))}
+        </div>
+        <p className="hx-description" style={{ marginTop: "var(--hx-space-3)" }}>
+          Models are strictly gated. All evaluations must pass explicit threshold
+          boundaries without hidden prompt drift.
+        </p>
+      </Panel>
+
+      <Panel span={4} eyebrow="Quick Exec" title="Commands">
+        <div className="hx-list">
+          {controls.map((item) => (
+            <div key={item.title} className="hx-row">
+              <div className="hx-row-stack">
+                <span className="hx-row-primary">{item.title}</span>
+                <code className="hx-mono-detail">{item.command}</code>
+              </div>
+            </div>
+          ))}
+        </div>
+      </Panel>
+
+      <Panel span={12} eyebrow="Triage" title="Case Queue" actions={<Badge tone="accent">{topCases.length} ranked</Badge>}>
+        {topCases.length > 0 ? (
+          <div className="hx-card-grid">
+            {topCases.map((entry, index) => (
+              <div key={entry.case.id} className="hx-card">
+                <div className="hx-card-head">
+                  <h3>#{index + 1} {entry.case.title}</h3>
+                  <Badge tone={entry.severity === "critical" || entry.severity === "high" ? "danger" : entry.severity === "medium" ? "warn" : "ok"}>
+                    {entry.severity}
+                  </Badge>
+                </div>
+                <div className="hx-card-body">
+                  <p className="hx-row-secondary">{entry.case.status} · score {entry.priority.total}</p>
+                  <p className="hx-mono-detail">{entry.watchlist_name}</p>
+                  <p className="hx-mono-detail">latest: {entry.latest_signal_at ?? "unknown"}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="hx-table-empty">
+            <p>No ranked cases available. The case queue is empty or the API is unreachable.</p>
+          </div>
+        )}
+      </Panel>
+
+      <Panel span={12} eyebrow="Substrate" title="Agent ROI Kernels" actions={<Badge tone="info">{agentClassCount} classes</Badge>}>
+        <div className="hx-card-grid">
+          {featuredAgents.map((agent) => (
+            <div key={agent.name} className={`hx-card${agent.tone === "danger" ? " hx-row--danger" : ""}`} style={{ borderLeftWidth: "3px" }}>
+              <div className="hx-card-head">
+                <h3>{agent.name}</h3>
+                {agent.tone === "danger" && <Badge tone="danger">TRIPPED</Badge>}
+              </div>
+              <p className="hx-row-secondary">{agent.value}</p>
+            </div>
+          ))}
+        </div>
+      </Panel>
     </section>
   );
 }

--- a/ui/src/screens/EvidencePage.tsx
+++ b/ui/src/screens/EvidencePage.tsx
@@ -24,6 +24,19 @@ import {
   makeSavedViewId,
   saveEvidenceDeskWorkspaceState,
 } from "../lib/intelDeskWorkspace";
+import {
+  Badge,
+  Button,
+  EmptyState,
+  FormField,
+  FormGrid,
+  Input,
+  Panel,
+  Select,
+  StatusLine,
+  Tag,
+  Textarea,
+} from "../components";
 
 const DEFAULT_CLAIMS: ProposedClaim[] = [
   {
@@ -421,128 +434,121 @@ export function EvidencePage() {
   }
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel panel-hero panel-span-12">
-        <p className="mono-label">Evidence Pipeline</p>
-        <h2>Ingest Signals, Rank Evidence, Triage Claims</h2>
-        <p>
+    <section className="hx-page-grid">
+      <Panel
+        hero
+        span={12}
+        eyebrow="Evidence Pipeline"
+        title="Ingest Signals, Rank Evidence, Triage Claims"
+      >
+        <p className="hx-description">
           Manual ingest stands in for collection jobs in this slice. Every submission becomes
           normalized evidence with provenance, bounded claims, watchlist hits, and case updates.
           Evidence and claims are now ranked through deterministic queue math instead of raw
           reverse-chronological lists.
         </p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-6">
-        <p className="mono-label">Ingest Evidence</p>
-        <form className="form-grid" onSubmit={onSubmit}>
-          <label className="field field-full">
-            <span>source_id</span>
-            <select value={sourceId} onChange={(e) => setSourceId(e.target.value)}>
+      <Panel span={6} eyebrow="Ingest Evidence">
+        <form className="hx-form-grid" onSubmit={onSubmit}>
+          <FormField label="source_id" full>
+            <Select value={sourceId} onChange={(e) => setSourceId(e.target.value)}>
               {sources.map((source) => (
                 <option key={source.id} value={source.id}>
                   {source.name}
                 </option>
               ))}
-            </select>
-          </label>
+            </Select>
+          </FormField>
 
-          <label className="field field-full">
-            <span>title</span>
-            <input value={title} onChange={(e) => setTitle(e.target.value)} />
-          </label>
+          <FormField label="title" full>
+            <Input value={title} onChange={(e) => setTitle(e.target.value)} />
+          </FormField>
 
-          <label className="field field-full">
-            <span>summary</span>
-            <textarea rows={3} value={summary} onChange={(e) => setSummary(e.target.value)} />
-          </label>
+          <FormField label="summary" full>
+            <Textarea rows={3} value={summary} onChange={(e) => setSummary(e.target.value)} />
+          </FormField>
 
-          <label className="field field-full">
-            <span>content</span>
-            <textarea rows={6} value={content} onChange={(e) => setContent(e.target.value)} />
-          </label>
+          <FormField label="content" full>
+            <Textarea rows={6} value={content} onChange={(e) => setContent(e.target.value)} />
+          </FormField>
 
-          <label className="field field-full">
-            <span>url</span>
-            <input value={url} onChange={(e) => setUrl(e.target.value)} />
-          </label>
+          <FormField label="url" full>
+            <Input value={url} onChange={(e) => setUrl(e.target.value)} />
+          </FormField>
 
-          <label className="field">
-            <span>observed_at</span>
-            <input value={observedAt} onChange={(e) => setObservedAt(e.target.value)} />
-          </label>
+          <FormField label="observed_at">
+            <Input value={observedAt} onChange={(e) => setObservedAt(e.target.value)} />
+          </FormField>
 
-          <label className="field field-full">
-            <span>tags</span>
-            <input value={tagsText} onChange={(e) => setTagsText(e.target.value)} />
-          </label>
+          <FormField label="tags" full>
+            <Input value={tagsText} onChange={(e) => setTagsText(e.target.value)} />
+          </FormField>
 
-          <label className="field field-full">
-            <span>entity_labels</span>
-            <input value={entitiesText} onChange={(e) => setEntitiesText(e.target.value)} />
-          </label>
+          <FormField label="entity_labels" full>
+            <Input value={entitiesText} onChange={(e) => setEntitiesText(e.target.value)} />
+          </FormField>
 
-          <label className="field field-full">
-            <span>proposed_claims</span>
-            <textarea
-              className="command-editor"
-              rows={8}
-              value={claimsText}
-              onChange={(e) => setClaimsText(e.target.value)}
-            />
-          </label>
+          <FormField label="proposed_claims" full>
+            <Textarea rows={8} value={claimsText} onChange={(e) => setClaimsText(e.target.value)} />
+          </FormField>
 
-          <button className="btn-primary" type="submit">
+          <Button variant="primary" type="submit">
             Ingest Evidence
-          </button>
+          </Button>
         </form>
-        <p className="status-line">{status}</p>
-      </article>
+        <StatusLine>{status}</StatusLine>
+      </Panel>
 
-      <article className="panel panel-span-6">
-        <p className="mono-label">Latest Ingest Result</p>
+      <Panel span={6} eyebrow="Latest Ingest Result">
         {lastResult ? (
-          <div className="stack-list">
-            <div>
-              <p className="panel-note">
+          <div className="hx-stack">
+            <div className="hx-card-section">
+              <p className="hx-mono-detail">
                 Evidence: <code>{lastResult.evidence.id}</code>
               </p>
-              <p className="panel-note">
+              <p className="hx-mono-detail">
                 Provenance hash: <code>{lastResult.evidence.provenance_hash}</code>
               </p>
             </div>
 
-            <div>
-              <p className="mono-label">Watchlist Hits</p>
+            <div className="hx-card-section">
+              <p className="hx-eyebrow">Watchlist Hits</p>
               {lastResult.hits.length === 0 ? (
-                <p className="panel-note">No watchlist conditions matched.</p>
+                <p className="hx-description">No watchlist conditions matched.</p>
               ) : (
-                <div className="command-stack">
+                <div className="hx-list">
                   {lastResult.hits.map((hit) => (
-                    <div key={`${hit.watchlist_id}-${hit.evidence_id}`} className="command-row">
+                    <div key={`${hit.watchlist_id}-${hit.evidence_id}`} className="hx-row">
                       <h3>{hit.watchlist_name}</h3>
-                      <code>severity: {hit.severity}</code>
-                      <code>reason: {hit.reason}</code>
-                      <code>keywords: {hit.matched_keywords.join(", ") || "none"}</code>
-                      <code>entities: {hit.matched_entities.join(", ") || "none"}</code>
+                      <code className="hx-mono-detail">severity: {hit.severity}</code>
+                      <code className="hx-mono-detail">reason: {hit.reason}</code>
+                      <code className="hx-mono-detail">
+                        keywords: {hit.matched_keywords.join(", ") || "none"}
+                      </code>
+                      <code className="hx-mono-detail">
+                        entities: {hit.matched_entities.join(", ") || "none"}
+                      </code>
                     </div>
                   ))}
                 </div>
               )}
             </div>
 
-            <div>
-              <p className="mono-label">Case Updates</p>
+            <div className="hx-card-section">
+              <p className="hx-eyebrow">Case Updates</p>
               {lastResult.case_updates.length === 0 ? (
-                <p className="panel-note">No case lifecycle changes were required.</p>
+                <p className="hx-description">No case lifecycle changes were required.</p>
               ) : (
-                <div className="command-stack">
+                <div className="hx-list">
                   {lastResult.case_updates.map((transition) => (
-                    <div key={transition.case.id} className="command-row">
+                    <div key={transition.case.id} className="hx-row">
                       <h3>{transition.case.title}</h3>
-                      <code>case_id: {transition.case.id}</code>
-                      <code>status: {transition.case.status}</code>
-                      <code>decision: {JSON.stringify(transition.decision)}</code>
+                      <code className="hx-mono-detail">case_id: {transition.case.id}</code>
+                      <code className="hx-mono-detail">status: {transition.case.status}</code>
+                      <code className="hx-mono-detail">
+                        decision: {JSON.stringify(transition.decision)}
+                      </code>
                     </div>
                   ))}
                 </div>
@@ -550,40 +556,35 @@ export function EvidencePage() {
             </div>
           </div>
         ) : (
-          <p>No ingest run yet.</p>
+          <EmptyState title="No ingest run yet." />
         )}
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-6">
-        <p className="mono-label">Evidence Filters</p>
-        <div className="form-grid">
-          <label className="field">
-            <span>source_id</span>
-            <input
+      <Panel span={6} eyebrow="Evidence Filters">
+        <FormGrid>
+          <FormField label="source_id">
+            <Input
               value={evidenceSourceFilter}
               onChange={(e) => setEvidenceSourceFilter(e.target.value)}
               placeholder="rss_national_security"
             />
-          </label>
-          <label className="field">
-            <span>tag</span>
-            <input
+          </FormField>
+          <FormField label="tag">
+            <Input
               value={evidenceTagFilter}
               onChange={(e) => setEvidenceTagFilter(e.target.value)}
               placeholder="security"
             />
-          </label>
-          <label className="field">
-            <span>entity</span>
-            <input
+          </FormField>
+          <FormField label="entity">
+            <Input
               value={evidenceEntityFilter}
               onChange={(e) => setEvidenceEntityFilter(e.target.value)}
               placeholder="alice north"
             />
-          </label>
-          <label className="field">
-            <span>linked_status</span>
-            <select
+          </FormField>
+          <FormField label="linked_status">
+            <Select
               value={evidenceLinkedStatusFilter}
               onChange={(e) =>
                 setEvidenceLinkedStatusFilter(e.target.value as CaseStatus | "all")
@@ -595,27 +596,24 @@ export function EvidencePage() {
               <option value="brief_ready">brief_ready</option>
               <option value="escalated">escalated</option>
               <option value="closed">closed</option>
-            </select>
-          </label>
-          <label className="field">
-            <span>min_trust</span>
-            <input
+            </Select>
+          </FormField>
+          <FormField label="min_trust">
+            <Input
               value={evidenceMinTrustFilter}
               onChange={(e) => setEvidenceMinTrustFilter(e.target.value)}
               placeholder="80"
             />
-          </label>
-          <label className="field field-full">
-            <span>q</span>
-            <input
+          </FormField>
+          <FormField label="q" full>
+            <Input
               value={evidenceQueryFilter}
               onChange={(e) => setEvidenceQueryFilter(e.target.value)}
               placeholder="orion leadership resignation"
             />
-          </label>
-          <label className="field">
-            <span>limit</span>
-            <select
+          </FormField>
+          <FormField label="limit">
+            <Select
               value={evidenceLimitFilter}
               onChange={(e) => setEvidenceLimitFilter(e.target.value)}
             >
@@ -625,25 +623,23 @@ export function EvidencePage() {
               <option value="50">50</option>
               <option value="100">100</option>
               <option value="all">all</option>
-            </select>
-          </label>
-        </div>
-        <div className="button-row">
-          <button className="btn-secondary" type="button" onClick={applyEvidenceFilters}>
+            </Select>
+          </FormField>
+        </FormGrid>
+        <div className="hx-cluster">
+          <Button variant="secondary" type="button" onClick={applyEvidenceFilters}>
             Apply Evidence Filters
-          </button>
-          <button className="btn-secondary" type="button" onClick={resetEvidenceFilters}>
+          </Button>
+          <Button variant="secondary" type="button" onClick={resetEvidenceFilters}>
             Reset
-          </button>
+          </Button>
         </div>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-6">
-        <p className="mono-label">Claim Filters</p>
-        <div className="form-grid">
-          <label className="field">
-            <span>review_status</span>
-            <select
+      <Panel span={6} eyebrow="Claim Filters">
+        <FormGrid>
+          <FormField label="review_status">
+            <Select
               value={claimReviewFilter}
               onChange={(e) =>
                 setClaimReviewFilter(e.target.value as ClaimReviewStatus | "all")
@@ -653,27 +649,24 @@ export function EvidencePage() {
               <option value="needs_review">needs_review</option>
               <option value="corroborated">corroborated</option>
               <option value="rejected">rejected</option>
-            </select>
-          </label>
-          <label className="field">
-            <span>subject</span>
-            <input
+            </Select>
+          </FormField>
+          <FormField label="subject">
+            <Input
               value={claimSubjectFilter}
               onChange={(e) => setClaimSubjectFilter(e.target.value)}
               placeholder="alice north"
             />
-          </label>
-          <label className="field">
-            <span>predicate</span>
-            <input
+          </FormField>
+          <FormField label="predicate">
+            <Input
               value={claimPredicateFilter}
               onChange={(e) => setClaimPredicateFilter(e.target.value)}
               placeholder="resigned_from"
             />
-          </label>
-          <label className="field">
-            <span>linked_status</span>
-            <select
+          </FormField>
+          <FormField label="linked_status">
+            <Select
               value={claimLinkedStatusFilter}
               onChange={(e) =>
                 setClaimLinkedStatusFilter(e.target.value as CaseStatus | "all")
@@ -685,27 +678,24 @@ export function EvidencePage() {
               <option value="brief_ready">brief_ready</option>
               <option value="escalated">escalated</option>
               <option value="closed">closed</option>
-            </select>
-          </label>
-          <label className="field">
-            <span>min_confidence_bps</span>
-            <input
+            </Select>
+          </FormField>
+          <FormField label="min_confidence_bps">
+            <Input
               value={claimMinConfidenceFilter}
               onChange={(e) => setClaimMinConfidenceFilter(e.target.value)}
               placeholder="8500"
             />
-          </label>
-          <label className="field field-full">
-            <span>q</span>
-            <input
+          </FormField>
+          <FormField label="q" full>
+            <Input
               value={claimQueryFilter}
               onChange={(e) => setClaimQueryFilter(e.target.value)}
               placeholder="leadership appointment"
             />
-          </label>
-          <label className="field">
-            <span>limit</span>
-            <select
+          </FormField>
+          <FormField label="limit">
+            <Select
               value={claimLimitFilter}
               onChange={(e) => setClaimLimitFilter(e.target.value)}
             >
@@ -715,172 +705,164 @@ export function EvidencePage() {
               <option value="50">50</option>
               <option value="100">100</option>
               <option value="all">all</option>
-            </select>
-          </label>
-        </div>
-        <div className="button-row">
-          <button className="btn-secondary" type="button" onClick={applyClaimFilters}>
+            </Select>
+          </FormField>
+        </FormGrid>
+        <div className="hx-cluster">
+          <Button variant="secondary" type="button" onClick={applyClaimFilters}>
             Apply Claim Filters
-          </button>
-          <button className="btn-secondary" type="button" onClick={resetClaimFilters}>
+          </Button>
+          <Button variant="secondary" type="button" onClick={resetClaimFilters}>
             Reset
-          </button>
+          </Button>
         </div>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <p className="mono-label">Saved Views</p>
-        <div className="form-grid">
-          <label className="field field-full">
-            <span>view_name</span>
-            <input
+      <Panel span={12} eyebrow="Saved Views">
+        <FormGrid>
+          <FormField label="view_name" full>
+            <Input
               value={savedViewName}
               onChange={(e) => setSavedViewName(e.target.value)}
               placeholder="high-trust-needs-review"
             />
-          </label>
-        </div>
-        <div className="button-row">
-          <button className="btn-secondary" type="button" onClick={saveCurrentView}>
+          </FormField>
+        </FormGrid>
+        <div className="hx-cluster">
+          <Button variant="secondary" type="button" onClick={saveCurrentView}>
             Save Current View
-          </button>
-          <button className="btn-secondary" type="button" onClick={clearWorkspace}>
+          </Button>
+          <Button variant="secondary" type="button" onClick={clearWorkspace}>
             Clear Local Workspace
-          </button>
+          </Button>
         </div>
         {savedViews.length === 0 ? (
-          <p className="panel-note">No saved evidence desk views yet.</p>
+          <p className="hx-description">No saved evidence desk views yet.</p>
         ) : (
-          <div className="command-stack">
+          <div className="hx-list">
             {savedViews.map((view) => (
-              <div key={view.id} className="command-row">
-                <div className="agent-card-head">
+              <div key={view.id} className="hx-card">
+                <div className="hx-card-head">
                   <h3>{view.name}</h3>
-                  <span className={`status-pill ${activeViewId === view.id ? "ok" : "info"}`}>
+                  <Badge tone={activeViewId === view.id ? "ok" : "info"}>
                     {activeViewId === view.id ? "active" : "saved"}
-                  </span>
+                  </Badge>
                 </div>
-                <code>evidence: {evidenceFilterSummary(view.evidenceFilters)}</code>
-                <code>claims: {claimFilterSummary(view.claimFilters)}</code>
-                <div className="button-row">
-                  <button
-                    className="btn-secondary"
-                    onClick={() => applySavedView(view)}
-                    type="button"
-                  >
+                <code className="hx-mono-detail">
+                  evidence: {evidenceFilterSummary(view.evidenceFilters)}
+                </code>
+                <code className="hx-mono-detail">
+                  claims: {claimFilterSummary(view.claimFilters)}
+                </code>
+                <div className="hx-cluster">
+                  <Button variant="secondary" onClick={() => applySavedView(view)} type="button">
                     Apply
-                  </button>
-                  <button
-                    className="btn-secondary"
-                    onClick={() => deleteSavedView(view)}
-                    type="button"
-                  >
+                  </Button>
+                  <Button variant="secondary" onClick={() => deleteSavedView(view)} type="button">
                     Delete
-                  </button>
+                  </Button>
                 </div>
               </div>
             ))}
           </div>
         )}
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-7">
-        <p className="mono-label">Ranked Evidence Queue</p>
-        <div className="agent-grid">
+      <Panel span={7} eyebrow="Ranked Evidence Queue">
+        <div className="hx-card-grid">
           {evidence.map((entry, index) => (
-            <div key={entry.evidence.id} className="agent-card">
-              <div className="agent-card-head">
+            <div key={entry.evidence.id} className="hx-card">
+              <div className="hx-card-head">
                 <h3>
                   #{index + 1} {entry.evidence.title}
                 </h3>
-                <span className={`status-pill ${severityClass(entry.max_linked_severity)}`}>
+                <Badge tone={severityClass(entry.max_linked_severity) as "ok" | "warn" | "danger" | "info"}>
                   {entry.max_linked_severity ?? "unlinked"}
-                </span>
+                </Badge>
               </div>
-              <p>{entry.evidence.summary || entry.evidence.content.slice(0, 140)}</p>
-              <div className="pill-row">
-                <span className="info-pill">{priorityLabel(entry.priority)}</span>
-                <span className="info-pill">{entry.source_name}</span>
-                <span className="info-pill">trust: {entry.source_trust_score}</span>
-                <span className="info-pill">observed: {entry.evidence.observed_at}</span>
+              <p className="hx-description">
+                {entry.evidence.summary || entry.evidence.content.slice(0, 140)}
+              </p>
+              <div className="hx-tag-row">
+                <Tag>{priorityLabel(entry.priority)}</Tag>
+                <Tag>{entry.source_name}</Tag>
+                <Tag>trust: {entry.source_trust_score}</Tag>
+                <Tag>observed: {entry.evidence.observed_at}</Tag>
                 {entry.semantic_score_bps != null ? (
-                  <span className="info-pill">semantic: {entry.semantic_score_bps}</span>
+                  <Tag>semantic: {entry.semantic_score_bps}</Tag>
                 ) : null}
               </div>
-              <div className="pill-row">
-                <span className="info-pill">linked_cases: {entry.linked_case_count}</span>
-                <span className="info-pill">linked_claims: {entry.linked_claim_count}</span>
-                <span className="info-pill">provenance: {entry.evidence.provenance_hash}</span>
+              <div className="hx-tag-row">
+                <Tag>linked_cases: {entry.linked_case_count}</Tag>
+                <Tag>linked_claims: {entry.linked_claim_count}</Tag>
+                <Tag>provenance: {entry.evidence.provenance_hash}</Tag>
               </div>
-              <div className="pill-row">
+              <div className="hx-tag-row">
                 {entry.evidence.tags.map((tag) => (
-                  <span key={tag} className="tag-chip">
-                    {tag}
-                  </span>
+                  <Tag key={tag}>{tag}</Tag>
                 ))}
               </div>
             </div>
           ))}
         </div>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-5">
-        <p className="mono-label">Ranked Claim Queue</p>
-        <div className="command-stack">
+      <Panel span={5} eyebrow="Ranked Claim Queue">
+        <div className="hx-list">
           {claims.map((entry) => (
-            <div key={entry.claim.id} className="command-row">
-              <div className="agent-card-head">
+            <div key={entry.claim.id} className="hx-row">
+              <div className="hx-card-head">
                 <h3>
                   {entry.claim.subject} {entry.claim.predicate} {entry.claim.object}
                 </h3>
-                <span className={`status-pill ${reviewStatusClass(entry.claim.review_status)}`}>
+                <Badge tone={reviewStatusClass(entry.claim.review_status) as "ok" | "warn" | "danger"}>
                   {entry.claim.review_status}
-                </span>
+                </Badge>
               </div>
-              <div className="pill-row">
-                <span className="info-pill">{priorityLabel(entry.priority)}</span>
-                <span className={`status-pill ${severityClass(entry.max_linked_severity)}`}>
+              <div className="hx-tag-row">
+                <Tag>{priorityLabel(entry.priority)}</Tag>
+                <Badge tone={severityClass(entry.max_linked_severity) as "ok" | "warn" | "danger" | "info"}>
                   {entry.max_linked_severity ?? "unlinked"}
-                </span>
-                <span className="info-pill">{entry.source_name}</span>
-                <span className="info-pill">trust: {entry.source_trust_score}</span>
+                </Badge>
+                <Tag>{entry.source_name}</Tag>
+                <Tag>trust: {entry.source_trust_score}</Tag>
                 {entry.semantic_score_bps != null ? (
-                  <span className="info-pill">semantic: {entry.semantic_score_bps}</span>
+                  <Tag>semantic: {entry.semantic_score_bps}</Tag>
                 ) : null}
               </div>
-              <code>{entry.claim.id}</code>
-              <code>confidence_bps: {entry.claim.confidence_bps}</code>
-              <code>evidence: {entry.evidence_title}</code>
-              <code>observed_at: {entry.evidence_observed_at}</code>
-              <code>linked_case_count: {entry.linked_case_count}</code>
-              <code>rationale: {entry.claim.rationale}</code>
-              <div className="button-row">
-                <button
-                  className="btn-secondary"
+              <code className="hx-mono-detail">{entry.claim.id}</code>
+              <code className="hx-mono-detail">confidence_bps: {entry.claim.confidence_bps}</code>
+              <code className="hx-mono-detail">evidence: {entry.evidence_title}</code>
+              <code className="hx-mono-detail">observed_at: {entry.evidence_observed_at}</code>
+              <code className="hx-mono-detail">linked_case_count: {entry.linked_case_count}</code>
+              <code className="hx-mono-detail">rationale: {entry.claim.rationale}</code>
+              <div className="hx-cluster">
+                <Button
+                  variant="secondary"
                   onClick={() => void applyReviewStatus(entry.claim.id, "corroborated")}
                   type="button"
                 >
                   Corroborate
-                </button>
-                <button
-                  className="btn-secondary"
+                </Button>
+                <Button
+                  variant="secondary"
                   onClick={() => void applyReviewStatus(entry.claim.id, "rejected")}
                   type="button"
                 >
                   Reject
-                </button>
-                <button
-                  className="btn-secondary"
+                </Button>
+                <Button
+                  variant="secondary"
                   onClick={() => void applyReviewStatus(entry.claim.id, "needs_review")}
                   type="button"
                 >
                   Reset
-                </button>
+                </Button>
               </div>
             </div>
           ))}
         </div>
-      </article>
+      </Panel>
     </section>
   );
 }

--- a/ui/src/screens/FederationPage.tsx
+++ b/ui/src/screens/FederationPage.tsx
@@ -1,0 +1,491 @@
+import { FormEvent, useEffect, useState } from "react";
+import {
+  PeerDesk,
+  DispatchLogEntry,
+  FederationOverview,
+  fetchFederationOverview,
+  fetchPeers,
+  upsertPeer,
+  deletePeer,
+  fetchDispatchLog,
+  manualBroadcast,
+} from "../lib/api";
+import {
+  Panel,
+  StatCard,
+  StatGrid,
+  Badge,
+  Button,
+  FormField,
+  Input,
+  Textarea,
+  CheckboxField,
+  DataTable,
+  EmptyState,
+  LoadingState,
+  ErrorState,
+  StatusLine,
+} from "../components";
+
+type BadgeTone = "default" | "ok" | "warn" | "danger" | "info" | "neutral" | "accent";
+
+function parseCsv(value: string): string[] {
+  return value
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function dispatchStatusTone(status: string): BadgeTone {
+  switch (status) {
+    case "delivered":
+      return "ok";
+    case "failed":
+      return "danger";
+    case "unreachable":
+      return "warn";
+    default:
+      return "neutral";
+  }
+}
+
+function trustTone(score: number): BadgeTone {
+  if (score >= 80) return "ok";
+  if (score >= 50) return "warn";
+  return "danger";
+}
+
+export function FederationPage() {
+  const [overview, setOverview] = useState<FederationOverview | null>(null);
+  const [peers, setPeers] = useState<PeerDesk[]>([]);
+  const [logEntries, setLogEntries] = useState<DispatchLogEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusMsg, setStatusMsg] = useState("");
+
+  // Form state for peer upsert
+  const [editingPeer, setEditingPeer] = useState<PeerDesk | null>(null);
+  const [peerId, setPeerId] = useState("");
+  const [peerName, setPeerName] = useState("");
+  const [peerUrl, setPeerUrl] = useState("");
+  const [peerToken, setPeerToken] = useState("");
+  const [peerTrust, setPeerTrust] = useState("80");
+  const [peerEnabled, setPeerEnabled] = useState(true);
+  const [peerTags, setPeerTags] = useState("");
+
+  // Broadcast form
+  const [broadcastTitle, setBroadcastTitle] = useState("");
+  const [broadcastSummary, setBroadcastSummary] = useState("");
+  const [broadcastContent, setBroadcastContent] = useState("");
+  const [broadcastTags, setBroadcastTags] = useState("");
+
+  async function loadAll() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [ov, p, log] = await Promise.all([
+        fetchFederationOverview(),
+        fetchPeers(),
+        fetchDispatchLog(50),
+      ]);
+      setOverview(ov);
+      setPeers(p);
+      setLogEntries(log);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load federation data");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadAll();
+  }, []);
+
+  function resetPeerForm() {
+    setEditingPeer(null);
+    setPeerId("");
+    setPeerName("");
+    setPeerUrl("");
+    setPeerToken("");
+    setPeerTrust("80");
+    setPeerEnabled(true);
+    setPeerTags("");
+  }
+
+  function startEditPeer(peer: PeerDesk) {
+    setEditingPeer(peer);
+    setPeerId(peer.id);
+    setPeerName(peer.name);
+    setPeerUrl(peer.endpoint_url);
+    setPeerToken(peer.auth_token);
+    setPeerTrust(String(peer.trust_score));
+    setPeerEnabled(peer.enabled);
+    setPeerTags(peer.tags.join(", "));
+  }
+
+  async function handlePeerSubmit(e: FormEvent) {
+    e.preventDefault();
+    setStatusMsg("");
+    try {
+      await upsertPeer({
+        id: peerId.trim(),
+        name: peerName.trim(),
+        endpoint_url: peerUrl.trim(),
+        auth_token: peerToken.trim(),
+        trust_score: parseInt(peerTrust, 10) || 0,
+        enabled: peerEnabled,
+        tags: parseCsv(peerTags),
+      });
+      setStatusMsg(editingPeer ? "Peer updated." : "Peer registered.");
+      resetPeerForm();
+      await loadAll();
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : "Failed to save peer");
+    }
+  }
+
+  async function handleDeletePeer(peerId: string) {
+    if (!confirm(`Remove peer "${peerId}"?`)) return;
+    setStatusMsg("");
+    try {
+      await deletePeer(peerId);
+      setStatusMsg(`Peer ${peerId} removed.`);
+      await loadAll();
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : "Failed to delete peer");
+    }
+  }
+
+  async function handleBroadcast(e: FormEvent) {
+    e.preventDefault();
+    setStatusMsg("");
+    try {
+      const result = await manualBroadcast({
+        title: broadcastTitle.trim(),
+        summary: broadcastSummary.trim(),
+        content: broadcastContent.trim(),
+        tags: parseCsv(broadcastTags),
+      });
+      setStatusMsg(`Broadcast sent to ${result.dispatch_count} peer(s).`);
+      setBroadcastTitle("");
+      setBroadcastSummary("");
+      setBroadcastContent("");
+      setBroadcastTags("");
+      await loadAll();
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : "Failed to broadcast");
+    }
+  }
+
+  if (loading) return <LoadingState title="Loading federation status..." />;
+  if (error)
+    return (
+      <ErrorState
+        title="Failed to load federation data"
+        description={error}
+      >
+        <Button onClick={loadAll}>Retry</Button>
+      </ErrorState>
+    );
+
+  const fedStatus = overview?.status;
+
+  return (
+    <div className="hx-page">
+      <header className="hx-page-header">
+        <h1>Federation</h1>
+        <p className="hx-page-subtitle">
+          Network Helix intelligence desks together. Share intelligence, coordinate cases, and
+          swarm investigations across trusted peers.
+        </p>
+      </header>
+
+      {fedStatus && (
+        <StatGrid>
+          <StatCard
+            label="Desk ID"
+            value={fedStatus.desk_id}
+          />
+          <StatCard
+            label="Peers"
+            value={String(fedStatus.peer_count)}
+            sublabel={`${fedStatus.enabled_peer_count} enabled`}
+          />
+          <StatCard
+            label="Total Dispatches"
+            value={String(fedStatus.total_dispatches)}
+          />
+          <StatCard
+            label="Federation"
+            value={fedStatus.federation_enabled ? "Active" : "Inactive"}
+            tone={fedStatus.federation_enabled ? "ok" : "default"}
+          />
+        </StatGrid>
+      )}
+
+      {fedStatus && (
+        <Panel title="Federation Status">
+          <div className="hx-stat-row">
+            <span>Successful dispatches</span>
+            <Badge tone="ok">{fedStatus.successful_dispatches}</Badge>
+          </div>
+          <div className="hx-stat-row">
+            <span>Failed dispatches</span>
+            <Badge tone="danger">{fedStatus.failed_dispatches}</Badge>
+          </div>
+          <div className="hx-stat-row">
+            <span>Federation enabled</span>
+            <Badge tone={fedStatus.federation_enabled ? "ok" : "neutral"}>
+              {fedStatus.federation_enabled ? "Yes" : "No"}
+            </Badge>
+          </div>
+        </Panel>
+      )}
+
+      <Panel title={editingPeer ? "Edit Peer Desk" : "Register Peer Desk"}>
+        <form onSubmit={handlePeerSubmit} className="hx-form">
+          <FormField label="Peer ID" hint="Unique slug (lowercase, digits, hyphens)">
+            <Input
+              value={peerId}
+              onChange={(e) => setPeerId(e.target.value)}
+              placeholder="desk-beta"
+              disabled={!!editingPeer}
+              required
+            />
+          </FormField>
+          <FormField label="Name">
+            <Input
+              value={peerName}
+              onChange={(e) => setPeerName(e.target.value)}
+              placeholder="Beta Desk"
+              required
+            />
+          </FormField>
+          <FormField label="Endpoint URL" hint="Base URL of the remote Helix instance">
+            <Input
+              value={peerUrl}
+              onChange={(e) => setPeerUrl(e.target.value)}
+              placeholder="https://helix-beta.example.com"
+              required
+            />
+          </FormField>
+          <FormField label="Auth Token" hint="Bearer token for outbound dispatches">
+            <Input
+              type="password"
+              value={peerToken}
+              onChange={(e) => setPeerToken(e.target.value)}
+              placeholder="secret-token-..."
+              required
+            />
+          </FormField>
+          <FormField label="Trust Score (0-100)">
+            <Input
+              type="number"
+              min={0}
+              max={100}
+              value={peerTrust}
+              onChange={(e) => setPeerTrust(e.target.value)}
+              required
+            />
+          </FormField>
+          <FormField label="Tags (comma-separated)">
+            <Input
+              value={peerTags}
+              onChange={(e) => setPeerTags(e.target.value)}
+              placeholder="osint, market"
+            />
+          </FormField>
+          <CheckboxField
+            label="Enabled"
+            checked={peerEnabled}
+            onChange={setPeerEnabled}
+          />
+          <div className="hx-form-actions">
+            <Button type="submit">{editingPeer ? "Update Peer" : "Register Peer"}</Button>
+            {editingPeer && (
+              <Button type="button" variant="ghost" onClick={resetPeerForm}>
+                Cancel
+              </Button>
+            )}
+          </div>
+        </form>
+      </Panel>
+
+      <Panel title={`Peer Desks (${peers.length})`}>
+        {peers.length === 0 ? (
+          <EmptyState title="No peer desks registered" description="Add one above to start swarming." />
+        ) : (
+          <DataTable
+            columns={[
+              {
+                key: "id",
+                header: "ID",
+                render: (p) => <code>{p.id}</code>,
+              },
+              {
+                key: "name",
+                header: "Name",
+                render: (p) => p.name,
+              },
+              {
+                key: "endpoint",
+                header: "Endpoint",
+                render: (p) => <code>{p.endpoint_url}</code>,
+              },
+              {
+                key: "trust",
+                header: "Trust",
+                render: (p) => <Badge tone={trustTone(p.trust_score)}>{p.trust_score}</Badge>,
+              },
+              {
+                key: "enabled",
+                header: "Status",
+                render: (p) => (
+                  <Badge tone={p.enabled ? "ok" : "neutral"}>
+                    {p.enabled ? "Enabled" : "Disabled"}
+                  </Badge>
+                ),
+              },
+              {
+                key: "actions",
+                header: "Actions",
+                render: (p) => (
+                  <div className="hx-row-gap">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      onClick={() => startEditPeer(p)}
+                    >
+                      Edit
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="danger"
+                      onClick={() => handleDeletePeer(p.id)}
+                    >
+                      Remove
+                    </Button>
+                  </div>
+                ),
+              },
+            ]}
+            rows={peers}
+            rowKey={(p) => p.id}
+            emptyMessage="No peers registered"
+          />
+        )}
+      </Panel>
+
+      <Panel title="Manual Broadcast">
+        <p className="hx-form-hint">
+          Send an intelligence bulletin to all enabled peers. The payload is delivered as a
+          CloudEvents-formatted federation event.
+        </p>
+        <form onSubmit={handleBroadcast} className="hx-form">
+          <FormField label="Title">
+            <Input
+              value={broadcastTitle}
+              onChange={(e) => setBroadcastTitle(e.target.value)}
+              placeholder="Intelligence bulletin title"
+              required
+            />
+          </FormField>
+          <FormField label="Summary">
+            <Textarea
+              value={broadcastSummary}
+              onChange={(e) => setBroadcastSummary(e.target.value)}
+              placeholder="Brief summary of the intelligence..."
+              rows={2}
+              required
+            />
+          </FormField>
+          <FormField label="Content">
+            <Textarea
+              value={broadcastContent}
+              onChange={(e) => setBroadcastContent(e.target.value)}
+              placeholder="Full details to share with peer desks..."
+              rows={4}
+              required
+            />
+          </FormField>
+          <FormField label="Tags (comma-separated)">
+            <Input
+              value={broadcastTags}
+              onChange={(e) => setBroadcastTags(e.target.value)}
+              placeholder="osint, priority"
+            />
+          </FormField>
+          <div className="hx-form-actions">
+            <Button type="submit" disabled={!fedStatus?.federation_enabled}>
+              Broadcast to Peers
+            </Button>
+          </div>
+        </form>
+      </Panel>
+
+      <Panel title={`Dispatch Log (${logEntries.length})`}>
+        {logEntries.length === 0 ? (
+          <EmptyState
+            title="No outbound dispatches yet"
+            description="Federation events will appear here when intelligence is shared with peers."
+          />
+        ) : (
+          <DataTable
+            columns={[
+              {
+                key: "dispatched_at",
+                header: "Timestamp",
+                render: (e) => <code>{e.dispatched_at}</code>,
+                width: "180px",
+              },
+              {
+                key: "event_kind",
+                header: "Event Type",
+                render: (e) => <code>{e.event_kind}</code>,
+              },
+              {
+                key: "event_title",
+                header: "Title",
+                render: (e) => e.event_title,
+              },
+              {
+                key: "peer_id",
+                header: "Peer",
+                render: (e) => <code>{e.peer_id}</code>,
+              },
+              {
+                key: "status",
+                header: "Status",
+                render: (e) => <Badge tone={dispatchStatusTone(e.status)}>{e.status}</Badge>,
+              },
+              {
+                key: "latency",
+                header: "Latency",
+                render: (e) => `${e.latency_ms}ms`,
+                width: "80px",
+              },
+              {
+                key: "details",
+                header: "Details",
+                render: (e) =>
+                  e.error_message ? (
+                    <span className="hx-text-muted">{e.error_message}</span>
+                  ) : e.http_status ? (
+                    <span className="hx-text-muted">HTTP {e.http_status}</span>
+                  ) : (
+                    "—"
+                  ),
+              },
+            ]}
+            rows={logEntries}
+            rowKey={(e) => e.id}
+            emptyMessage="No dispatches logged"
+          />
+        )}
+      </Panel>
+
+      {statusMsg && <StatusLine>{statusMsg}</StatusLine>}
+    </div>
+  );
+}

--- a/ui/src/screens/MarketIntelPage.tsx
+++ b/ui/src/screens/MarketIntelPage.tsx
@@ -12,17 +12,27 @@ import {
   fetchMarketIntelOverview,
   generateMarketIntelBrief,
 } from "../lib/api";
+import {
+  Panel,
+  StatCard,
+  StatGrid,
+  Badge,
+  Button,
+  Tag,
+  StatusLine,
+  CodeBlock,
+} from "../components";
 
-function caseStatusClass(activeCaseCount: number, escalatedCaseCount?: number) {
-  if ((escalatedCaseCount ?? 0) > 0) return "danger";
-  if (activeCaseCount > 0) return "warn";
-  return "ok";
+function caseStatusTone(activeCaseCount: number, escalatedCaseCount?: number) {
+  if ((escalatedCaseCount ?? 0) > 0) return "danger" as const;
+  if (activeCaseCount > 0) return "warn" as const;
+  return "ok" as const;
 }
 
-function briefStatusClass(status: MarketIntelCaseBrief["status"], attachedToCase: boolean) {
-  if (status === "escalated") return "danger";
-  if (attachedToCase || status === "brief_ready") return "ok";
-  return "warn";
+function briefStatusTone(status: MarketIntelCaseBrief["status"], attachedToCase: boolean) {
+  if (status === "escalated") return "danger" as const;
+  if (attachedToCase || status === "brief_ready") return "ok" as const;
+  return "warn" as const;
 }
 
 function priorityLabel(priority: PriorityBreakdown) {
@@ -31,17 +41,15 @@ function priorityLabel(priority: PriorityBreakdown) {
 
 function renderPlaybook(playbook: MarketIntelPlaybook) {
   return (
-    <div key={playbook.id} className="agent-card">
-      <div className="agent-card-head">
+    <div key={playbook.id} className="hx-card">
+      <div className="hx-card-head">
         <h3>{playbook.name}</h3>
-        <span className="status-pill info">deterministic</span>
+        <Badge tone="info">deterministic</Badge>
       </div>
-      <p>{playbook.objective}</p>
-      <div className="pill-row">
+      <p className="hx-description">{playbook.objective}</p>
+      <div className="hx-tag-row">
         {playbook.signals.map((signal) => (
-          <span key={signal} className="tag-chip">
-            {signal}
-          </span>
+          <Tag key={signal}>{signal}</Tag>
         ))}
       </div>
     </div>
@@ -50,29 +58,27 @@ function renderPlaybook(playbook: MarketIntelPlaybook) {
 
 function renderTheme(theme: MarketIntelThemeCard) {
   return (
-    <div key={theme.theme_id} className="agent-card">
-      <div className="agent-card-head">
+    <div key={theme.theme_id} className="hx-card">
+      <div className="hx-card-head">
         <h3>{theme.name}</h3>
-        <span className={`status-pill ${caseStatusClass(theme.active_case_count, theme.escalated_case_count)}`}>
+        <Badge tone={caseStatusTone(theme.active_case_count, theme.escalated_case_count)}>
           {theme.active_case_count > 0 ? `${theme.active_case_count} active` : "watching"}
-        </span>
+        </Badge>
       </div>
-      <p>{theme.summary}</p>
-      <div className="pill-row">
-        <span className="info-pill">{priorityLabel(theme.priority)}</span>
-        <span className="info-pill">watchlists: {theme.watchlist_count}</span>
-        <span className="info-pill">evidence: {theme.evidence_count}</span>
-        <span className="info-pill">escalated: {theme.escalated_case_count}</span>
+      <p className="hx-description">{theme.summary}</p>
+      <div className="hx-tag-row">
+        <Tag>{priorityLabel(theme.priority)}</Tag>
+        <Tag>watchlists: {theme.watchlist_count}</Tag>
+        <Tag>evidence: {theme.evidence_count}</Tag>
+        <Tag>escalated: {theme.escalated_case_count}</Tag>
       </div>
-      <div className="pill-row">
+      <div className="hx-tag-row">
         {theme.top_entities.length > 0 ? (
           theme.top_entities.map((entity) => (
-            <span key={entity} className="tag-chip">
-              {entity}
-            </span>
+            <Tag key={entity}>{entity}</Tag>
           ))
         ) : (
-          <span className="info-pill">no tracked entities yet</span>
+          <Tag>no tracked entities yet</Tag>
         )}
       </div>
     </div>
@@ -81,22 +87,20 @@ function renderTheme(theme: MarketIntelThemeCard) {
 
 function renderCompany(card: MarketIntelCompanyCard) {
   return (
-    <div key={card.company} className="command-row">
-      <div className="agent-card-head">
+    <div key={card.company} className="hx-row hx-row-stack">
+      <div className="hx-card-head">
         <h3>{card.company}</h3>
-        <span className={`status-pill ${caseStatusClass(card.active_case_count)}`}>
+        <Badge tone={caseStatusTone(card.active_case_count)}>
           {card.active_case_count > 0 ? `${card.active_case_count} cases` : "tracked"}
-        </span>
+        </Badge>
       </div>
-      <code>mentions: {card.mention_count}</code>
-      <code>claims: {card.claim_count}</code>
-      <code>latest_signal_at: {card.latest_signal_at ?? "none"}</code>
-      <div className="pill-row">
-        <span className="info-pill">{priorityLabel(card.priority)}</span>
+      <code className="hx-mono-detail">mentions: {card.mention_count}</code>
+      <code className="hx-mono-detail">claims: {card.claim_count}</code>
+      <code className="hx-mono-detail">latest_signal_at: {card.latest_signal_at ?? "none"}</code>
+      <div className="hx-tag-row">
+        <Tag>{priorityLabel(card.priority)}</Tag>
         {card.themes.map((theme) => (
-          <span key={theme} className="tag-chip">
-            {theme}
-          </span>
+          <Tag key={theme}>{theme}</Tag>
         ))}
       </div>
     </div>
@@ -109,67 +113,61 @@ function renderCaseBrief(
   onExport: (caseId: string) => void
 ) {
   return (
-    <div key={briefing.case_id} className="agent-card">
-      <div className="agent-card-head">
+    <div key={briefing.case_id} className="hx-card">
+      <div className="hx-card-head">
         <h3>{briefing.title}</h3>
-        <span className={`status-pill ${briefStatusClass(briefing.status, briefing.attached_to_case)}`}>
+        <Badge tone={briefStatusTone(briefing.status, briefing.attached_to_case)}>
           {briefing.status}
-        </span>
+        </Badge>
       </div>
-      <p>{briefing.summary}</p>
-      <div className="pill-row">
-        <span className="info-pill">{priorityLabel(briefing.priority)}</span>
-        <span className="info-pill">theme: {briefing.theme_name}</span>
-        <span className="info-pill">company: {briefing.company ?? "unassigned"}</span>
-        <span className="info-pill">evidence: {briefing.evidence_count}</span>
-        <span className="info-pill">claims: {briefing.claim_count}</span>
+      <p className="hx-description">{briefing.summary}</p>
+      <div className="hx-tag-row">
+        <Tag>{priorityLabel(briefing.priority)}</Tag>
+        <Tag>theme: {briefing.theme_name}</Tag>
+        <Tag>company: {briefing.company ?? "unassigned"}</Tag>
+        <Tag>evidence: {briefing.evidence_count}</Tag>
+        <Tag>claims: {briefing.claim_count}</Tag>
       </div>
-      <div className="pill-row">
-        <span className="info-pill">
-          latest_signal_at: {briefing.latest_signal_at ?? "unknown"}
-        </span>
-        <span className={`status-pill ${briefing.attached_to_case ? "ok" : "warn"}`}>
+      <div className="hx-tag-row">
+        <Tag>latest_signal_at: {briefing.latest_signal_at ?? "unknown"}</Tag>
+        <Badge tone={briefing.attached_to_case ? "ok" : "warn"}>
           {briefing.attached_to_case ? "brief attached" : "preview only"}
-        </span>
+        </Badge>
       </div>
-      <div className="stack-list">
+      <div className="hx-stack">
         <div>
-          <p className="mono-label">Key Claims</p>
-          <div className="pill-row">
+          <p className="hx-eyebrow">Key Claims</p>
+          <div className="hx-tag-row">
             {briefing.key_claims.map((claim) => (
-              <span key={claim} className="tag-chip">
-                {claim}
-              </span>
+              <Tag key={claim}>{claim}</Tag>
             ))}
           </div>
         </div>
         <div>
-          <p className="mono-label">Recommended Actions</p>
-          <div className="pill-row">
+          <p className="hx-eyebrow">Recommended Actions</p>
+          <div className="hx-tag-row">
             {briefing.recommended_actions.map((action) => (
-              <span key={action} className="tag-chip">
-                {action}
-              </span>
+              <Tag key={action}>{action}</Tag>
             ))}
           </div>
         </div>
       </div>
-      <div className="button-row">
-        <button
-          className="btn-secondary"
+      <div className="hx-cluster">
+        <Button
+          variant="secondary"
           type="button"
           onClick={() => onAttach(briefing.case_id)}
           disabled={briefing.attached_to_case}
         >
           {briefing.attached_to_case ? "Attached" : "Attach Brief"}
-        </button>
-        <button
-          className="btn-secondary"
+        </Button>
+        <Button
+          variant="secondary"
           type="button"
           onClick={() => onExport(briefing.case_id)}
         >
           Export Packet
-        </button>
+        </Button>
       </div>
     </div>
   );
@@ -222,91 +220,78 @@ export function MarketIntelPage() {
   }
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel panel-hero panel-span-12">
-        <p className="mono-label">Market Intelligence</p>
-        <h2>Competitors, Pricing, Launches, and Channel Motion</h2>
-        <p>
+    <section className="hx-page-grid">
+      <Panel hero span={12} eyebrow="Market Intelligence" title="Competitors, Pricing, Launches, and Channel Motion">
+        <p className="hx-description">
           Market intelligence runs on the same deterministic substrate as the OSINT desk: explicit
           sources, provenance-linked evidence, watchlists, cases, and guarded follow-up. The use
           case changes. The trust model does not.
         </p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <p className="mono-label">Market Coverage</p>
-        <div className="metrics-grid">
-          <div className="metric-card">
-            <p className="metric-label">Market Sources</p>
-            <p className="metric-value">{overview?.market_source_count ?? 0}</p>
-          </div>
-          <div className="metric-card">
-            <p className="metric-label">Market Watchlists</p>
-            <p className="metric-value">{overview?.market_watchlist_count ?? 0}</p>
-          </div>
-          <div className="metric-card">
-            <p className="metric-label">Tracked Companies</p>
-            <p className="metric-value">{overview?.tracked_company_count ?? 0}</p>
-          </div>
-          <div className="metric-card">
-            <p className="metric-label">Active Cases</p>
-            <p className="metric-value">{overview?.active_case_count ?? 0}</p>
-          </div>
-        </div>
-        <p className="status-line">{status}</p>
-      </article>
+      <Panel span={12} eyebrow="Market Coverage" title="Coverage Metrics">
+        <StatGrid>
+          <StatCard label="Market Sources" value={overview?.market_source_count ?? 0} />
+          <StatCard label="Market Watchlists" value={overview?.market_watchlist_count ?? 0} />
+          <StatCard label="Tracked Companies" value={overview?.tracked_company_count ?? 0} />
+          <StatCard label="Active Cases" value={overview?.active_case_count ?? 0} />
+        </StatGrid>
+        <StatusLine>{status}</StatusLine>
+      </Panel>
 
-      <article className="panel panel-span-7">
-        <p className="mono-label">Theme Coverage</p>
-        <div className="agent-grid">{overview?.theme_cards.map(renderTheme)}</div>
-      </article>
+      <Panel span={7} eyebrow="Theme Coverage" title="Themes">
+        <div className="hx-card-grid">{overview?.theme_cards.map(renderTheme)}</div>
+      </Panel>
 
-      <article className="panel panel-span-5">
-        <p className="mono-label">Tracked Companies</p>
-        <div className="command-stack">
+      <Panel span={5} eyebrow="Tracked Companies" title="Companies">
+        <div className="hx-list">
           {overview?.company_cards.length ? (
             overview.company_cards.map(renderCompany)
           ) : (
-            <p>No company signals yet. Register sources or ingest evidence to populate this view.</p>
+            <div className="hx-table-empty">
+              <p>No company signals yet. Register sources or ingest evidence to populate this view.</p>
+            </div>
           )}
         </div>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <p className="mono-label">Active Case Briefs</p>
-        <div className="agent-grid">
+      <Panel span={12} eyebrow="Active Case Briefs" title="Case Briefs">
+        <div className="hx-card-grid">
           {overview?.case_briefs.length ? (
             overview.case_briefs.map((briefing) =>
               renderCaseBrief(briefing, attachBrief, exportBrief)
             )
           ) : (
-            <p>No market-intelligence cases are active yet.</p>
+            <div className="hx-table-empty">
+              <p>No market-intelligence cases are active yet.</p>
+            </div>
           )}
         </div>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <p className="mono-label">Reference Playbooks</p>
-        <div className="agent-grid">{overview?.playbooks.map(renderPlaybook)}</div>
-      </article>
+      <Panel span={12} eyebrow="Reference Playbooks" title="Playbooks">
+        <div className="hx-card-grid">{overview?.playbooks.map(renderPlaybook)}</div>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <p className="mono-label">Latest Attached Brief</p>
+      <Panel span={12} eyebrow="Latest Attached Brief" title="Attached Brief">
         {lastBrief ? (
-          <pre className="json-output">{JSON.stringify(lastBrief, null, 2)}</pre>
+          <CodeBlock label="Brief JSON">{JSON.stringify(lastBrief, null, 2)}</CodeBlock>
         ) : (
-          <p>No brief has been attached in this session.</p>
+          <div className="hx-table-empty">
+            <p>No brief has been attached in this session.</p>
+          </div>
         )}
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <p className="mono-label">Latest Export Packet</p>
+      <Panel span={12} eyebrow="Latest Export Packet" title="Export Packet">
         {lastExportPacket ? (
-          <pre className="json-output">{JSON.stringify(lastExportPacket, null, 2)}</pre>
+          <CodeBlock label="Packet JSON">{JSON.stringify(lastExportPacket, null, 2)}</CodeBlock>
         ) : (
-          <p>No market brief export packet has been generated in this session.</p>
+          <div className="hx-table-empty">
+            <p>No market brief export packet has been generated in this session.</p>
+          </div>
         )}
-      </article>
+      </Panel>
     </section>
   );
 }

--- a/ui/src/screens/OnchainPage.tsx
+++ b/ui/src/screens/OnchainPage.tsx
@@ -4,6 +4,16 @@ import {
   fetchOnchainReceipt,
   sendRawOnchainTransaction,
 } from "../lib/api";
+import {
+  Panel,
+  FormField,
+  Input,
+  Textarea,
+  CheckboxField,
+  Button,
+  Badge,
+  StatusLine,
+} from "../components";
 
 export function OnchainPage() {
   const [rpcUrl, setRpcUrl] = useState<string>("https://rpc.ankr.com/eth");
@@ -58,110 +68,88 @@ export function OnchainPage() {
     }
   }
 
+  const phaseTone = (phase: string) =>
+    phase === "Confirmed" ? "ok" : phase === "Reverted" || phase === "Failed" ? "danger" : phase === "Idle" ? "neutral" : "info";
+
   return (
-    <section className="dashboard-grid">
-      <article className="panel panel-hero panel-span-12">
-        <p className="mono-label">Onchain Shell</p>
-        <h2>EVM Raw Transaction Submit + Receipt Polling</h2>
-        <p>
-          Deterministic transaction intent in core, imperative JSON-RPC execution in shell. Use
-          dry-run mode first, then submit signed raw tx when ready.
+    <section className="hx-page-grid">
+      <Panel hero span={12} eyebrow="Onchain Shell" title="EVM Raw Transaction Submit + Receipt Polling">
+        <p className="hx-description">
+          Deterministic transaction intent in core, imperative JSON-RPC execution in
+          shell. Use dry-run mode first, then submit signed raw tx when ready.
         </p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-6">
-        <p className="mono-label">Broadcast Transaction</p>
-        <form className="form-grid" onSubmit={onSubmit}>
-          <label className="field field-full">
-            <span>rpc_url</span>
-            <input value={rpcUrl} onChange={(e) => setRpcUrl(e.target.value)} />
-          </label>
+      <Panel span={6} eyebrow="Broadcast" title="Transaction Intent">
+        <form className="hx-form-grid" onSubmit={onSubmit}>
+          <FormField label="RPC URL" full>
+            <Input value={rpcUrl} onChange={(e) => setRpcUrl(e.target.value)} />
+          </FormField>
 
-          <label className="field field-full">
-            <span>raw_tx_hex</span>
-            <textarea
-              className="command-editor"
-              rows={4}
-              value={rawTxHex}
-              onChange={(e) => setRawTxHex(e.target.value)}
-            />
-          </label>
+          <FormField label="Raw TX Hex" full>
+            <Textarea rows={4} value={rawTxHex} onChange={(e) => setRawTxHex(e.target.value)} />
+          </FormField>
 
-          <label className="field">
-            <span>max_poll_rounds</span>
-            <input
-              type="number"
-              min={1}
-              value={maxPollRounds}
-              onChange={(e) => setMaxPollRounds(Number(e.target.value))}
-            />
-          </label>
+          <FormField label="Max poll rounds">
+            <Input type="number" min={1} value={maxPollRounds} onChange={(e) => setMaxPollRounds(Number(e.target.value))} />
+          </FormField>
 
-          <label className="field">
-            <span>poll_interval_ms</span>
-            <input
-              type="number"
-              min={50}
-              value={pollIntervalMs}
-              onChange={(e) => setPollIntervalMs(Number(e.target.value))}
-            />
-          </label>
+          <FormField label="Poll interval (ms)">
+            <Input type="number" min={50} value={pollIntervalMs} onChange={(e) => setPollIntervalMs(Number(e.target.value))} />
+          </FormField>
 
-          <label className="field checkbox-field">
-            <input
-              type="checkbox"
-              checked={awaitReceipt}
-              onChange={(e) => setAwaitReceipt(e.target.checked)}
-            />
-            <span>await_receipt</span>
-          </label>
+          <CheckboxField label="Await receipt" checked={awaitReceipt} onChange={setAwaitReceipt} />
+          <CheckboxField label="Dry run" checked={dryRun} onChange={setDryRun} />
 
-          <label className="field checkbox-field">
-            <input type="checkbox" checked={dryRun} onChange={(e) => setDryRun(e.target.checked)} />
-            <span>dry_run</span>
-          </label>
-
-          <button className="btn-primary" type="submit">
-            Execute Broadcast
-          </button>
+          <FormField label="" full>
+            <Button type="submit" variant={dryRun ? "primary" : "danger"}>
+              {dryRun ? "Dry Run Broadcast" : "Execute Broadcast"}
+            </Button>
+          </FormField>
         </form>
-        <p className="status-line">{status}</p>
-      </article>
+        <StatusLine>{status}</StatusLine>
+      </Panel>
 
-      <article className="panel panel-span-3">
-        <p className="mono-label">Result</p>
+      <Panel span={3} eyebrow="Result" title="Broadcast Output">
         {result ? (
-          <div className="command-stack">
-            <code className="command-inline">phase: {result.phase}</code>
-            <code className="command-inline">tx_hash: {result.tx_hash ?? "none"}</code>
-            <code className="command-inline">
-              poll_rounds: {result.poll_rounds}/{result.max_poll_rounds}
-            </code>
-            <code className="command-inline">
-              receipt_status: {result.receipt?.status ?? "none"}
-            </code>
-            <code className="command-inline">
-              receipt_block: {result.receipt?.blockNumber ?? "none"}
-            </code>
+          <div className="hx-list">
+            <div className="hx-row">
+              <span className="hx-row-primary">phase</span>
+              <Badge tone={phaseTone(result.phase)}>{result.phase}</Badge>
+            </div>
+            <div className="hx-row hx-row-stack">
+              <span className="hx-row-primary">tx_hash</span>
+              <code className="hx-mono-detail">{result.tx_hash ?? "none"}</code>
+            </div>
+            <div className="hx-row">
+              <span className="hx-row-primary">poll rounds</span>
+              <span className="hx-row-secondary">{result.poll_rounds}/{result.max_poll_rounds}</span>
+            </div>
+            <div className="hx-row">
+              <span className="hx-row-primary">receipt status</span>
+              <span className="hx-row-secondary">{result.receipt?.status ?? "none"}</span>
+            </div>
+            <div className="hx-row">
+              <span className="hx-row-primary">receipt block</span>
+              <span className="hx-row-secondary">{result.receipt?.blockNumber ?? "none"}</span>
+            </div>
           </div>
         ) : (
-          <p>No result yet.</p>
+          <div className="hx-table-empty"><p>No result yet.</p></div>
         )}
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-3">
-        <p className="mono-label">Manual Receipt Lookup</p>
-        <form onSubmit={onLookupReceipt} className="form-grid">
-          <label className="field field-full">
-            <span>tx_hash</span>
-            <input value={receiptHash} onChange={(e) => setReceiptHash(e.target.value)} />
-          </label>
-          <button className="btn-secondary" type="submit">
-            Fetch Receipt
-          </button>
+      <Panel span={3} eyebrow="Lookup" title="Manual Receipt">
+        <form onSubmit={onLookupReceipt} className="hx-form-grid">
+          <FormField label="TX Hash" full>
+            <Input value={receiptHash} onChange={(e) => setReceiptHash(e.target.value)} placeholder="0x..." />
+          </FormField>
+          <FormField label="" full>
+            <Button type="submit" variant="secondary">Fetch Receipt</Button>
+          </FormField>
         </form>
-        <p className="status-line">{receiptStatus}</p>
-      </article>
+        <StatusLine>{receiptStatus}</StatusLine>
+      </Panel>
     </section>
   );
 }

--- a/ui/src/screens/OperatorPage.tsx
+++ b/ui/src/screens/OperatorPage.tsx
@@ -1,0 +1,401 @@
+import { FormEvent, useEffect, useState } from "react";
+import {
+  OperatorStatus,
+  AutopilotMode,
+  OperatorActionScope,
+  DeskOperatorConfig,
+  OperatorStatusResponse,
+  OperatorActivityEntry,
+  fetchOperatorStatus,
+  fetchOperatorConfig,
+  updateOperatorConfig,
+  startOperator,
+  stopOperator,
+  pauseOperator,
+  fetchOperatorActivity,
+} from "../lib/api";
+import {
+  Panel,
+  StatCard,
+  StatGrid,
+  Badge,
+  Button,
+  FormField,
+  Input,
+  Textarea,
+  CheckboxField,
+  Select,
+  DataTable,
+  EmptyState,
+  LoadingState,
+  ErrorState,
+  StatusLine,
+} from "../components";
+
+type BadgeTone = "default" | "ok" | "warn" | "danger" | "info" | "neutral" | "accent";
+type StatTone = "default" | "accent" | "ok" | "warn" | "danger" | "info";
+
+function statusTone(status: OperatorStatus): BadgeTone {
+  switch (status) {
+    case "running":
+      return "ok";
+    case "paused":
+      return "warn";
+    case "stopped":
+    default:
+      return "default";
+  }
+}
+
+function statusStatTone(status: OperatorStatus): StatTone {
+  return statusTone(status) as StatTone;
+}
+
+function modeTone(mode: AutopilotMode): BadgeTone {
+  switch (mode) {
+    case "auto":
+      return "ok";
+    case "assist":
+      return "info";
+    case "off":
+    default:
+      return "default";
+  }
+}
+
+function modeStatTone(mode: AutopilotMode): StatTone {
+  return modeTone(mode) as StatTone;
+}
+
+function actionTone(entry: OperatorActivityEntry): BadgeTone {
+  if (entry.allowed) return "ok";
+  return "danger";
+}
+
+export function OperatorPage() {
+  const [status, setStatus] = useState<OperatorStatusResponse | null>(null);
+  const [config, setConfig] = useState<DeskOperatorConfig | null>(null);
+  const [activity, setActivity] = useState<OperatorActivityEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusMsg, setStatusMsg] = useState("");
+
+  // Editable config form state
+  const [editEnabled, setEditEnabled] = useState(false);
+  const [editMode, setEditMode] = useState<AutopilotMode>("assist");
+  const [editScope, setEditScope] = useState<OperatorActionScope>("intelligence");
+  const [editInterval, setEditInterval] = useState("60");
+  const [editMaxActions, setEditMaxActions] = useState("3");
+  const [editMaxCtx, setEditMaxCtx] = useState("10");
+  const [editModel, setEditModel] = useState("gpt-4o-mini");
+  const [editRules, setEditRules] = useState("");
+  const [editDispatch, setEditDispatch] = useState(false);
+  const [editLogDenied, setEditLogDenied] = useState(true);
+
+  async function loadAll() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [st, cfg, act] = await Promise.all([
+        fetchOperatorStatus(),
+        fetchOperatorConfig(),
+        fetchOperatorActivity(50),
+      ]);
+      setStatus(st);
+      setConfig(cfg);
+      setActivity(act);
+      // Sync form state with loaded config
+      setEditEnabled(cfg.enabled);
+      setEditMode(cfg.autopilot_mode);
+      setEditScope(cfg.action_scope);
+      setEditInterval(String(cfg.loop_interval_secs));
+      setEditMaxActions(String(cfg.max_actions_per_cycle));
+      setEditMaxCtx(String(cfg.max_context_items));
+      setEditModel(cfg.model);
+      setEditRules(cfg.rules_text);
+      setEditDispatch(cfg.dispatch_to_peers);
+      setEditLogDenied(cfg.log_denied_proposals);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load operator data");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    loadAll();
+  }, []);
+
+  async function handleConfigSubmit(e: FormEvent) {
+    e.preventDefault();
+    setStatusMsg("");
+    try {
+      const updated = await updateOperatorConfig({
+        enabled: editEnabled,
+        autopilot_mode: editMode,
+        action_scope: editScope,
+        loop_interval_secs: parseInt(editInterval, 10) || 60,
+        max_actions_per_cycle: parseInt(editMaxActions, 10) || 3,
+        max_context_items: parseInt(editMaxCtx, 10) || 10,
+        model: editModel.trim(),
+        rules_text: editRules,
+        dispatch_to_peers: editDispatch,
+        log_denied_proposals: editLogDenied,
+      });
+      setConfig(updated);
+      setStatusMsg("Configuration saved.");
+      // Refresh status to reflect any mode changes
+      const st = await fetchOperatorStatus();
+      setStatus(st);
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : "Failed to save config");
+    }
+  }
+
+  async function handleStart() {
+    setStatusMsg("");
+    try {
+      await startOperator();
+      const st = await fetchOperatorStatus();
+      setStatus(st);
+      setStatusMsg("Operator started.");
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : "Failed to start operator");
+    }
+  }
+
+  async function handleStop() {
+    setStatusMsg("");
+    try {
+      await stopOperator();
+      const st = await fetchOperatorStatus();
+      setStatus(st);
+      setStatusMsg("Operator stopped.");
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : "Failed to stop operator");
+    }
+  }
+
+  async function handlePause() {
+    setStatusMsg("");
+    try {
+      await pauseOperator();
+      const st = await fetchOperatorStatus();
+      setStatus(st);
+      setStatusMsg("Operator paused.");
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : "Failed to pause operator");
+    }
+  }
+
+  if (loading) return <LoadingState title="Loading operator status..." />;
+  if (error)
+    return (
+      <ErrorState title="Failed to load operator data" description={error}>
+        <Button onClick={loadAll}>Retry</Button>
+      </ErrorState>
+    );
+
+  return (
+    <div className="hx-page">
+      <header className="hx-page-header">
+        <h1>Desk Operator</h1>
+        <p className="hx-page-subtitle">
+          LLM-driven autonomous intelligence desk operator. The operator runs an
+          observe-think-act loop within deterministic guardrails — the LLM never
+          bypasses the guard.
+        </p>
+      </header>
+
+      {status && (
+        <StatGrid>
+          <StatCard
+            label="Status"
+            value={status.status}
+            tone={statusStatTone(status.status)}
+          />
+          <StatCard
+            label="Autopilot Mode"
+            value={status.autopilot_mode}
+            tone={modeStatTone(status.autopilot_mode)}
+          />
+          <StatCard
+            label="Cycles"
+            value={String(status.cycle_count)}
+            sublabel={`${status.activity_log_count} log entries`}
+          />
+          <StatCard
+            label="Model"
+            value={status.model}
+            sublabel={`${status.loop_interval_secs}s interval`}
+          />
+        </StatGrid>
+      )}
+
+      <Panel title="Operator Controls">
+        <div className="hx-stat-row">
+          <span>Current status</span>
+          <Badge tone={status ? statusTone(status.status) : "neutral"}>
+            {status?.status ?? "unknown"}
+          </Badge>
+        </div>
+        <div className="hx-stat-row">
+          <span>Enabled in config</span>
+          <Badge tone={status?.enabled ? "ok" : "neutral"}>
+            {status?.enabled ? "Yes" : "No"}
+          </Badge>
+        </div>
+        <div className="hx-stat-row">
+          <span>Action scope</span>
+          <Badge tone="info">{status?.action_scope ?? "—"}</Badge>
+        </div>
+        <div style={{ display: "flex", gap: "0.5rem", marginTop: "1rem" }}>
+          <Button
+            onClick={handleStart}
+            disabled={status?.status === "running"}
+          >
+            Start
+          </Button>
+          <Button
+            onClick={handlePause}
+            disabled={status?.status !== "running"}
+          >
+            Pause
+          </Button>
+          <Button
+            onClick={handleStop}
+            disabled={status?.status === "stopped"}
+          >
+            Stop
+          </Button>
+        </div>
+      </Panel>
+
+      <Panel title="Operator Configuration">
+        <form onSubmit={handleConfigSubmit} className="hx-form">
+          <CheckboxField
+            label="Enabled — master switch for the operator loop"
+            checked={editEnabled}
+            onChange={setEditEnabled}
+          />
+          <FormField label="Autopilot Mode" hint="Off=deny all, Assist=require confirmation, Auto=execute within guardrails">
+            <Select
+              value={editMode}
+              onChange={(e) => setEditMode(e.target.value as AutopilotMode)}
+            >
+              <option value="off">Off</option>
+              <option value="assist">Assist</option>
+              <option value="auto">Auto</option>
+            </Select>
+          </FormField>
+          <FormField label="Action Scope" hint="Observe-only, Intelligence, Policy, or Full authority">
+            <Select
+              value={editScope}
+              onChange={(e) => setEditScope(e.target.value as OperatorActionScope)}
+            >
+              <option value="observe_only">Observe Only</option>
+              <option value="intelligence">Intelligence</option>
+              <option value="policy">Policy</option>
+              <option value="full">Full</option>
+            </Select>
+          </FormField>
+          <FormField label="Loop Interval (seconds)" hint="Minimum 5, maximum 3600">
+            <Input
+              type="number"
+              value={editInterval}
+              onChange={(e) => setEditInterval(e.target.value)}
+              min={5}
+              max={3600}
+              required
+            />
+          </FormField>
+          <FormField label="Max Actions Per Cycle" hint="Maximum 10">
+            <Input
+              type="number"
+              value={editMaxActions}
+              onChange={(e) => setEditMaxActions(e.target.value)}
+              min={1}
+              max={10}
+              required
+            />
+          </FormField>
+          <FormField label="Max Context Items" hint="Maximum 20 items in LLM prompt">
+            <Input
+              type="number"
+              value={editMaxCtx}
+              onChange={(e) => setEditMaxCtx(e.target.value)}
+              min={1}
+              max={20}
+              required
+            />
+          </FormField>
+          <FormField label="LLM Model" hint="Model identifier (e.g. gpt-4o-mini)">
+            <Input
+              value={editModel}
+              onChange={(e) => setEditModel(e.target.value)}
+              placeholder="gpt-4o-mini"
+              required
+            />
+          </FormField>
+          <FormField label="Rules Text" hint="Natural language instructions for the operator (max 4096 chars)">
+            <Textarea
+              value={editRules}
+              onChange={(e) => setEditRules(e.target.value)}
+              rows={6}
+              placeholder="Prioritize cases about entity X. Escalate when trust score drops below 50..."
+            />
+          </FormField>
+          <CheckboxField
+            label="Dispatch to Federation Peers — share operator decisions with federation peers"
+            checked={editDispatch}
+            onChange={setEditDispatch}
+          />
+          <CheckboxField
+            label="Log Denied Proposals — record denied proposals in the activity log for audit"
+            checked={editLogDenied}
+            onChange={setEditLogDenied}
+          />
+          <div style={{ marginTop: "1rem" }}>
+            <Button type="submit">Save Configuration</Button>
+          </div>
+        </form>
+      </Panel>
+
+      <Panel title="Activity Log">
+        {activity.length === 0 ? (
+          <EmptyState
+            title="No activity yet"
+            description="Operator decisions will appear here once the loop runs."
+          />
+        ) : (
+          <DataTable
+            rowKey={(entry) => entry.id}
+            columns={[
+              { key: "cycle", header: "Cycle", render: (e) => String(e.cycle) },
+              { key: "action_type", header: "Action", render: (e) => e.action_type },
+              { key: "rationale", header: "Rationale", render: (e) => e.rationale },
+              {
+                key: "allowed",
+                header: "Decision",
+                render: (e) => (
+                  <Badge tone={actionTone(e)}>
+                    {e.allowed ? "Allowed" : "Denied"}
+                  </Badge>
+                ),
+              },
+              {
+                key: "denial_reason",
+                header: "Reason",
+                render: (e) => e.denial_reason ?? "—",
+              },
+              { key: "timestamp", header: "Timestamp", render: (e) => e.timestamp },
+            ]}
+            rows={activity}
+          />
+        )}
+      </Panel>
+
+      {statusMsg && <StatusLine>{statusMsg}</StatusLine>}
+    </div>
+  );
+}

--- a/ui/src/screens/OperatorPage.tsx
+++ b/ui/src/screens/OperatorPage.tsx
@@ -6,6 +6,10 @@ import {
   DeskOperatorConfig,
   OperatorStatusResponse,
   OperatorActivityEntry,
+  OperatorSession,
+  SessionKind,
+  SessionRole,
+  ConfirmationRequest,
   fetchOperatorStatus,
   fetchOperatorConfig,
   updateOperatorConfig,
@@ -13,6 +17,13 @@ import {
   stopOperator,
   pauseOperator,
   fetchOperatorActivity,
+  joinSession,
+  leaveSession,
+  listSessions,
+  sessionHeartbeat,
+  listConfirmations,
+  confirmProposal,
+  denyProposal,
 } from "../lib/api";
 import {
   Panel,
@@ -72,6 +83,28 @@ function actionTone(entry: OperatorActivityEntry): BadgeTone {
   return "danger";
 }
 
+function sessionStatusTone(s: OperatorSession): BadgeTone {
+  switch (s.status) {
+    case "active": return "ok";
+    case "idle": return "warn";
+    case "disconnected": return "danger";
+    default: return "neutral";
+  }
+}
+
+function kindTone(k: SessionKind): BadgeTone {
+  return k === "ai" ? "accent" : "info";
+}
+
+function confirmationTone(c: ConfirmationRequest): BadgeTone {
+  switch (c.status) {
+    case "confirmed": return "ok";
+    case "denied": return "danger";
+    case "expired": return "warn";
+    case "pending": default: return "info";
+  }
+}
+
 export function OperatorPage() {
   const [status, setStatus] = useState<OperatorStatusResponse | null>(null);
   const [config, setConfig] = useState<DeskOperatorConfig | null>(null);
@@ -79,6 +112,17 @@ export function OperatorPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [statusMsg, setStatusMsg] = useState("");
+
+  // CoPilot state
+  const [sessions, setSessions] = useState<OperatorSession[]>([]);
+  const [humanCount, setHumanCount] = useState(0);
+  const [aiCount, setAiCount] = useState(0);
+  const [confirmations, setConfirmations] = useState<ConfirmationRequest[]>([]);
+  const [mySession, setMySession] = useState<OperatorSession | null>(null);
+  const [joinName, setJoinName] = useState("");
+  const [joinKind, setJoinKind] = useState<SessionKind>("human");
+  const [joinRole, setJoinRole] = useState<SessionRole>("operator");
+  const [joinLocation, setJoinLocation] = useState("");
 
   // Editable config form state
   const [editEnabled, setEditEnabled] = useState(false);
@@ -96,14 +140,20 @@ export function OperatorPage() {
     setLoading(true);
     setError(null);
     try {
-      const [st, cfg, act] = await Promise.all([
+      const [st, cfg, act, sess, confs] = await Promise.all([
         fetchOperatorStatus(),
         fetchOperatorConfig(),
         fetchOperatorActivity(50),
+        listSessions(),
+        listConfirmations(),
       ]);
       setStatus(st);
       setConfig(cfg);
       setActivity(act);
+      setSessions(sess.sessions);
+      setHumanCount(sess.human_count);
+      setAiCount(sess.ai_count);
+      setConfirmations(confs.pending);
       // Sync form state with loaded config
       setEditEnabled(cfg.enabled);
       setEditMode(cfg.autopilot_mode);
@@ -187,6 +237,84 @@ export function OperatorPage() {
       setStatusMsg(err instanceof Error ? err.message : "Failed to pause operator");
     }
   }
+
+  // ---- CoPilot handlers ----
+
+  async function handleJoin(e: FormEvent) {
+    e.preventDefault();
+    setStatusMsg("");
+    try {
+      const session = await joinSession({
+        display_name: joinName.trim(),
+        kind: joinKind,
+        role: joinRole,
+        location: joinLocation.trim() || undefined,
+      });
+      setMySession(session);
+      setStatusMsg(`Joined as ${session.display_name}.`);
+      setJoinName("");
+      setJoinLocation("");
+      await loadAll();
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : "Failed to join");
+    }
+  }
+
+  async function handleLeave() {
+    if (!mySession) return;
+    setStatusMsg("");
+    try {
+      await leaveSession(mySession.id);
+      setMySession(null);
+      setStatusMsg("Left the desk.");
+      await loadAll();
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : "Failed to leave");
+    }
+  }
+
+  async function handleConfirm(confirmationId: string) {
+    if (!mySession) {
+      setStatusMsg("You must join the desk first to confirm proposals.");
+      return;
+    }
+    setStatusMsg("");
+    try {
+      await confirmProposal(confirmationId, mySession.id);
+      setStatusMsg("Proposal confirmed.");
+      await loadAll();
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : "Failed to confirm");
+    }
+  }
+
+  async function handleDeny(confirmationId: string) {
+    if (!mySession) {
+      setStatusMsg("You must join the desk first to deny proposals.");
+      return;
+    }
+    setStatusMsg("");
+    try {
+      await denyProposal(confirmationId, mySession.id);
+      setStatusMsg("Proposal denied.");
+      await loadAll();
+    } catch (err) {
+      setStatusMsg(err instanceof Error ? err.message : "Failed to deny");
+    }
+  }
+
+  // Heartbeat effect — keep our session alive while connected
+  useEffect(() => {
+    if (!mySession) return;
+    const interval = setInterval(async () => {
+      try {
+        await sessionHeartbeat(mySession.id);
+      } catch {
+        // Silent fail — heartbeat will retry
+      }
+    }, 15000); // 15 second heartbeat
+    return () => clearInterval(interval);
+  }, [mySession]);
 
   if (loading) return <LoadingState title="Loading operator status..." />;
   if (error)
@@ -391,6 +519,149 @@ export function OperatorPage() {
               { key: "timestamp", header: "Timestamp", render: (e) => e.timestamp },
             ]}
             rows={activity}
+          />
+        )}
+      </Panel>
+
+      {/* CoPilot Mode: Multi-participant collaboration */}
+
+      <Panel title="CoPilot — Join the Desk">
+        {mySession ? (
+          <div>
+            <div className="hx-stat-row">
+              <span>You are connected as</span>
+              <Badge tone={kindTone(mySession.kind)}>
+                {mySession.display_name} ({mySession.kind})
+              </Badge>
+            </div>
+            <div className="hx-stat-row">
+              <span>Role</span>
+              <Badge tone="info">{mySession.role}</Badge>
+            </div>
+            <div className="hx-stat-row">
+              <span>Status</span>
+              <Badge tone={sessionStatusTone(mySession)}>{mySession.status}</Badge>
+            </div>
+            <div style={{ marginTop: "1rem" }}>
+              <Button onClick={handleLeave}>Leave Desk</Button>
+            </div>
+          </div>
+        ) : (
+          <form onSubmit={handleJoin} className="hx-form">
+            <FormField label="Display Name" hint="Your name as it appears to other operators">
+              <Input
+                value={joinName}
+                onChange={(e) => setJoinName(e.target.value)}
+                placeholder="Alice"
+                required
+              />
+            </FormField>
+            <FormField label="Kind" hint="Human or AI copilot">
+              <Select
+                value={joinKind}
+                onChange={(e) => setJoinKind(e.target.value as SessionKind)}
+              >
+                <option value="human">Human</option>
+                <option value="ai">AI Copilot</option>
+              </Select>
+            </FormField>
+            <FormField label="Role" hint="Viewer=observe only, Operator=can confirm, Admin=full control">
+              <Select
+                value={joinRole}
+                onChange={(e) => setJoinRole(e.target.value as SessionRole)}
+              >
+                <option value="viewer">Viewer</option>
+                <option value="operator">Operator</option>
+                <option value="admin">Admin</option>
+              </Select>
+            </FormField>
+            <FormField label="Location" hint="Where you're operating from (optional)">
+              <Input
+                value={joinLocation}
+                onChange={(e) => setJoinLocation(e.target.value)}
+                placeholder="Tokyo"
+              />
+            </FormField>
+            <div style={{ marginTop: "1rem" }}>
+              <Button type="submit">Join Desk</Button>
+            </div>
+          </form>
+        )}
+      </Panel>
+
+      <Panel title={`CoPilot — Active Participants (${sessions.length})`}>
+        {sessions.length === 0 ? (
+          <EmptyState
+            title="No one connected"
+            description="Join the desk to start collaborating. Humans and AI copilots can work together in real time."
+          />
+        ) : (
+          <DataTable
+            rowKey={(s) => s.id}
+            columns={[
+              { key: "display_name", header: "Name", render: (s) => s.display_name },
+              {
+                key: "kind",
+                header: "Kind",
+                render: (s) => <Badge tone={kindTone(s.kind)}>{s.kind}</Badge>,
+              },
+              { key: "role", header: "Role", render: (s) => s.role },
+              {
+                key: "status",
+                header: "Status",
+                render: (s) => (
+                  <Badge tone={sessionStatusTone(s)}>{s.status}</Badge>
+                ),
+              },
+              { key: "location", header: "Location", render: (s) => s.location ?? "—" },
+              { key: "joined_at", header: "Joined", render: (s) => s.joined_at },
+            ]}
+            rows={sessions}
+          />
+        )}
+      </Panel>
+
+      <Panel title={`Confirmation Queue — Pending AI Proposals (${confirmations.length})`}>
+        {confirmations.length === 0 ? (
+          <EmptyState
+            title="No pending confirmations"
+            description="When the AI operator proposes actions in assist mode, they will appear here for human review."
+          />
+        ) : (
+          <DataTable
+            rowKey={(c) => c.id}
+            columns={[
+              { key: "cycle", header: "Cycle", render: (c) => String(c.cycle) },
+              {
+                key: "action_type",
+                header: "Action",
+                render: (c) => c.proposal.type,
+              },
+              { key: "rationale", header: "Rationale", render: (c) => c.rationale },
+              {
+                key: "status",
+                header: "Status",
+                render: (c) => (
+                  <Badge tone={confirmationTone(c)}>{c.status}</Badge>
+                ),
+              },
+              {
+                key: "actions",
+                header: "Review",
+                render: (c) =>
+                  c.status === "pending" ? (
+                    <div style={{ display: "flex", gap: "0.5rem" }}>
+                      <Button onClick={() => handleConfirm(c.id)}>Confirm</Button>
+                      <Button onClick={() => handleDeny(c.id)}>Deny</Button>
+                    </div>
+                  ) : (
+                    <span>
+                      {c.resolved_by_name ? `by ${c.resolved_by_name}` : "—"}
+                    </span>
+                  ),
+              },
+            ]}
+            rows={confirmations}
           />
         )}
       </Panel>

--- a/ui/src/screens/PolicyWorkbenchPage.tsx
+++ b/ui/src/screens/PolicyWorkbenchPage.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useMemo, useState } from "react";
+import { FormEvent, ReactNode, useEffect, useMemo, useState } from "react";
 import {
   DeterministicPolicyConfig,
   PolicyCommand,
@@ -7,6 +7,16 @@ import {
   simulatePolicy,
   updatePolicyConfig,
 } from "../lib/api";
+import {
+  Panel,
+  FormField,
+  Input,
+  Textarea,
+  Button,
+  StatusLine,
+  DataTable,
+  LoadingState,
+} from "../components";
 
 const DEFAULT_COMMANDS: PolicyCommand[] = [
   { type: "nonce_reserve" },
@@ -59,6 +69,111 @@ function prettyCommand(c: PolicyCommand): string {
   }
 }
 
+type StepRow = { idx: number; step: PolicyStepResult };
+
+type StepColumn = {
+  key: string;
+  header: string;
+  render: (row: StepRow) => ReactNode;
+  width?: string;
+};
+
+const OUTPUT_COLUMNS: StepColumn[] = [
+  { key: "index", header: "#", render: (row) => row.idx + 1 },
+  { key: "command", header: "Command", render: (row) => prettyCommand(row.step.command) },
+  {
+    key: "decision",
+    header: "Decision",
+    render: (row) => {
+      const d = row.step.decision;
+      return (
+        <>
+          {d.kind}
+          {d.reason ? ` (${d.reason})` : ""}
+          {d.decision ? ` (${d.decision})` : ""}
+          {d.status ? ` (${d.status})` : ""}
+          {d.route ? ` (${d.route})` : ""}
+          {d.outcome ? ` (${d.outcome})` : ""}
+          {d.quoted !== undefined ? ` (quoted=${d.quoted})` : ""}
+          {d.state ? ` (${d.state})` : ""}
+          {d.remaining_depth !== undefined ? ` (remaining_depth=${d.remaining_depth})` : ""}
+          {d.nonce !== undefined ? ` (nonce=${d.nonce})` : ""}
+          {d.next_nonce !== undefined ? ` (next_nonce=${d.next_nonce})` : ""}
+          {d.max_fee !== undefined
+            ? ` (max_fee=${d.max_fee}, priority=${d.max_priority_fee}, rejects=${d.rejection_count})`
+            : ""}
+        </>
+      );
+    },
+  },
+  { key: "rate_tokens", header: "Rate Tokens", render: (row) => row.step.snapshot.rate_tokens },
+  { key: "queue_depth", header: "Queue Depth", render: (row) => row.step.snapshot.queue_depth },
+  { key: "breaker", header: "Breaker", render: (row) => row.step.snapshot.breaker_phase },
+  { key: "retry", header: "Retry Left", render: (row) => row.step.snapshot.retry_remaining },
+  {
+    key: "dlq",
+    header: "DLQ Failures",
+    render: (row) => row.step.snapshot.dlq_consecutive_failures,
+  },
+  {
+    key: "sla",
+    header: "SLA",
+    render: (row) =>
+      row.step.snapshot.sla_active
+        ? `${row.step.snapshot.sla_expired ? "expired" : "active"}:${row.step.snapshot.sla_remaining_ticks}`
+        : "idle",
+  },
+  {
+    key: "nonce",
+    header: "Nonce",
+    render: (row) =>
+      `next=${row.step.snapshot.nonce_next}, in_flight=${row.step.snapshot.nonce_in_flight}`,
+  },
+  {
+    key: "fee",
+    header: "Fee",
+    render: (row) => `rejections=${row.step.snapshot.fee_rejection_count}`,
+  },
+  {
+    key: "finality",
+    header: "Finality",
+    render: (row) =>
+      `depth=${row.step.snapshot.finality_observed_depth}, finalized=${String(
+        row.step.snapshot.finality_finalized
+      )}, reorg=${String(row.step.snapshot.finality_reorg_detected)}`,
+  },
+  {
+    key: "allowlist",
+    header: "Allowlist",
+    render: (row) => `paused=${String(row.step.snapshot.allowlist_paused)}`,
+  },
+];
+
+const CONFIG_KEYS = [
+  "dedup_window_ticks",
+  "rate_max_tokens",
+  "rate_refill_per_tick",
+  "breaker_failure_threshold",
+  "breaker_open_duration_ticks",
+  "retry_budget",
+  "approval_quorum",
+  "approval_reviewers",
+  "backpressure_soft_limit",
+  "backpressure_hard_limit",
+  "sla_deadline_ticks",
+  "dlq_max_consecutive_failures",
+  "nonce_start",
+  "nonce_max_in_flight",
+  "fee_base_fee",
+  "fee_priority_fee",
+  "fee_bump_bps",
+  "fee_max_fee_cap",
+  "finality_required_depth",
+  "allowlist_chain_id",
+  "allowlist_contract_tag",
+  "allowlist_method_tag",
+] as const;
+
 export function PolicyWorkbenchPage() {
   const [config, setConfig] = useState<DeterministicPolicyConfig | null>(null);
   const [configStatus, setConfigStatus] = useState<string>("Loading config...");
@@ -105,170 +220,80 @@ export function PolicyWorkbenchPage() {
     }
   }
 
-  const finalSnapshot = useMemo(() => (steps.length > 0 ? steps[steps.length - 1].snapshot : null), [steps]);
+  const finalSnapshot = useMemo(
+    () => (steps.length > 0 ? steps[steps.length - 1].snapshot : null),
+    [steps]
+  );
+
+  const stepRows: StepRow[] = useMemo(
+    () => steps.map((step, idx) => ({ idx, step })),
+    [steps]
+  );
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel panel-hero panel-span-12">
-        <p className="mono-label">Policy Workbench</p>
-        <h2>Deterministic Controls + Replayable Simulation</h2>
-        <p>
+    <section className="hx-page-grid">
+      <Panel hero span={12} eyebrow="Policy Workbench" title="Deterministic Controls + Replayable Simulation">
+        <p className="hx-description">
           Edit policy parameters, run deterministic command sequences, and inspect final snapshots.
         </p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-6">
-        <p className="mono-label">Policy Config</p>
-        <form onSubmit={onSaveConfig} className="form-grid">
-          {config ? (
-            <>
-              {(
-                [
-                  "dedup_window_ticks",
-                  "rate_max_tokens",
-                  "rate_refill_per_tick",
-                  "breaker_failure_threshold",
-                  "breaker_open_duration_ticks",
-                  "retry_budget",
-                  "approval_quorum",
-                  "approval_reviewers",
-                  "backpressure_soft_limit",
-                  "backpressure_hard_limit",
-                  "sla_deadline_ticks",
-                  "dlq_max_consecutive_failures",
-                  "nonce_start",
-                  "nonce_max_in_flight",
-                  "fee_base_fee",
-                  "fee_priority_fee",
-                  "fee_bump_bps",
-                  "fee_max_fee_cap",
-                  "finality_required_depth",
-                  "allowlist_chain_id",
-                  "allowlist_contract_tag",
-                  "allowlist_method_tag",
-                ] as const
-              ).map((key) => (
-                <label key={key} className="field">
-                  <span>{key}</span>
-                  <input
-                    type="number"
-                    min={0}
-                    value={config[key]}
-                    onChange={(e) =>
-                      setConfig({
-                        ...config,
-                        [key]: Number(e.target.value),
-                      })
-                    }
-                  />
-                </label>
-              ))}
-              <button type="submit" className="btn-primary">
-                Save Config
-              </button>
-            </>
-          ) : (
-            <p>Loading...</p>
-          )}
-        </form>
-        <p className="status-line">{configStatus}</p>
-      </article>
+      <Panel span={6} eyebrow="Policy Config" title="Parameters">
+        {config ? (
+          <form className="hx-form-grid" onSubmit={onSaveConfig}>
+            {CONFIG_KEYS.map((key) => (
+              <FormField key={key} label={key}>
+                <Input
+                  type="number"
+                  min={0}
+                  value={config[key]}
+                  onChange={(e) =>
+                    setConfig({
+                      ...config,
+                      [key]: Number(e.target.value),
+                    })
+                  }
+                />
+              </FormField>
+            ))}
+            <div className="hx-cluster" style={{ gridColumn: "1 / -1" }}>
+              <Button type="submit">Save Config</Button>
+            </div>
+          </form>
+        ) : (
+          <LoadingState title="Loading config..." />
+        )}
+        <StatusLine>{configStatus}</StatusLine>
+      </Panel>
 
-      <article className="panel panel-span-6">
-        <p className="mono-label">Simulation Commands</p>
-        <textarea
-          className="command-editor"
-          value={commandsText}
-          onChange={(e) => setCommandsText(e.target.value)}
-          rows={14}
-        />
-        <div className="button-row">
-          <button className="btn-primary" onClick={onSimulate}>
+      <Panel span={6} eyebrow="Simulation Commands" title="Replay Sequence">
+        <FormField label="Command JSON" full>
+          <Textarea rows={14} value={commandsText} onChange={(e) => setCommandsText(e.target.value)} />
+        </FormField>
+        <div className="hx-cluster">
+          <Button type="button" onClick={onSimulate}>
             Run Simulation
-          </button>
-          <button
-            className="btn-secondary"
+          </Button>
+          <Button
+            variant="secondary"
+            type="button"
             onClick={() => setCommandsText(JSON.stringify(DEFAULT_COMMANDS, null, 2))}
           >
             Reset Example
-          </button>
+          </Button>
         </div>
-        <p className="status-line">{simulateStatus}</p>
-      </article>
+        <StatusLine>{simulateStatus}</StatusLine>
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <p className="mono-label">Simulation Output</p>
-        <div className="table-wrap">
-          <table className="result-table">
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>Command</th>
-                <th>Decision</th>
-                <th>Rate Tokens</th>
-                <th>Queue Depth</th>
-                <th>Breaker</th>
-                <th>Retry Left</th>
-                <th>DLQ Failures</th>
-                <th>SLA</th>
-                <th>Nonce</th>
-                <th>Fee</th>
-                <th>Finality</th>
-                <th>Allowlist</th>
-              </tr>
-            </thead>
-            <tbody>
-              {steps.map((step, idx) => (
-                <tr key={`${idx}-${step.decision.kind}`}>
-                  <td>{idx + 1}</td>
-                  <td>{prettyCommand(step.command)}</td>
-                  <td>
-                    {step.decision.kind}
-                    {step.decision.reason ? ` (${step.decision.reason})` : ""}
-                    {step.decision.decision ? ` (${step.decision.decision})` : ""}
-                    {step.decision.status ? ` (${step.decision.status})` : ""}
-                    {step.decision.route ? ` (${step.decision.route})` : ""}
-                    {step.decision.outcome ? ` (${step.decision.outcome})` : ""}
-                    {step.decision.quoted !== undefined ? ` (quoted=${step.decision.quoted})` : ""}
-                    {step.decision.state ? ` (${step.decision.state})` : ""}
-                    {step.decision.remaining_depth !== undefined
-                      ? ` (remaining_depth=${step.decision.remaining_depth})`
-                      : ""}
-                    {step.decision.nonce !== undefined ? ` (nonce=${step.decision.nonce})` : ""}
-                    {step.decision.next_nonce !== undefined
-                      ? ` (next_nonce=${step.decision.next_nonce})`
-                      : ""}
-                    {step.decision.max_fee !== undefined
-                      ? ` (max_fee=${step.decision.max_fee}, priority=${step.decision.max_priority_fee}, rejects=${step.decision.rejection_count})`
-                      : ""}
-                  </td>
-                  <td>{step.snapshot.rate_tokens}</td>
-                  <td>{step.snapshot.queue_depth}</td>
-                  <td>{step.snapshot.breaker_phase}</td>
-                  <td>{step.snapshot.retry_remaining}</td>
-                  <td>{step.snapshot.dlq_consecutive_failures}</td>
-                  <td>
-                    {step.snapshot.sla_active
-                      ? `${step.snapshot.sla_expired ? "expired" : "active"}:${step.snapshot.sla_remaining_ticks}`
-                      : "idle"}
-                  </td>
-                  <td>
-                    next={step.snapshot.nonce_next}, in_flight={step.snapshot.nonce_in_flight}
-                  </td>
-                  <td>rejections={step.snapshot.fee_rejection_count}</td>
-                  <td>
-                    depth={step.snapshot.finality_observed_depth}, finalized=
-                    {String(step.snapshot.finality_finalized)}, reorg=
-                    {String(step.snapshot.finality_reorg_detected)}
-                  </td>
-                  <td>paused={String(step.snapshot.allowlist_paused)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+      <Panel span={12} eyebrow="Simulation Output" title="Step Trace">
+        <DataTable
+          columns={OUTPUT_COLUMNS}
+          rows={stepRows}
+          rowKey={(row) => `${row.idx}-${row.step.decision.kind}`}
+          emptyMessage="Run a simulation to inspect the deterministic step trace."
+        />
         {finalSnapshot && (
-          <p className="status-line">
+          <StatusLine>
             Final snapshot: tokens={finalSnapshot.rate_tokens}, queue={finalSnapshot.queue_depth},
             breaker={finalSnapshot.breaker_phase}, retry={finalSnapshot.retry_remaining},
             dlq_failures={finalSnapshot.dlq_consecutive_failures}, sla=
@@ -281,9 +306,9 @@ export function PolicyWorkbenchPage() {
             {String(finalSnapshot.finality_finalized)}, reorg=
             {String(finalSnapshot.finality_reorg_detected)}, allowlist_paused=
             {String(finalSnapshot.allowlist_paused)}
-          </p>
+          </StatusLine>
         )}
-      </article>
+      </Panel>
     </section>
   );
 }

--- a/ui/src/screens/RulesPage.tsx
+++ b/ui/src/screens/RulesPage.tsx
@@ -12,6 +12,21 @@ import {
   runRecipeTriggerPlan,
   upsertAutomationRule,
 } from "../lib/api";
+import {
+  Panel,
+  StatCard,
+  StatGrid,
+  Badge,
+  Button,
+  FormField,
+  Input,
+  Textarea,
+  Select,
+  CheckboxField,
+  StatusLine,
+  Tag,
+  CodeBlock,
+} from "../components";
 
 const OPERATOR_OPTIONS: { value: RuleOperator; label: string }[] = [
   { value: "equals", label: "equals" },
@@ -257,55 +272,48 @@ export function RulesPage() {
   }
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel panel-hero panel-span-12">
-        <p className="mono-label">Automation Rules</p>
-        <h2>Event Rules With Durable Trigger Plans</h2>
-        <p>
+    <section className="hx-page-grid">
+      <Panel hero span={12} eyebrow="Automation Rules" title="Event Rules With Durable Trigger Plans">
+        <p className="hx-description">
           Store deterministic match rules, evaluate CloudEvents, and inspect the recipe trigger
           packets before automation reaches the runtime.
         </p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-4">
-        <p className="mono-label">Rule Status</p>
-        <div className="metrics-grid">
-          <div className="metric-card">
-            <span className="metric-label">rules</span>
-            <strong className="metric-value">{rules.length}</strong>
-          </div>
-          <div className="metric-card">
-            <span className="metric-label">enabled</span>
-            <strong className="metric-value">{enabledCount}</strong>
-          </div>
-        </div>
-        <div className="pill-row">
-          <span className={`status-pill ${persistenceEnabled ? "ok" : "warn"}`}>
-            {persistenceEnabled ? "durable" : "in-memory"}
-          </span>
-          <button className="btn-secondary" type="button" onClick={() => void loadRules()}>
+      <Panel
+        span={4}
+        eyebrow="Rule Status"
+        title="Workspace Metrics"
+        actions={
+          <Button variant="secondary" type="button" onClick={() => void loadRules()}>
             Refresh
-          </button>
+          </Button>
+        }
+      >
+        <StatGrid>
+          <StatCard label="rules" value={rules.length} tone="info" />
+          <StatCard label="enabled" value={enabledCount} tone="ok" />
+        </StatGrid>
+        <div className="hx-tag-row">
+          <Badge tone={persistenceEnabled ? "ok" : "warn"}>
+            {persistenceEnabled ? "durable" : "in-memory"}
+          </Badge>
         </div>
-        <p className="status-line">{status}</p>
-      </article>
+        <StatusLine>{status}</StatusLine>
+      </Panel>
 
-      <article className="panel panel-span-8">
-        <p className="mono-label">Create Rule</p>
-        <form className="form-grid" onSubmit={onSubmit}>
-          <label className="field field-full">
-            <span>name</span>
-            <input value={name} onChange={(event) => setName(event.target.value)} />
-          </label>
+      <Panel span={8} eyebrow="Create Rule" title="Rule Builder">
+        <form className="hx-form-grid" onSubmit={onSubmit}>
+          <FormField label="name" full>
+            <Input value={name} onChange={(event) => setName(event.target.value)} />
+          </FormField>
 
-          <label className="field">
-            <span>match_field</span>
-            <input value={field} onChange={(event) => setField(event.target.value)} />
-          </label>
+          <FormField label="match_field">
+            <Input value={field} onChange={(event) => setField(event.target.value)} />
+          </FormField>
 
-          <label className="field">
-            <span>operator</span>
-            <select
+          <FormField label="operator">
+            <Select
               value={operator}
               onChange={(event) => setOperator(event.target.value as RuleOperator)}
             >
@@ -314,224 +322,241 @@ export function RulesPage() {
                   {option.label}
                 </option>
               ))}
-            </select>
-          </label>
+            </Select>
+          </FormField>
 
-          <label className="field">
-            <span>value_json</span>
-            <input
+          <FormField label="value_json">
+            <Input
               disabled={operator === "exists"}
               value={literal}
               onChange={(event) => setLiteral(event.target.value)}
             />
-          </label>
+          </FormField>
 
-          <label className="field">
-            <span>recipe_id</span>
-            <input value={recipeId} onChange={(event) => setRecipeId(event.target.value)} />
-          </label>
+          <FormField label="recipe_id">
+            <Input value={recipeId} onChange={(event) => setRecipeId(event.target.value)} />
+          </FormField>
 
-          <label className="field">
-            <span>parameter</span>
-            <input
+          <FormField label="parameter">
+            <Input
               value={parameterName}
               onChange={(event) => setParameterName(event.target.value)}
             />
-          </label>
+          </FormField>
 
-          <label className="field">
-            <span>from_event</span>
-            <input
+          <FormField label="from_event">
+            <Input
               value={parameterPath}
               onChange={(event) => setParameterPath(event.target.value)}
             />
-          </label>
+          </FormField>
 
-          <label className="field checkbox-field">
-            <input
-              type="checkbox"
-              checked={enabled}
-              onChange={(event) => setEnabled(event.target.checked)}
-            />
-            <span>enabled</span>
-          </label>
+          <CheckboxField
+            label="enabled"
+            checked={enabled}
+            onChange={(checked) => setEnabled(checked)}
+            full
+          />
 
-          <button className="btn-primary" type="submit">
-            Save Rule
-          </button>
+          <div className="hx-cluster" style={{ gridColumn: "1 / -1" }}>
+            <Button type="submit">Save Rule</Button>
+          </div>
         </form>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-6">
-        <div className="panel-toolbar">
-          <div>
-            <p className="mono-label">Rule Catalog</p>
-            <p className="status-line">{rules.length} stored rule definition(s).</p>
+      <Panel
+        span={6}
+        eyebrow="Rule Catalog"
+        title="Stored Definitions"
+        actions={<Badge tone="info">{rules.length} rule(s)</Badge>}
+      >
+        <StatusLine>{rules.length} stored rule definition(s).</StatusLine>
+        {rules.length === 0 ? (
+          <div className="hx-table-empty">
+            <p>No automation rules are stored in the current workspace.</p>
           </div>
-        </div>
-        <div className="command-list">
-          {rules.length === 0 ? (
-            <p className="panel-note">No automation rules are stored in the current workspace.</p>
-          ) : (
-            rules.map((rule) => (
-              <div key={rule.id} className="command-row">
-                <div className="command-row-head">
-                  <h3>{rule.name}</h3>
-                  <span className={`status-pill ${rule.enabled !== false ? "ok" : "warn"}`}>
-                    {rule.enabled !== false ? "enabled" : "paused"}
-                  </span>
+        ) : (
+          <div className="hx-list">
+            {rules.map((rule) => (
+              <div key={rule.id} className="hx-row">
+                <div className="hx-row-stack">
+                  <div className="hx-row-primary">
+                    <h3>{rule.name}</h3>
+                    <Badge tone={rule.enabled !== false ? "ok" : "warn"}>
+                      {rule.enabled !== false ? "enabled" : "paused"}
+                    </Badge>
+                  </div>
+                  <p className="hx-mono-detail">{rule.id}</p>
+                  <div className="hx-tag-row">
+                    <Tag>{describeCondition(rule.condition)}</Tag>
+                    <Tag>{actionTarget(rule)}</Tag>
+                  </div>
                 </div>
-                <p className="mono-detail">{rule.id}</p>
-                <div className="pill-row">
-                  <span className="info-pill">{describeCondition(rule.condition)}</span>
-                  <span className="info-pill">{actionTarget(rule)}</span>
-                </div>
-                <pre className="json-block">{formatJson(rule.actions)}</pre>
+                <CodeBlock>{formatJson(rule.actions)}</CodeBlock>
               </div>
-            ))
-          )}
-        </div>
-      </article>
-
-      <article className="panel panel-span-6">
-        <div className="panel-toolbar">
-          <div>
-            <p className="mono-label">Evaluate Event</p>
-            <p className="status-line">{plans.length} trigger plan(s) from latest evaluation.</p>
+            ))}
           </div>
-          <button className="btn-secondary" type="button" onClick={() => void onEvaluate()}>
+        )}
+      </Panel>
+
+      <Panel
+        span={6}
+        eyebrow="Evaluate Event"
+        title="Trigger Plan Preview"
+        actions={
+          <Button variant="secondary" type="button" onClick={() => void onEvaluate()}>
             Evaluate
-          </button>
-        </div>
-        <label className="field field-full">
-          <span>event_json</span>
-          <textarea
+          </Button>
+        }
+      >
+        <StatusLine>{plans.length} trigger plan(s) from latest evaluation.</StatusLine>
+        <FormField label="event_json" full>
+          <Textarea
             rows={9}
             value={eventJson}
             onChange={(event) => setEventJson(event.target.value)}
           />
-        </label>
-        <div className="command-list rule-plan-list">
-          {plans.length === 0 ? (
-            <p className="panel-note">No trigger plans have been produced.</p>
-          ) : (
-            plans.map((plan) => (
-              <div key={`${plan.rule_id}:${plan.action_id ?? plan.recipe_id ?? plan.recipe_name}`} className="command-row">
-                <div className="command-row-head">
-                  <h3>{plan.rule_name}</h3>
-                  <div className="toolbar-actions">
-                    <span className="status-pill info">trigger</span>
-                    <button
-                      className="btn-secondary"
-                      type="button"
-                      onClick={() => void onRunPlan(plan)}
-                    >
-                      Run
-                    </button>
+        </FormField>
+        {plans.length === 0 ? (
+          <div className="hx-table-empty">
+            <p>No trigger plans have been produced.</p>
+          </div>
+        ) : (
+          <div className="hx-list">
+            {plans.map((plan) => (
+              <div
+                key={`${plan.rule_id}:${plan.action_id ?? plan.recipe_id ?? plan.recipe_name}`}
+                className="hx-row hx-row--info"
+              >
+                <div className="hx-row-stack">
+                  <div className="hx-row-primary">
+                    <h3>{plan.rule_name}</h3>
+                    <div className="hx-cluster">
+                      <Badge tone="info">trigger</Badge>
+                      <Button
+                        variant="secondary"
+                        type="button"
+                        onClick={() => void onRunPlan(plan)}
+                      >
+                        Run
+                      </Button>
+                    </div>
+                  </div>
+                  <div className="hx-tag-row">
+                    {plan.recipe_id ? <Tag>recipe_id: {plan.recipe_id}</Tag> : null}
+                    {plan.recipe_name ? <Tag>recipe_name: {plan.recipe_name}</Tag> : null}
                   </div>
                 </div>
-                <div className="pill-row">
-                  {plan.recipe_id ? <span className="info-pill">recipe_id: {plan.recipe_id}</span> : null}
-                  {plan.recipe_name ? (
-                    <span className="info-pill">recipe_name: {plan.recipe_name}</span>
-                  ) : null}
-                </div>
-                <pre className="json-block">{formatJson(plan.parameters)}</pre>
+                <CodeBlock>{formatJson(plan.parameters)}</CodeBlock>
               </div>
-            ))
-          )}
-        </div>
-      </article>
-
-      <article className="panel panel-span-12">
-        <div className="panel-toolbar">
-          <div>
-            <p className="mono-label">Evaluation History</p>
-            <p className="status-line">{historyStatus}</p>
+            ))}
           </div>
-          <div className="toolbar-actions">
-            <span className={`status-pill ${historyPersistenceEnabled ? "ok" : "warn"}`}>
+        )}
+      </Panel>
+
+      <Panel
+        span={12}
+        eyebrow="Evaluation History"
+        title="Persisted Evaluations"
+        actions={
+          <div className="hx-cluster">
+            <Badge tone={historyPersistenceEnabled ? "ok" : "warn"}>
               {historyPersistenceEnabled ? "durable" : "not persisted"}
-            </span>
-            <button
-              className="btn-secondary"
+            </Badge>
+            <Button
+              variant="secondary"
               type="button"
               onClick={() => void loadEvaluationHistory()}
             >
               Refresh
-            </button>
+            </Button>
           </div>
-        </div>
-        <div className="command-list">
-          {evaluations.length === 0 ? (
-            <p className="panel-note">No rule evaluations have been persisted.</p>
-          ) : (
-            evaluations.map((entry) => (
-              <div key={entry.id} className="command-row">
-                <div className="command-row-head">
-                  <h3>{entry.event_type}</h3>
-                  <span className={`status-pill ${entry.trigger_plan_count > 0 ? "ok" : "warn"}`}>
-                    {entry.trigger_plan_count} plan(s)
-                  </span>
+        }
+      >
+        <StatusLine>{historyStatus}</StatusLine>
+        {evaluations.length === 0 ? (
+          <div className="hx-table-empty">
+            <p>No rule evaluations have been persisted.</p>
+          </div>
+        ) : (
+          <div className="hx-list">
+            {evaluations.map((entry) => (
+              <div key={entry.id} className="hx-row">
+                <div className="hx-row-stack">
+                  <div className="hx-row-primary">
+                    <h3>{entry.event_type}</h3>
+                    <Badge tone={entry.trigger_plan_count > 0 ? "ok" : "warn"}>
+                      {entry.trigger_plan_count} plan(s)
+                    </Badge>
+                  </div>
+                  <p className="hx-mono-detail">{entry.event_id}</p>
+                  <div className="hx-tag-row">
+                    <Tag>source: {entry.event_source}</Tag>
+                    <Tag>rules: {entry.rule_count}</Tag>
+                    <Tag>created: {entry.created_at}</Tag>
+                  </div>
                 </div>
-                <p className="mono-detail">{entry.event_id}</p>
-                <div className="pill-row">
-                  <span className="info-pill">source: {entry.event_source}</span>
-                  <span className="info-pill">rules: {entry.rule_count}</span>
-                  <span className="info-pill">created: {entry.created_at}</span>
-                </div>
-                <pre className="json-block">
+                <CodeBlock>
                   {formatJson({
                     event: entry.event,
                     trigger_plans: entry.trigger_plans,
                   })}
-                </pre>
+                </CodeBlock>
               </div>
-            ))
-          )}
-        </div>
-      </article>
+            ))}
+          </div>
+        )}
+      </Panel>
 
-      <article className="panel panel-span-12">
-        <div className="panel-toolbar">
-          <div>
-            <p className="mono-label">Recipe Run History</p>
-            <p className="status-line">{runStatus}</p>
-          </div>
-          <div className="toolbar-actions">
-            <span className={`status-pill ${runPersistenceEnabled ? "ok" : "warn"}`}>
+      <Panel
+        span={12}
+        eyebrow="Recipe Run History"
+        title="Automation Executions"
+        actions={
+          <div className="hx-cluster">
+            <Badge tone={runPersistenceEnabled ? "ok" : "warn"}>
               {runPersistenceEnabled ? "durable" : "not persisted"}
-            </span>
-            <button className="btn-secondary" type="button" onClick={() => void loadRecipeRuns()}>
+            </Badge>
+            <Button variant="secondary" type="button" onClick={() => void loadRecipeRuns()}>
               Refresh
-            </button>
+            </Button>
           </div>
-        </div>
-        <div className="command-list">
-          {runs.length === 0 ? (
-            <p className="panel-note">No recipe runs have been persisted.</p>
-          ) : (
-            runs.map((entry) => (
-              <div key={entry.id} className="command-row">
-                <div className="command-row-head">
-                  <h3>{entry.resolved_recipe_name ?? entry.requested_recipe_name ?? "unresolved recipe"}</h3>
-                  <span className={`status-pill ${entry.status === "completed" ? "ok" : "warn"}`}>
-                    {entry.status}
-                  </span>
+        }
+      >
+        <StatusLine>{runStatus}</StatusLine>
+        {runs.length === 0 ? (
+          <div className="hx-table-empty">
+            <p>No recipe runs have been persisted.</p>
+          </div>
+        ) : (
+          <div className="hx-list">
+            {runs.map((entry) => (
+              <div key={entry.id} className="hx-row">
+                <div className="hx-row-stack">
+                  <div className="hx-row-primary">
+                    <h3>
+                      {entry.resolved_recipe_name ??
+                        entry.requested_recipe_name ??
+                        "unresolved recipe"}
+                    </h3>
+                    <Badge tone={entry.status === "completed" ? "ok" : "warn"}>
+                      {entry.status}
+                    </Badge>
+                  </div>
+                  <p className="hx-mono-detail">run {entry.id}</p>
+                  <div className="hx-tag-row">
+                    {entry.evaluation_id ? (
+                      <Tag>evaluation: {entry.evaluation_id}</Tag>
+                    ) : null}
+                    {entry.resolved_recipe_id ? (
+                      <Tag>recipe_id: {entry.resolved_recipe_id}</Tag>
+                    ) : null}
+                    <Tag>agents: {entry.started_agent_ids.length}</Tag>
+                    <Tag>created: {entry.created_at}</Tag>
+                  </div>
                 </div>
-                <p className="mono-detail">run {entry.id}</p>
-                <div className="pill-row">
-                  {entry.evaluation_id ? (
-                    <span className="info-pill">evaluation: {entry.evaluation_id}</span>
-                  ) : null}
-                  {entry.resolved_recipe_id ? (
-                    <span className="info-pill">recipe_id: {entry.resolved_recipe_id}</span>
-                  ) : null}
-                  <span className="info-pill">agents: {entry.started_agent_ids.length}</span>
-                  <span className="info-pill">created: {entry.created_at}</span>
-                </div>
-                {entry.error ? <p className="status-line">reason: {entry.error}</p> : null}
-                <pre className="json-block">
+                {entry.error ? <StatusLine>reason: {entry.error}</StatusLine> : null}
+                <CodeBlock>
                   {formatJson({
                     trigger_plan: entry.trigger_plan,
                     parameters: entry.parameters,
@@ -539,12 +564,12 @@ export function RulesPage() {
                     emitted_events: entry.emitted_events,
                     state_snapshots: entry.state_snapshots,
                   })}
-                </pre>
+                </CodeBlock>
               </div>
-            ))
-          )}
-        </div>
-      </article>
+            ))}
+          </div>
+        )}
+      </Panel>
     </section>
   );
 }

--- a/ui/src/screens/SourcesPage.tsx
+++ b/ui/src/screens/SourcesPage.tsx
@@ -1,5 +1,17 @@
 import { FormEvent, useEffect, useState } from "react";
 import { SourceDefinition, SourceKind, collectSource, createSource, fetchSources } from "../lib/api";
+import {
+  Panel,
+  FormField,
+  Input,
+  Textarea,
+  Select,
+  CheckboxField,
+  Button,
+  Badge,
+  Tag,
+  StatusLine,
+} from "../components";
 
 const SOURCE_KIND_OPTIONS: { value: SourceKind; label: string }[] = [
   { value: "rss_feed", label: "RSS Feed" },
@@ -112,172 +124,130 @@ export function SourcesPage() {
   }
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel panel-hero panel-span-12">
-        <p className="mono-label">Source Registry</p>
-        <h2>Self-Hosted Collection With Explicit Trust Boundaries</h2>
-        <p>
-          Register collection adapters, bound their cadence, and assign deterministic trust scores
-          before evidence enters the desk.
+    <section className="hx-page-grid">
+      <Panel hero span={12} eyebrow="Source Registry" title="Self-Hosted Collection With Explicit Trust Boundaries">
+        <p className="hx-description">
+          Register collection adapters, bound their cadence, and assign deterministic
+          trust scores before evidence enters the desk.
         </p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-5">
-        <p className="mono-label">Create Source</p>
-        <form className="form-grid" onSubmit={onSubmit}>
-          <label className="field field-full">
-            <span>profile_id</span>
-            <input value={profileId} onChange={(e) => setProfileId(e.target.value)} />
-          </label>
+      <Panel span={5} eyebrow="Create" title="Register Source">
+        <form className="hx-form-grid" onSubmit={onSubmit}>
+          <FormField label="Profile ID" full>
+            <Input value={profileId} onChange={(e) => setProfileId(e.target.value)} />
+          </FormField>
 
-          <label className="field field-full">
-            <span>name</span>
-            <input value={name} onChange={(e) => setName(e.target.value)} />
-          </label>
+          <FormField label="Name" full>
+            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. TechCrunch RSS" />
+          </FormField>
 
-          <label className="field field-full">
-            <span>description</span>
-            <textarea
-              rows={4}
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-            />
-          </label>
+          <FormField label="Description" full>
+            <Textarea rows={3} value={description} onChange={(e) => setDescription(e.target.value)} placeholder="What this source collects" />
+          </FormField>
 
-          <label className="field">
-            <span>kind</span>
-            <select value={kind} onChange={(e) => setKind(e.target.value as SourceKind)}>
+          <FormField label="Kind">
+            <Select value={kind} onChange={(e) => setKind(e.target.value as SourceKind)}>
               {SOURCE_KIND_OPTIONS.map((option) => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
+                <option key={option.value} value={option.value}>{option.label}</option>
               ))}
-            </select>
-          </label>
+            </Select>
+          </FormField>
 
-          <label className="field field-full">
-            <span>endpoint_url</span>
-            <input value={endpointUrl} onChange={(e) => setEndpointUrl(e.target.value)} />
-          </label>
+          <FormField label="Cadence (min)" hint="1–1440">
+            <Input type="number" min={1} max={1440} value={cadence} onChange={(e) => setCadence(Number(e.target.value))} />
+          </FormField>
 
-          <label className="field field-full">
-            <span>credential_id</span>
-            <input value={credentialId} onChange={(e) => setCredentialId(e.target.value)} />
-          </label>
+          <FormField label="Endpoint URL" full>
+            <Input value={endpointUrl} onChange={(e) => setEndpointUrl(e.target.value)} placeholder="https://..." />
+          </FormField>
 
-          <label className="field">
-            <span>credential_header_name</span>
-            <input
-              value={credentialHeaderName}
-              onChange={(e) => setCredentialHeaderName(e.target.value)}
-            />
-          </label>
+          <FormField label="Credential ID" full>
+            <Input value={credentialId} onChange={(e) => setCredentialId(e.target.value)} placeholder="optional" />
+          </FormField>
 
-          <label className="field">
-            <span>credential_header_prefix</span>
-            <input
-              value={credentialHeaderPrefix}
-              onChange={(e) => setCredentialHeaderPrefix(e.target.value)}
-            />
-          </label>
+          <FormField label="Header name">
+            <Input value={credentialHeaderName} onChange={(e) => setCredentialHeaderName(e.target.value)} />
+          </FormField>
 
-          <label className="field">
-            <span>cadence_minutes</span>
-            <input
-              type="number"
-              min={1}
-              max={1440}
-              value={cadence}
-              onChange={(e) => setCadence(Number(e.target.value))}
-            />
-          </label>
+          <FormField label="Header prefix">
+            <Input value={credentialHeaderPrefix} onChange={(e) => setCredentialHeaderPrefix(e.target.value)} />
+          </FormField>
 
-          <label className="field">
-            <span>trust_score</span>
-            <input
-              type="number"
-              min={0}
-              max={100}
-              value={trustScore}
-              onChange={(e) => setTrustScore(Number(e.target.value))}
-            />
-          </label>
+          <FormField label="Trust score" hint="0–100">
+            <Input type="number" min={0} max={100} value={trustScore} onChange={(e) => setTrustScore(Number(e.target.value))} />
+          </FormField>
 
-          <label className="field field-full">
-            <span>tags</span>
-            <input value={tagsText} onChange={(e) => setTagsText(e.target.value)} />
-          </label>
+          <FormField label="Tags" full hint="Comma-separated">
+            <Input value={tagsText} onChange={(e) => setTagsText(e.target.value)} />
+          </FormField>
 
-          <label className="field checkbox-field field-full">
-            <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
-            <span>enabled</span>
-          </label>
+          <CheckboxField label="Enabled" checked={enabled} onChange={setEnabled} full />
 
-          <button className="btn-primary" type="submit">
-            Register Source
-          </button>
+          <FormField label="" full>
+            <Button type="submit">Register Source</Button>
+          </FormField>
         </form>
-        <p className="status-line">{status}</p>
-      </article>
+        <StatusLine>{status}</StatusLine>
+      </Panel>
 
-      <article className="panel panel-span-7">
-        <p className="mono-label">Active Sources</p>
-        <div className="agent-grid">
-          {sources.map((source) => (
-            <div key={source.id} className="agent-card">
-              <div className="agent-card-head">
-                <h3>{source.name}</h3>
-                <span className={`status-pill ${source.enabled ? "ok" : "warn"}`}>
-                  {source.enabled ? "enabled" : "paused"}
-                </span>
+      <Panel span={7} eyebrow="Active" title="Sources" actions={<Badge tone="accent">{sources.length}</Badge>}>
+        {sources.length === 0 ? (
+          <div className="hx-table-empty"><p>No sources registered yet.</p></div>
+        ) : (
+          <div className="hx-card-grid">
+            {sources.map((source) => (
+              <div key={source.id} className="hx-card">
+                <div className="hx-card-head">
+                  <h3>{source.name}</h3>
+                  <Badge tone={source.enabled ? "ok" : "warn"}>
+                    {source.enabled ? "enabled" : "paused"}
+                  </Badge>
+                </div>
+                <p className="hx-row-secondary">{source.description}</p>
+                <p className="hx-mono-detail">{source.id}</p>
+                <p className="hx-mono-detail">profile: {source.profile_id}</p>
+                {source.endpoint_url && <p className="hx-mono-detail">{source.endpoint_url}</p>}
+                {source.kind === "webhook_ingest" && (
+                  <p className="hx-mono-detail">webhook: /api/v1/sources/{source.id}/webhook</p>
+                )}
+                {source.kind === "file_import" && (
+                  <p className="hx-mono-detail">file import: /api/v1/sources/{source.id}/import</p>
+                )}
+                <div className="hx-tag-row">
+                  <Tag>kind: {source.kind}</Tag>
+                  <Tag>cadence: {source.cadence_minutes}m</Tag>
+                  <Tag>trust: {source.trust_score}</Tag>
+                  {source.credential_id && (
+                    <Tag>credential: {source.credential_id}</Tag>
+                  )}
+                </div>
+                <div className="hx-tag-row">
+                  {source.tags.map((tag) => (
+                    <Tag key={tag}>{tag}</Tag>
+                  ))}
+                </div>
+                <Button
+                  variant="secondary"
+                  type="button"
+                  disabled={
+                    !supportsPullCollection(source) ||
+                    !source.endpoint_url ||
+                    collectingSourceId === source.id
+                  }
+                  onClick={() => void onCollect(source)}
+                >
+                  {supportsPullCollection(source)
+                    ? collectingSourceId === source.id
+                      ? "Collecting..."
+                      : "Collect Now"
+                    : "Push Ingest"}
+                </Button>
               </div>
-              <p>{source.description}</p>
-              <p className="mono-detail">{source.id}</p>
-              <p className="mono-detail">profile: {source.profile_id}</p>
-              {source.endpoint_url ? <p className="mono-detail">{source.endpoint_url}</p> : null}
-              {source.kind === "webhook_ingest" ? (
-                <p className="mono-detail">webhook: /api/v1/sources/{source.id}/webhook</p>
-              ) : null}
-              {source.kind === "file_import" ? (
-                <p className="mono-detail">file import: /api/v1/sources/{source.id}/import</p>
-              ) : null}
-              <div className="pill-row">
-                <span className="info-pill">kind: {source.kind}</span>
-                <span className="info-pill">cadence: {source.cadence_minutes}m</span>
-                <span className="info-pill">trust: {source.trust_score}</span>
-                {source.credential_id ? (
-                  <span className="info-pill">
-                    credential: {source.credential_id} via {source.credential_header_name}
-                  </span>
-                ) : null}
-              </div>
-              <div className="pill-row">
-                {source.tags.map((tag) => (
-                  <span key={tag} className="tag-chip">
-                    {tag}
-                  </span>
-                ))}
-              </div>
-              <button
-                className="btn-secondary"
-                type="button"
-                disabled={
-                  !supportsPullCollection(source) ||
-                  !source.endpoint_url ||
-                  collectingSourceId === source.id
-                }
-                onClick={() => void onCollect(source)}
-              >
-                {supportsPullCollection(source)
-                  ? collectingSourceId === source.id
-                    ? "Collecting"
-                    : "Collect Now"
-                  : "Push Ingest"}
-              </button>
-            </div>
-          ))}
-        </div>
-      </article>
+            ))}
+          </div>
+        )}
+      </Panel>
     </section>
   );
 }

--- a/ui/src/screens/WatchlistsPage.tsx
+++ b/ui/src/screens/WatchlistsPage.tsx
@@ -5,6 +5,20 @@ import {
   createWatchlist,
   fetchWatchlists,
 } from "../lib/api";
+import {
+  Panel,
+  FormField,
+  Input,
+  Textarea,
+  Select,
+  CheckboxField,
+  FormGrid,
+  Button,
+  Badge,
+  Tag,
+  StatusLine,
+  severityTone,
+} from "../components";
 
 const SEVERITY_OPTIONS: WatchlistSeverity[] = ["low", "medium", "high", "critical"];
 
@@ -13,12 +27,6 @@ function parseCsv(value: string): string[] {
     .split(",")
     .map((item) => item.trim())
     .filter(Boolean);
-}
-
-function severityClass(severity: WatchlistSeverity) {
-  if (severity === "critical" || severity === "high") return "danger";
-  if (severity === "medium") return "warn";
-  return "ok";
 }
 
 export function WatchlistsPage() {
@@ -74,118 +82,97 @@ export function WatchlistsPage() {
   }
 
   return (
-    <section className="dashboard-grid">
-      <article className="panel panel-hero panel-span-12">
-        <p className="mono-label">Watchlists</p>
-        <h2>Deterministic Match Rules For What Matters</h2>
-        <p>
-          Model explicit keywords, entities, source-trust floors, and severity so the desk opens
-          work only when bounded conditions are met.
+    <section className="hx-page-grid">
+      <Panel hero span={12} eyebrow="Watchlists" title="Deterministic Match Rules For What Matters">
+        <p className="hx-description">
+          Model explicit keywords, entities, source-trust floors, and severity so the
+          desk opens work only when bounded conditions are met.
         </p>
-      </article>
+      </Panel>
 
-      <article className="panel panel-span-5">
-        <p className="mono-label">Create Watchlist</p>
-        <form className="form-grid" onSubmit={onSubmit}>
-          <label className="field field-full">
-            <span>name</span>
-            <input value={name} onChange={(e) => setName(e.target.value)} />
-          </label>
+      <Panel span={5} eyebrow="Create" title="New Watchlist">
+        <form className="hx-form-grid" onSubmit={onSubmit}>
+          <FormField label="Name" full>
+            <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g. Executive departures" />
+          </FormField>
 
-          <label className="field field-full">
-            <span>description</span>
-            <textarea
-              rows={4}
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-            />
-          </label>
+          <FormField label="Description" full>
+            <Textarea rows={3} value={description} onChange={(e) => setDescription(e.target.value)} placeholder="What this watchlist tracks and why" />
+          </FormField>
 
-          <label className="field field-full">
-            <span>keywords</span>
-            <input value={keywordsText} onChange={(e) => setKeywordsText(e.target.value)} />
-          </label>
+          <FormField label="Keywords" full hint="Comma-separated">
+            <Input value={keywordsText} onChange={(e) => setKeywordsText(e.target.value)} />
+          </FormField>
 
-          <label className="field field-full">
-            <span>entities</span>
-            <input value={entitiesText} onChange={(e) => setEntitiesText(e.target.value)} />
-          </label>
+          <FormField label="Entities" full hint="Comma-separated">
+            <Input value={entitiesText} onChange={(e) => setEntitiesText(e.target.value)} />
+          </FormField>
 
-          <label className="field">
-            <span>min_source_trust</span>
-            <input
+          <FormField label="Min source trust" hint="0–100">
+            <Input
               type="number"
               min={0}
               max={100}
               value={minTrust}
               onChange={(e) => setMinTrust(Number(e.target.value))}
             />
-          </label>
+          </FormField>
 
-          <label className="field">
-            <span>severity</span>
-            <select value={severity} onChange={(e) => setSeverity(e.target.value as WatchlistSeverity)}>
+          <FormField label="Severity">
+            <Select value={severity} onChange={(e) => setSeverity(e.target.value as WatchlistSeverity)}>
               {SEVERITY_OPTIONS.map((value) => (
-                <option key={value} value={value}>
-                  {value}
-                </option>
+                <option key={value} value={value}>{value}</option>
               ))}
-            </select>
-          </label>
+            </Select>
+          </FormField>
 
-          <label className="field checkbox-field field-full">
-            <input type="checkbox" checked={enabled} onChange={(e) => setEnabled(e.target.checked)} />
-            <span>enabled</span>
-          </label>
+          <CheckboxField label="Enabled" checked={enabled} onChange={setEnabled} full />
 
-          <button className="btn-primary" type="submit">
-            Create Watchlist
-          </button>
+          <FormField label="" full>
+            <Button type="submit">Create Watchlist</Button>
+          </FormField>
         </form>
-        <p className="status-line">{status}</p>
-      </article>
+        <StatusLine>{status}</StatusLine>
+      </Panel>
 
-      <article className="panel panel-span-7">
-        <p className="mono-label">Configured Watchlists</p>
-        <div className="agent-grid">
-          {watchlists.map((watchlist) => (
-            <div key={watchlist.id} className="agent-card">
-              <div className="agent-card-head">
-                <h3>{watchlist.name}</h3>
-                <span className={`status-pill ${severityClass(watchlist.severity)}`}>{watchlist.severity}</span>
-              </div>
-              <p>{watchlist.description}</p>
-              <p className="mono-detail">{watchlist.id}</p>
-              <div className="pill-row">
-                <span className="info-pill">min trust: {watchlist.min_source_trust}</span>
-                <span className="info-pill">enabled: {watchlist.enabled ? "yes" : "no"}</span>
-              </div>
-              <div className="stack-list">
-                <div>
-                  <p className="mono-label">keywords</p>
-                  <div className="pill-row">
+      <Panel span={7} eyebrow="Configured" title="Watchlists" actions={<Badge tone="accent">{watchlists.length}</Badge>}>
+        {watchlists.length === 0 ? (
+          <div className="hx-table-empty"><p>No watchlists configured yet.</p></div>
+        ) : (
+          <div className="hx-card-grid">
+            {watchlists.map((watchlist) => (
+              <div key={watchlist.id} className="hx-card">
+                <div className="hx-card-head">
+                  <h3>{watchlist.name}</h3>
+                  <Badge tone={severityTone(watchlist.severity)}>{watchlist.severity}</Badge>
+                </div>
+                <p className="hx-row-secondary">{watchlist.description}</p>
+                <p className="hx-mono-detail">{watchlist.id}</p>
+                <div className="hx-tag-row">
+                  <Tag>min trust: {watchlist.min_source_trust}</Tag>
+                  <Tag>enabled: {watchlist.enabled ? "yes" : "no"}</Tag>
+                </div>
+                <div className="hx-card-section">
+                  <span className="hx-eyebrow">Keywords</span>
+                  <div className="hx-tag-row">
                     {watchlist.keywords.map((keyword) => (
-                      <span key={keyword} className="tag-chip">
-                        {keyword}
-                      </span>
+                      <Tag key={keyword}>{keyword}</Tag>
                     ))}
                   </div>
                 </div>
-                <div>
-                  <p className="mono-label">entities</p>
-                  <div className="pill-row">
+                <div className="hx-card-section">
+                  <span className="hx-eyebrow">Entities</span>
+                  <div className="hx-tag-row">
                     {watchlist.entities.map((entity) => (
-                      <span key={entity} className="tag-chip">
-                        {entity}
-                      </span>
+                      <Tag key={entity}>{entity}</Tag>
                     ))}
                   </div>
                 </div>
               </div>
-            </div>
-          ))}
-        </div>
-      </article>
+            ))}
+          </div>
+        )}
+      </Panel>
     </section>
   );
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1,29 +1,51 @@
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
+
+/* ============================================================
+   Helix Design System v2
+   Refined dark intelligence platform aesthetic
+   ============================================================ */
 
 :root {
-  --hx-bg: #04070d;
-  --hx-bg-elevated: #08111d;
-  --hx-panel: rgba(9, 17, 29, 0.88);
-  --hx-panel-strong: rgba(12, 22, 38, 0.96);
-  --hx-panel-soft: rgba(8, 14, 24, 0.78);
-  --hx-border: rgba(104, 173, 255, 0.18);
-  --hx-border-strong: rgba(104, 173, 255, 0.36);
-  --hx-grid: rgba(125, 161, 214, 0.08);
-  --hx-text: #e8f1ff;
-  --hx-text-mid: #a9bad3;
-  --hx-text-dim: #7390b6;
-  --hx-text-low: #51657f;
-  --hx-accent: #68adff;
-  --hx-accent-strong: #93c5fd;
+  /* Surface palette */
+  --hx-bg: #050811;
+  --hx-bg-elevated: #0a1018;
+  --hx-panel: rgba(13, 20, 33, 0.92);
+  --hx-panel-strong: rgba(16, 25, 41, 0.96);
+  --hx-panel-soft: rgba(10, 16, 27, 0.82);
+  --hx-panel-hover: rgba(20, 30, 48, 0.85);
+
+  /* Borders */
+  --hx-border: rgba(99, 159, 245, 0.14);
+  --hx-border-strong: rgba(99, 159, 245, 0.28);
+  --hx-border-subtle: rgba(99, 159, 245, 0.08);
+
+  /* Text */
+  --hx-text: #eaf1fb;
+  --hx-text-mid: #a3b5d0;
+  --hx-text-dim: #6b82a8;
+  --hx-text-low: #475872;
+
+  /* Accent palette */
+  --hx-accent: #639ff5;
+  --hx-accent-strong: #8ab8ff;
+  --hx-accent-soft: rgba(99, 159, 245, 0.12);
   --hx-info: #2dd4bf;
-  --hx-ok: #22c55e;
-  --hx-warn: #f59e0b;
+  --hx-ok: #34d399;
+  --hx-warn: #fbbf24;
   --hx-danger: #fb7185;
-  --hx-shadow: 0 24px 80px rgba(2, 6, 23, 0.42);
-  --hx-shadow-glow: 0 0 0 1px rgba(104, 173, 255, 0.1), 0 18px 48px rgba(5, 12, 22, 0.55);
-  --hx-radius-lg: 22px;
-  --hx-radius-md: 16px;
-  --hx-radius-sm: 12px;
+  --hx-purple: #a78bfa;
+
+  /* Shadows */
+  --hx-shadow: 0 20px 60px rgba(2, 6, 16, 0.5);
+  --hx-shadow-glow: 0 0 0 1px rgba(99, 159, 245, 0.06), 0 16px 40px rgba(3, 8, 18, 0.5);
+  --hx-shadow-sm: 0 4px 16px rgba(2, 6, 16, 0.35);
+
+  /* Radii */
+  --hx-radius-lg: 18px;
+  --hx-radius-md: 12px;
+  --hx-radius-sm: 8px;
+
+  /* Spacing scale */
   --hx-space-1: 4px;
   --hx-space-2: 8px;
   --hx-space-3: 12px;
@@ -31,7 +53,11 @@
   --hx-space-5: 20px;
   --hx-space-6: 24px;
   --hx-space-7: 32px;
-  --hx-topbar-height: 68px;
+  --hx-space-8: 40px;
+
+  --hx-topbar-height: 60px;
+  --hx-sidebar-width: 260px;
+  --hx-sidebar-collapsed: 72px;
 }
 
 * {
@@ -53,11 +79,12 @@ body {
   margin: 0;
   overflow: hidden;
   background:
-    radial-gradient(circle at top left, rgba(104, 173, 255, 0.16), transparent 28%),
-    radial-gradient(circle at 85% 18%, rgba(45, 212, 191, 0.12), transparent 20%),
-    linear-gradient(180deg, #07111d 0%, #04070d 42%, #02050a 100%);
+    radial-gradient(ellipse at 20% 0%, rgba(99, 159, 245, 0.10), transparent 50%),
+    radial-gradient(ellipse at 80% 100%, rgba(45, 212, 191, 0.06), transparent 50%),
+    linear-gradient(180deg, #080d18 0%, #050811 50%, #03060d 100%);
   color: var(--hx-text);
-  font-family: 'IBM Plex Sans', sans-serif;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 14px;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -75,7 +102,7 @@ button {
 
 button:disabled {
   cursor: not-allowed;
-  opacity: 0.55;
+  opacity: 0.5;
 }
 
 button,
@@ -83,56 +110,41 @@ a,
 input,
 select,
 textarea {
-  transition: border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease,
-    color 180ms ease, transform 180ms ease, opacity 180ms ease;
+  transition: border-color 160ms ease, box-shadow 160ms ease, background-color 160ms ease,
+    color 160ms ease, transform 160ms ease, opacity 160ms ease;
 }
 
 :focus-visible {
-  outline: 2px solid var(--hx-accent-strong);
+  outline: 2px solid var(--hx-accent);
   outline-offset: 2px;
 }
 
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+h1, h2, h3, h4, h5, h6 {
   margin: 0;
   color: var(--hx-text);
   font-family: 'Space Grotesk', sans-serif;
   font-weight: 600;
-  letter-spacing: 0.02em;
+  letter-spacing: -0.01em;
 }
 
 h2 {
-  font-size: clamp(1.45rem, 1.05rem + 1.4vw, 2.3rem);
-  line-height: 1.08;
+  font-size: clamp(1.4rem, 1rem + 1.3vw, 2.1rem);
+  line-height: 1.15;
 }
 
 h3 {
-  font-size: 1rem;
-  line-height: 1.25;
+  font-size: 1.05rem;
+  line-height: 1.3;
 }
 
 p {
   margin: 0;
   color: var(--hx-text-mid);
-  font-size: 0.95rem;
+  font-size: 0.92rem;
   line-height: 1.65;
 }
 
-code,
-pre,
-.mono-label,
-.mono-detail,
-.command-inline,
-.t-label,
-.t-val,
-.group-label,
-.panel-title,
-.d-label,
-.status-indicator {
+code, pre, .mono {
   font-family: 'IBM Plex Mono', monospace;
 }
 
@@ -140,52 +152,1226 @@ a {
   color: inherit;
 }
 
-.tac-root {
+/* ============================================================
+   Layout: Root + Background
+   ============================================================ */
+
+.hx-root {
   position: relative;
   min-height: 100%;
 }
 
-.tac-scanlines,
-.tac-glow-orbs {
+.hx-bg-grid {
   position: fixed;
   inset: 0;
   pointer-events: none;
-}
-
-.tac-scanlines {
   z-index: 0;
-  opacity: 0.22;
-  background-image: linear-gradient(to bottom, transparent 50%, rgba(4, 12, 21, 0.42) 50%);
-  background-size: 100% 4px;
-}
-
-.tac-glow-orbs {
-  z-index: 0;
-  background:
-    radial-gradient(circle at 8% 12%, rgba(104, 173, 255, 0.12), transparent 24%),
-    radial-gradient(circle at 85% 82%, rgba(245, 158, 11, 0.08), transparent 22%),
-    radial-gradient(circle at 42% 35%, rgba(45, 212, 191, 0.06), transparent 20%);
-}
-
-.tac-glow-orbs::after {
-  content: "";
-  position: absolute;
-  inset: 0;
   background-image:
-    linear-gradient(var(--hx-grid) 1px, transparent 1px),
-    linear-gradient(90deg, var(--hx-grid) 1px, transparent 1px);
-  background-size: 38px 38px;
-  mask-image: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.95) 18%, transparent 78%);
-  -webkit-mask-image: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.95) 18%, transparent 78%);
+    linear-gradient(rgba(99, 159, 245, 0.04) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(99, 159, 245, 0.04) 1px, transparent 1px);
+  background-size: 44px 44px;
+  mask-image: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.6) 10%, transparent 75%);
+  -webkit-mask-image: radial-gradient(ellipse at center, rgba(0, 0, 0, 0.6) 10%, transparent 75%);
 }
 
-.tac-layout {
+.hx-layout {
   position: relative;
   z-index: 1;
   display: flex;
   min-height: 100%;
   flex-direction: column;
 }
+
+/* ============================================================
+   Topbar
+   ============================================================ */
+
+.hx-topbar {
+  display: flex;
+  min-height: var(--hx-topbar-height);
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--hx-space-4);
+  padding: 0 var(--hx-space-6);
+  border-bottom: 1px solid var(--hx-border);
+  background: rgba(5, 8, 17, 0.88);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+.hx-topbar-brand,
+.hx-topbar-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--hx-space-4);
+}
+
+.hx-topbar-brand {
+  flex-wrap: wrap;
+}
+
+.hx-topbar-menu {
+  display: none;
+  min-height: 38px;
+  padding: 0 var(--hx-space-3);
+  border: 1px solid var(--hx-border);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-panel-soft);
+  color: var(--hx-text-mid);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.hx-topbar-collapse {
+  min-height: 34px;
+  padding: 0 var(--hx-space-3);
+  border: 1px solid var(--hx-border);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-panel-soft);
+  color: var(--hx-text-dim);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  align-items: center;
+  display: inline-flex;
+}
+
+.hx-topbar-collapse:hover {
+  border-color: var(--hx-border-strong);
+  color: var(--hx-text);
+}
+
+.hx-brand-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, rgba(99, 159, 245, 0.2), rgba(45, 212, 191, 0.12));
+  border: 1px solid var(--hx-border);
+  color: var(--hx-accent-strong);
+  font-size: 1rem;
+}
+
+.hx-brand-name {
+  color: var(--hx-text);
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.hx-brand-version {
+  padding-left: var(--hx-space-3);
+  border-left: 1px solid var(--hx-border);
+  color: var(--hx-text-dim);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+}
+
+.hx-topbar-meta {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.hx-meta-chip {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  gap: var(--hx-space-2);
+  padding: 0 var(--hx-space-3);
+  border: 1px solid var(--hx-border-subtle);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-panel-soft);
+}
+
+.hx-meta-chip .hx-meta-label {
+  color: var(--hx-text-low);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hx-meta-chip .hx-meta-value {
+  color: var(--hx-accent-strong);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+}
+
+.hx-meta-chip .hx-meta-value.is-ok {
+  color: var(--hx-ok);
+}
+
+.hx-meta-auth {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  gap: var(--hx-space-2);
+  padding: 0 var(--hx-space-3);
+  border: 1px solid var(--hx-border);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-panel-soft);
+}
+
+.hx-meta-auth .hx-meta-label {
+  color: var(--hx-text-low);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hx-token-input {
+  width: 110px;
+  border: 0;
+  border-bottom: 1px solid var(--hx-border);
+  background: transparent;
+  color: var(--hx-text);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.74rem;
+  outline: none;
+  padding: 2px 0;
+}
+
+.hx-token-input::placeholder {
+  color: var(--hx-text-low);
+}
+
+.hx-token-input:focus {
+  border-bottom-color: var(--hx-accent);
+}
+
+.hx-token-clear {
+  min-height: 24px;
+  padding: 0 var(--hx-space-2);
+  border: 1px solid var(--hx-border);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-accent-soft);
+  color: var(--hx-text-mid);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.04em;
+}
+
+/* ============================================================
+   Main Grid: Sidebar + Workspace
+   ============================================================ */
+
+.hx-main-grid {
+  display: grid;
+  min-height: 0;
+  flex: 1;
+  grid-template-columns: var(--hx-sidebar-width) minmax(0, 1fr);
+}
+
+.hx-main-grid.is-collapsed {
+  grid-template-columns: var(--hx-sidebar-collapsed) minmax(0, 1fr);
+}
+
+/* ============================================================
+   Sidebar
+   ============================================================ */
+
+.hx-sidebar {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  justify-content: space-between;
+  border-right: 1px solid var(--hx-border);
+  background: rgba(6, 10, 19, 0.9);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+}
+
+.hx-sidebar.is-collapsed .hx-nav-group-label,
+.hx-sidebar.is-collapsed .hx-nav-text,
+.hx-sidebar.is-collapsed .hx-nav-caret,
+.hx-sidebar.is-collapsed .hx-sidebar-pref,
+.hx-sidebar.is-collapsed .hx-sidebar-status span:last-child {
+  display: none;
+}
+
+.hx-sidebar.is-collapsed .hx-nav-link {
+  justify-content: center;
+  padding: 0;
+}
+
+.hx-sidebar.is-collapsed .hx-nav-icon {
+  width: auto;
+}
+
+.hx-nav {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: var(--hx-space-5);
+  overflow: auto;
+  padding: var(--hx-space-5) var(--hx-space-3);
+}
+
+.hx-nav-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hx-space-1);
+}
+
+.hx-nav-group-label {
+  color: var(--hx-text-low);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0 var(--hx-space-3);
+  margin-bottom: var(--hx-space-1);
+}
+
+.hx-nav-group-items {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hx-nav-link {
+  display: flex;
+  min-height: 42px;
+  align-items: center;
+  gap: var(--hx-space-3);
+  padding: 0 var(--hx-space-3);
+  border: 1px solid transparent;
+  border-radius: var(--hx-radius-sm);
+  color: var(--hx-text-mid);
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+
+.hx-nav-link:hover {
+  background: rgba(99, 159, 245, 0.06);
+  color: var(--hx-text);
+}
+
+.hx-nav-link.active {
+  border-color: var(--hx-border);
+  background: linear-gradient(135deg, rgba(99, 159, 245, 0.12), rgba(45, 212, 191, 0.04));
+  color: var(--hx-text);
+  box-shadow: inset 2px 0 0 var(--hx-accent);
+}
+
+.hx-nav-icon {
+  display: inline-flex;
+  width: 1.2rem;
+  justify-content: center;
+  color: var(--hx-accent-strong);
+  font-size: 0.9rem;
+}
+
+.hx-nav-text {
+  flex: 1;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
+}
+
+.hx-nav-caret {
+  color: var(--hx-text-low);
+  font-size: 0.7rem;
+}
+
+.hx-sidebar-footer {
+  padding: var(--hx-space-3);
+  border-top: 1px solid var(--hx-border);
+  background: rgba(4, 7, 14, 0.7);
+}
+
+.hx-sidebar-pref {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hx-space-2);
+  margin-bottom: var(--hx-space-3);
+}
+
+.hx-sidebar-pref .hx-nav-group-label {
+  padding: 0;
+  margin-bottom: 0;
+}
+
+.hx-sidebar-pref select {
+  width: 100%;
+}
+
+.hx-sidebar-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--hx-space-2);
+  color: var(--hx-ok);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
+}
+
+.hx-pulse-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: currentColor;
+  box-shadow: 0 0 10px currentColor;
+  animation: hx-pulse 2.4s ease-in-out infinite;
+}
+
+.hx-sidebar-scrim {
+  display: none;
+}
+
+@keyframes hx-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.85); }
+}
+
+/* ============================================================
+   Workspace
+   ============================================================ */
+
+.hx-workspace {
+  min-height: 0;
+  overflow: auto;
+  padding: var(--hx-space-6);
+}
+
+.hx-workspace-frame {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hx-space-5);
+  margin: 0 auto;
+  width: min(1400px, 100%);
+}
+
+.hx-page-grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: var(--hx-space-4);
+  align-items: start;
+}
+
+.col-span-3 { grid-column: span 3; }
+.col-span-4 { grid-column: span 4; }
+.col-span-5 { grid-column: span 5; }
+.col-span-6 { grid-column: span 6; }
+.col-span-7 { grid-column: span 7; }
+.col-span-8 { grid-column: span 8; }
+.col-span-12 { grid-column: 1 / -1; }
+
+/* ============================================================
+   Panel
+   ============================================================ */
+
+.hx-panel {
+  position: relative;
+  grid-column: span 6;
+  overflow: hidden;
+  border: 1px solid var(--hx-border);
+  border-radius: var(--hx-radius-lg);
+  background: linear-gradient(180deg, var(--hx-panel-strong), var(--hx-panel));
+  box-shadow: var(--hx-shadow-glow);
+  padding: var(--hx-space-5);
+}
+
+.hx-panel::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(138, 184, 255, 0.3), transparent);
+}
+
+.hx-panel-hero {
+  grid-column: 1 / -1;
+  background:
+    radial-gradient(circle at top right, rgba(45, 212, 191, 0.08), transparent 30%),
+    linear-gradient(135deg, rgba(99, 159, 245, 0.12), var(--hx-panel) 60%);
+}
+
+.hx-panel-hero p:last-child {
+  max-width: 68ch;
+}
+
+.hx-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--hx-space-4);
+  margin-bottom: var(--hx-space-4);
+  padding-bottom: var(--hx-space-3);
+  border-bottom: 1px solid var(--hx-border-subtle);
+}
+
+.hx-panel-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.hx-eyebrow {
+  color: var(--hx-accent-strong);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.hx-panel-title {
+  color: var(--hx-text);
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.hx-panel-actions {
+  display: flex;
+  gap: var(--hx-space-2);
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.hx-panel-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hx-space-4);
+}
+
+/* ============================================================
+   Stat Cards
+   ============================================================ */
+
+.hx-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--hx-space-3);
+}
+
+.hx-stat {
+  display: flex;
+  min-height: 96px;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--hx-space-2);
+  border: 1px solid var(--hx-border-subtle);
+  border-radius: var(--hx-radius-md);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.015), rgba(3, 7, 13, 0.2));
+  padding: var(--hx-space-3) var(--hx-space-4);
+}
+
+.hx-stat-label {
+  color: var(--hx-text-low);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hx-stat-value {
+  color: var(--hx-text);
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: clamp(1.5rem, 1.2rem + 0.8vw, 2.1rem);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.hx-stat-sub {
+  color: var(--hx-text-dim);
+  font-size: 0.72rem;
+}
+
+.hx-stat--accent .hx-stat-value { color: var(--hx-accent-strong); }
+.hx-stat--ok .hx-stat-value { color: var(--hx-ok); }
+.hx-stat--warn .hx-stat-value { color: var(--hx-warn); }
+.hx-stat--danger .hx-stat-value { color: var(--hx-danger); }
+.hx-stat--info .hx-stat-value { color: var(--hx-info); }
+
+.hx-stat--ok { border-color: rgba(52, 211, 153, 0.18); }
+.hx-stat--warn { border-color: rgba(251, 191, 36, 0.18); }
+.hx-stat--danger { border-color: rgba(251, 113, 133, 0.18); }
+.hx-stat--info { border-color: rgba(45, 212, 191, 0.18); }
+
+/* ============================================================
+   Badges & Tags
+   ============================================================ */
+
+.hx-badge {
+  display: inline-flex;
+  max-width: 100%;
+  align-items: center;
+  gap: var(--hx-space-1);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  line-height: 1.2;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.hx-badge--default {
+  border: 1px solid var(--hx-border);
+  background: var(--hx-accent-soft);
+  color: var(--hx-accent-strong);
+}
+
+.hx-badge--ok {
+  border: 1px solid rgba(52, 211, 153, 0.22);
+  background: rgba(52, 211, 153, 0.1);
+  color: #6ee7b7;
+}
+
+.hx-badge--warn {
+  border: 1px solid rgba(251, 191, 36, 0.22);
+  background: rgba(251, 191, 36, 0.1);
+  color: #fcd34d;
+}
+
+.hx-badge--danger {
+  border: 1px solid rgba(251, 113, 133, 0.22);
+  background: rgba(251, 113, 133, 0.1);
+  color: #fda4af;
+}
+
+.hx-badge--info {
+  border: 1px solid rgba(45, 212, 191, 0.22);
+  background: rgba(45, 212, 191, 0.1);
+  color: #5eead4;
+}
+
+.hx-badge--neutral {
+  border: 1px solid var(--hx-border-subtle);
+  background: var(--hx-panel-soft);
+  color: var(--hx-text-dim);
+}
+
+.hx-tag {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid var(--hx-border-subtle);
+  border-radius: var(--hx-radius-sm);
+  background: rgba(99, 159, 245, 0.04);
+  color: var(--hx-text-mid);
+  font-size: 0.75rem;
+  padding: 3px 8px;
+  line-height: 1.3;
+}
+
+.hx-tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--hx-space-2);
+}
+
+/* ============================================================
+   Buttons
+   ============================================================ */
+
+.hx-btn {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: center;
+  gap: var(--hx-space-2);
+  padding: 0 var(--hx-space-4);
+  border: 1px solid var(--hx-border);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-panel-soft);
+  color: var(--hx-text);
+  font-family: 'Inter', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+.hx-btn--primary {
+  border-color: rgba(99, 159, 245, 0.3);
+  background: linear-gradient(180deg, rgba(99, 159, 245, 0.18), rgba(99, 159, 245, 0.06));
+  color: var(--hx-accent-strong);
+}
+
+.hx-btn--secondary {
+  background: var(--hx-panel-soft);
+  color: var(--hx-text-mid);
+}
+
+.hx-btn--ghost {
+  border-color: transparent;
+  background: transparent;
+  color: var(--hx-text-dim);
+}
+
+.hx-btn--danger {
+  border-color: rgba(251, 113, 133, 0.28);
+  background: rgba(251, 113, 133, 0.1);
+  color: #fda4af;
+}
+
+.hx-btn:hover:not(:disabled) {
+  border-color: var(--hx-border-strong);
+  box-shadow: var(--hx-shadow-sm);
+  transform: translateY(-1px);
+}
+
+.hx-btn--ghost:hover:not(:disabled) {
+  background: var(--hx-accent-soft);
+}
+
+/* ============================================================
+   Forms
+   ============================================================ */
+
+.hx-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--hx-space-4);
+}
+
+.hx-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hx-space-2);
+}
+
+.hx-field--full {
+  grid-column: 1 / -1;
+}
+
+.hx-field--row {
+  flex-direction: row;
+  align-items: center;
+  gap: var(--hx-space-3);
+  border: 1px solid var(--hx-border-subtle);
+  border-radius: var(--hx-radius-md);
+  background: var(--hx-panel-soft);
+  padding: 0 var(--hx-space-4);
+  min-height: 48px;
+}
+
+.hx-field-label {
+  color: var(--hx-text-dim);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hx-field-hint {
+  color: var(--hx-text-low);
+  font-size: 0.72rem;
+}
+
+.hx-input,
+.hx-select,
+.hx-textarea {
+  width: 100%;
+  border: 1px solid var(--hx-border);
+  border-radius: var(--hx-radius-md);
+  background: rgba(4, 8, 16, 0.9);
+  color: var(--hx-text);
+  padding: 10px 14px;
+  font-size: 0.88rem;
+}
+
+.hx-input,
+.hx-select {
+  min-height: 44px;
+}
+
+.hx-textarea {
+  resize: vertical;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.82rem;
+  line-height: 1.6;
+}
+
+.hx-input::placeholder,
+.hx-textarea::placeholder {
+  color: var(--hx-text-low);
+}
+
+.hx-input:focus,
+.hx-select:focus,
+.hx-textarea:focus {
+  border-color: var(--hx-border-strong);
+  box-shadow: 0 0 0 3px rgba(99, 159, 245, 0.1);
+  outline: none;
+}
+
+.hx-checkbox {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--hx-accent);
+}
+
+.hx-field--row .hx-field-label {
+  color: var(--hx-text);
+  text-transform: none;
+  font-family: 'Inter', sans-serif;
+  font-size: 0.88rem;
+}
+
+/* ============================================================
+   Status Line
+   ============================================================ */
+
+.hx-status-line {
+  color: var(--hx-text-dim);
+  font-size: 0.82rem;
+  line-height: 1.55;
+  padding: var(--hx-space-2) var(--hx-space-3);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-panel-soft);
+  border: 1px solid var(--hx-border-subtle);
+}
+
+.hx-status-line.hx-status--ok { color: var(--hx-ok); border-color: rgba(52, 211, 153, 0.18); }
+.hx-status-line.hx-status--warn { color: var(--hx-warn); border-color: rgba(251, 191, 36, 0.18); }
+.hx-status-line.hx-status--danger { color: var(--hx-danger); border-color: rgba(251, 113, 133, 0.18); }
+
+/* ============================================================
+   State Messages (Empty, Loading, Error)
+   ============================================================ */
+
+.hx-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--hx-space-2);
+  padding: var(--hx-space-7) var(--hx-space-5);
+  text-align: center;
+  border: 1px dashed var(--hx-border);
+  border-radius: var(--hx-radius-md);
+  background: var(--hx-panel-soft);
+}
+
+.hx-state-icon {
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 1.4rem;
+  color: var(--hx-text-low);
+}
+
+.hx-state-title {
+  color: var(--hx-text-mid);
+  font-size: 0.9rem;
+  font-weight: 500;
+}
+
+.hx-state-desc {
+  color: var(--hx-text-dim);
+  font-size: 0.82rem;
+  max-width: 48ch;
+}
+
+.hx-state--error {
+  border-color: rgba(251, 113, 133, 0.2);
+  background: rgba(251, 113, 133, 0.04);
+}
+
+.hx-state--error .hx-state-icon {
+  color: var(--hx-danger);
+}
+
+.hx-spinner {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--hx-border);
+  border-top-color: var(--hx-accent);
+  border-radius: 999px;
+  animation: hx-spin 0.8s linear infinite;
+}
+
+@keyframes hx-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* ============================================================
+   Data Table
+   ============================================================ */
+
+.hx-table-wrap {
+  overflow: auto;
+  border: 1px solid var(--hx-border-subtle);
+  border-radius: var(--hx-radius-md);
+  background: rgba(4, 8, 16, 0.6);
+}
+
+.hx-table {
+  width: 100%;
+  min-width: 720px;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+}
+
+.hx-table thead {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.hx-table th,
+.hx-table td {
+  border-bottom: 1px solid var(--hx-border-subtle);
+  padding: 10px 14px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.hx-table th {
+  background: rgba(10, 16, 27, 0.98);
+  color: var(--hx-accent-strong);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-weight: 500;
+}
+
+.hx-table tbody tr:nth-child(even) {
+  background: rgba(255, 255, 255, 0.015);
+}
+
+.hx-table tbody tr:hover {
+  background: rgba(99, 159, 245, 0.04);
+}
+
+.hx-table-empty {
+  padding: var(--hx-space-6);
+  text-align: center;
+  border: 1px dashed var(--hx-border);
+  border-radius: var(--hx-radius-md);
+  background: var(--hx-panel-soft);
+  color: var(--hx-text-dim);
+  font-size: 0.88rem;
+}
+
+/* ============================================================
+   Code Block
+   ============================================================ */
+
+.hx-code-block {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hx-space-2);
+}
+
+.hx-code-label {
+  color: var(--hx-text-low);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hx-code-pre {
+  overflow: auto;
+  border: 1px solid var(--hx-border-subtle);
+  border-radius: var(--hx-radius-md);
+  background: rgba(3, 7, 13, 0.5);
+  color: var(--hx-text-mid);
+  margin: 0;
+  padding: var(--hx-space-3);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.8rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ============================================================
+   Card Grid & Cards
+   ============================================================ */
+
+.hx-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: var(--hx-space-4);
+}
+
+.hx-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hx-space-3);
+  border: 1px solid var(--hx-border-subtle);
+  border-radius: var(--hx-radius-md);
+  background: var(--hx-panel-soft);
+  padding: var(--hx-space-4);
+}
+
+.hx-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--hx-space-3);
+}
+
+.hx-card-head h3 {
+  font-size: 0.95rem;
+}
+
+.hx-card-meta {
+  color: var(--hx-text-low);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.72rem;
+}
+
+.hx-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hx-space-3);
+}
+
+.hx-card-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hx-space-2);
+}
+
+.hx-card-section .hx-eyebrow {
+  font-size: 0.65rem;
+}
+
+/* ============================================================
+   List Rows
+   ============================================================ */
+
+.hx-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hx-space-2);
+}
+
+.hx-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--hx-space-3);
+  border: 1px solid var(--hx-border-subtle);
+  border-radius: var(--hx-radius-sm);
+  background: rgba(255, 255, 255, 0.015);
+  padding: 10px 14px;
+}
+
+.hx-row--ok { border-left: 3px solid rgba(52, 211, 153, 0.5); }
+.hx-row--warn { border-left: 3px solid rgba(251, 191, 36, 0.5); background: linear-gradient(90deg, rgba(251, 191, 36, 0.06), transparent); }
+.hx-row--danger { border-left: 3px solid rgba(251, 113, 133, 0.6); background: linear-gradient(90deg, rgba(251, 113, 133, 0.06), transparent); }
+.hx-row--info { border-left: 3px solid rgba(45, 212, 191, 0.5); }
+
+.hx-row-primary {
+  color: var(--hx-text);
+  font-size: 0.88rem;
+  font-weight: 500;
+}
+
+.hx-row-secondary {
+  color: var(--hx-text-dim);
+  font-size: 0.78rem;
+}
+
+.hx-row-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 3px;
+}
+
+/* ============================================================
+   Misc utilities
+   ============================================================ */
+
+.hx-mono {
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.hx-mono-detail {
+  color: var(--hx-text-low);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.02em;
+}
+
+.hx-description {
+  color: var(--hx-text-mid);
+  font-size: 0.92rem;
+  line-height: 1.65;
+  max-width: 68ch;
+}
+
+.hx-stack {
+  display: flex;
+  flex-direction: column;
+  gap: var(--hx-space-3);
+}
+
+.hx-cluster {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--hx-space-2);
+}
+
+/* ============================================================
+   Responsive
+   ============================================================ */
+
+@media (max-width: 1180px) {
+  .hx-panel,
+  .col-span-3,
+  .col-span-4,
+  .col-span-5,
+  .col-span-6,
+  .col-span-7,
+  .col-span-8 {
+    grid-column: span 6;
+  }
+
+  .col-span-12,
+  .hx-panel-hero {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 1024px) {
+  .hx-topbar {
+    padding: 0 var(--hx-space-4);
+  }
+
+  .hx-topbar-menu {
+    display: inline-flex;
+  }
+
+  .hx-topbar-collapse {
+    display: none;
+  }
+
+  .hx-brand-version {
+    display: none;
+  }
+
+  .hx-topbar-meta {
+    gap: var(--hx-space-2);
+  }
+
+  .hx-main-grid,
+  .hx-main-grid.is-collapsed {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .hx-sidebar {
+    position: fixed;
+    top: var(--hx-topbar-height);
+    bottom: 0;
+    left: 0;
+    width: min(84vw, 300px);
+    transform: translateX(-104%);
+    transition: transform 220ms ease;
+    z-index: 40;
+    box-shadow: var(--hx-shadow);
+  }
+
+  .hx-sidebar.is-open {
+    transform: translateX(0);
+  }
+
+  .hx-sidebar.is-collapsed .hx-nav-group-label,
+  .hx-sidebar.is-collapsed .hx-nav-text,
+  .hx-sidebar.is-collapsed .hx-nav-caret,
+  .hx-sidebar.is-collapsed .hx-sidebar-pref,
+  .hx-sidebar.is-collapsed .hx-sidebar-status span:last-child {
+    display: initial;
+  }
+
+  .hx-sidebar.is-collapsed .hx-nav-link {
+    justify-content: flex-start;
+    padding: 0 var(--hx-space-3);
+  }
+
+  .hx-sidebar-scrim {
+    display: block;
+    position: fixed;
+    inset: var(--hx-topbar-height) 0 0 0;
+    z-index: 30;
+    border: 0;
+    background: rgba(2, 6, 16, 0.5);
+    backdrop-filter: blur(2px);
+  }
+
+  .hx-workspace {
+    padding: var(--hx-space-4);
+  }
+
+  .hx-form-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .hx-page-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hx-panel,
+  .col-span-3,
+  .col-span-4,
+  .col-span-5,
+  .col-span-6,
+  .col-span-7,
+  .col-span-8,
+  .col-span-12,
+  .hx-panel-hero {
+    grid-column: 1 / -1;
+  }
+
+  .hx-topbar {
+    align-items: flex-start;
+    padding-top: var(--hx-space-2);
+    padding-bottom: var(--hx-space-2);
+  }
+
+  .hx-topbar-brand,
+  .hx-topbar-meta {
+    gap: var(--hx-space-2);
+  }
+
+  .hx-card-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hx-stat {
+    min-height: 80px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
+/* ============================================================
+   Legacy compatibility aliases
+   Maps old class names to new design system so existing
+   screens continue to work during incremental migration.
+   ============================================================ */
+
+.tac-root { composes: hx-root; }
+.tac-root { position: relative; min-height: 100%; }
+
+.tac-scanlines { display: none; }
+.tac-glow-orbs { display: none; }
+
+.tac-layout { position: relative; z-index: 1; display: flex; min-height: 100%; flex-direction: column; }
 
 .tac-topbar {
   display: flex;
@@ -195,89 +1381,58 @@ a {
   gap: var(--hx-space-4);
   padding: 0 var(--hx-space-6);
   border-bottom: 1px solid var(--hx-border);
-  background: rgba(3, 8, 15, 0.84);
-  backdrop-filter: blur(18px);
+  background: rgba(5, 8, 17, 0.88);
+  backdrop-filter: blur(20px);
 }
 
-.topbar-brand,
-.topbar-telemetry {
+.topbar-brand, .topbar-telemetry {
   display: flex;
   align-items: center;
   gap: var(--hx-space-4);
 }
 
-.topbar-brand {
-  flex-wrap: wrap;
-}
-
-.topbar-menu,
-.topbar-collapse,
-.btn-primary,
-.btn-secondary,
-.tac-btn {
-  display: inline-flex;
-  min-height: 42px;
-  align-items: center;
-  justify-content: center;
-  gap: var(--hx-space-2);
-  padding: 0 var(--hx-space-4);
-  border: 1px solid var(--hx-border);
-  border-radius: 999px;
-  background: rgba(104, 173, 255, 0.08);
-  color: var(--hx-text);
-  font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.78rem;
-  font-weight: 500;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04);
-}
-
-.topbar-menu,
-.topbar-collapse,
-.btn-secondary {
-  background: rgba(9, 17, 29, 0.9);
-}
+.topbar-brand { flex-wrap: wrap; }
 
 .topbar-menu {
   display: none;
+  min-height: 38px;
+  padding: 0 var(--hx-space-3);
+  border: 1px solid var(--hx-border);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-panel-soft);
+  color: var(--hx-text-mid);
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
+  align-items: center;
+  justify-content: center;
 }
 
 .topbar-collapse {
-  min-height: 36px;
+  min-height: 34px;
   padding: 0 var(--hx-space-3);
-  border: 1px solid rgba(104, 173, 255, 0.18);
-  border-radius: 999px;
-  background: rgba(9, 17, 29, 0.9);
-  color: var(--hx-text);
+  border: 1px solid var(--hx-border);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-panel-soft);
+  color: var(--hx-text-dim);
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
-}
-
-.btn-primary,
-.tac-btn {
-  border-color: rgba(104, 173, 255, 0.32);
-  background: linear-gradient(180deg, rgba(104, 173, 255, 0.2), rgba(104, 173, 255, 0.08));
-}
-
-.topbar-menu:hover,
-.topbar-collapse:hover,
-.btn-primary:hover,
-.btn-secondary:hover,
-.tac-btn:hover {
-  border-color: var(--hx-border-strong);
-  box-shadow: 0 0 0 1px rgba(104, 173, 255, 0.08), 0 12px 32px rgba(5, 12, 22, 0.35);
-  transform: translateY(-1px);
+  align-items: center;
+  display: inline-flex;
 }
 
 .brand-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, rgba(99, 159, 245, 0.2), rgba(45, 212, 191, 0.12));
+  border: 1px solid var(--hx-border);
   color: var(--hx-accent-strong);
-  font-size: 1.1rem;
+  font-size: 1rem;
 }
 
 .brand-name {
@@ -285,115 +1440,94 @@ a {
   font-family: 'Space Grotesk', sans-serif;
   font-size: 1.05rem;
   font-weight: 700;
-  letter-spacing: 0.18em;
+  letter-spacing: 0.12em;
 }
 
 .brand-version {
+  padding-left: var(--hx-space-3);
   border-left: 1px solid var(--hx-border);
-  padding-left: var(--hx-space-4);
   color: var(--hx-text-dim);
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.76rem;
-  letter-spacing: 0.06em;
+  font-size: 0.72rem;
 }
 
-.topbar-telemetry {
-  flex-wrap: wrap;
-  justify-content: flex-end;
-}
+.topbar-telemetry { flex-wrap: wrap; justify-content: flex-end; }
 
 .telemetry-block {
   display: inline-flex;
-  min-height: 36px;
+  min-height: 32px;
   align-items: center;
   gap: var(--hx-space-2);
   padding: 0 var(--hx-space-3);
-  border: 1px solid rgba(104, 173, 255, 0.12);
-  border-radius: 999px;
-  background: rgba(9, 17, 29, 0.72);
+  border: 1px solid var(--hx-border-subtle);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-panel-soft);
 }
 
 .telemetry-auth {
   display: inline-flex;
-  min-height: 36px;
+  min-height: 32px;
   align-items: center;
   gap: var(--hx-space-2);
   padding: 0 var(--hx-space-3);
-  border: 1px solid rgba(104, 173, 255, 0.16);
-  border-radius: 999px;
-  background: rgba(9, 17, 29, 0.82);
+  border: 1px solid var(--hx-border);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-panel-soft);
 }
 
 .topbar-token {
-  width: 118px;
+  width: 110px;
   border: 0;
-  border-bottom: 1px solid rgba(104, 173, 255, 0.28);
+  border-bottom: 1px solid var(--hx-border);
   background: transparent;
   color: var(--hx-text);
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.76rem;
+  font-size: 0.74rem;
   outline: none;
+  padding: 2px 0;
 }
 
-.topbar-token::placeholder {
-  color: var(--hx-text-low);
-}
-
-.topbar-token:focus {
-  border-bottom-color: var(--hx-accent-strong);
-}
+.topbar-token::placeholder { color: var(--hx-text-low); }
+.topbar-token:focus { border-bottom-color: var(--hx-accent); }
 
 .topbar-token-clear {
-  min-height: 26px;
+  min-height: 24px;
   padding: 0 var(--hx-space-2);
-  border: 1px solid rgba(104, 173, 255, 0.16);
-  border-radius: 999px;
-  background: rgba(104, 173, 255, 0.08);
+  border: 1px solid var(--hx-border);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-accent-soft);
   color: var(--hx-text-mid);
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.64rem;
-  letter-spacing: 0.08em;
+  font-size: 0.65rem;
 }
 
 .t-label {
   color: var(--hx-text-low);
-  font-size: 0.7rem;
-  letter-spacing: 0.08em;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
 }
 
 .t-val {
   color: var(--hx-accent-strong);
-  font-size: 0.76rem;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.75rem;
 }
 
-.t-val.ok,
-.ok {
-  color: var(--hx-ok);
-}
-
-.warn,
-.warning {
-  color: var(--hx-warn);
-}
-
-.danger,
-.alert {
-  color: var(--hx-danger);
-}
-
-.info {
-  color: var(--hx-info);
-}
+.t-val.ok, .ok { color: var(--hx-ok); }
+.warn, .warning { color: var(--hx-warn); }
+.danger, .alert { color: var(--hx-danger); }
+.info { color: var(--hx-info); }
 
 .tac-main-grid {
   display: grid;
   min-height: 0;
   flex: 1;
-  grid-template-columns: 280px minmax(0, 1fr);
+  grid-template-columns: var(--hx-sidebar-width) minmax(0, 1fr);
 }
 
 .tac-main-grid.sidebar-collapsed {
-  grid-template-columns: 88px minmax(0, 1fr);
+  grid-template-columns: var(--hx-sidebar-collapsed) minmax(0, 1fr);
 }
 
 .tac-sidebar {
@@ -402,8 +1536,8 @@ a {
   flex-direction: column;
   justify-content: space-between;
   border-right: 1px solid var(--hx-border);
-  background: rgba(6, 11, 19, 0.88);
-  backdrop-filter: blur(14px);
+  background: rgba(6, 10, 19, 0.9);
+  backdrop-filter: blur(16px);
 }
 
 .tac-sidebar.is-collapsed .group-label,
@@ -414,19 +1548,12 @@ a {
   display: none;
 }
 
-.tac-sidebar.is-collapsed .tac-nav {
-  padding-left: var(--hx-space-3);
-  padding-right: var(--hx-space-3);
-}
-
 .tac-sidebar.is-collapsed .tac-nav-link {
   justify-content: center;
   padding: 0;
 }
 
-.tac-sidebar.is-collapsed .nav-icon {
-  width: auto;
-}
+.tac-sidebar.is-collapsed .nav-icon { width: auto; }
 
 .tac-nav {
   display: flex;
@@ -434,122 +1561,99 @@ a {
   flex-direction: column;
   gap: var(--hx-space-5);
   overflow: auto;
-  padding: var(--hx-space-6) var(--hx-space-4);
+  padding: var(--hx-space-5) var(--hx-space-3);
 }
 
-.nav-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--hx-space-2);
-}
+.nav-group { display: flex; flex-direction: column; gap: var(--hx-space-1); }
 
 .group-label {
   color: var(--hx-text-low);
-  font-size: 0.68rem;
-  letter-spacing: 0.08em;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
+  padding: 0 var(--hx-space-3);
+  margin-bottom: var(--hx-space-1);
 }
 
-.group-items {
-  display: flex;
-  flex-direction: column;
-  gap: var(--hx-space-2);
-}
+.group-items { display: flex; flex-direction: column; gap: 2px; }
 
 .tac-nav-link {
   display: flex;
-  min-height: 48px;
+  min-height: 42px;
   align-items: center;
   gap: var(--hx-space-3);
-  padding: 0 var(--hx-space-4);
+  padding: 0 var(--hx-space-3);
   border: 1px solid transparent;
-  border-radius: 14px;
+  border-radius: var(--hx-radius-sm);
   color: var(--hx-text-mid);
   text-decoration: none;
 }
 
 .tac-nav-link:hover {
-  border-color: rgba(104, 173, 255, 0.12);
-  background: rgba(104, 173, 255, 0.08);
+  background: rgba(99, 159, 245, 0.06);
   color: var(--hx-text);
 }
 
 .tac-nav-link.active {
-  border-color: rgba(104, 173, 255, 0.22);
-  background: linear-gradient(135deg, rgba(104, 173, 255, 0.16), rgba(45, 212, 191, 0.06));
+  border-color: var(--hx-border);
+  background: linear-gradient(135deg, rgba(99, 159, 245, 0.12), rgba(45, 212, 191, 0.04));
   color: var(--hx-text);
-  box-shadow: inset 0 0 0 1px rgba(104, 173, 255, 0.08);
+  box-shadow: inset 2px 0 0 var(--hx-accent);
 }
 
 .nav-icon {
   display: inline-flex;
-  width: 1.3rem;
+  width: 1.2rem;
   justify-content: center;
   color: var(--hx-accent-strong);
+  font-size: 0.9rem;
 }
 
 .nav-text {
   flex: 1;
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.82rem;
-  letter-spacing: 0.05em;
+  font-size: 0.78rem;
+  letter-spacing: 0.02em;
 }
 
-.nav-caret {
-  color: var(--hx-text-low);
-}
+.nav-caret { color: var(--hx-text-low); font-size: 0.7rem; }
 
 .sidebar-footer {
-  padding: var(--hx-space-4);
+  padding: var(--hx-space-3);
   border-top: 1px solid var(--hx-border);
-  background: rgba(4, 8, 14, 0.78);
+  background: rgba(4, 7, 14, 0.7);
 }
 
 .sidebar-pref {
   display: flex;
   flex-direction: column;
   gap: var(--hx-space-2);
-  margin-bottom: var(--hx-space-4);
+  margin-bottom: var(--hx-space-3);
 }
 
-.sidebar-pref select {
-  width: 100%;
-}
+.sidebar-pref select { width: 100%; }
 
 .status-indicator {
   display: inline-flex;
   align-items: center;
   gap: var(--hx-space-2);
   color: var(--hx-ok);
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.04em;
 }
 
 .pulse-dot {
-  width: 8px;
-  height: 8px;
+  width: 7px;
+  height: 7px;
   border-radius: 999px;
   background: currentColor;
-  box-shadow: 0 0 12px currentColor;
-  animation: pulse-op 2.2s ease-in-out infinite;
+  box-shadow: 0 0 10px currentColor;
+  animation: hx-pulse 2.4s ease-in-out infinite;
 }
 
-.sidebar-scrim {
-  display: none;
-}
-
-@keyframes pulse-op {
-  0%,
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-
-  50% {
-    opacity: 0.45;
-    transform: scale(0.92);
-  }
-}
+.sidebar-scrim { display: none; }
 
 .tac-workspace {
   min-height: 0;
@@ -560,128 +1664,85 @@ a {
 .workspace-frame {
   display: flex;
   flex-direction: column;
-  gap: var(--hx-space-6);
+  gap: var(--hx-space-5);
   margin: 0 auto;
-  width: min(1440px, 100%);
+  width: min(1400px, 100%);
 }
 
-.dashboard-grid,
-.hud-grid {
+.dashboard-grid, .hud-grid {
   display: grid;
   grid-template-columns: repeat(12, minmax(0, 1fr));
   gap: var(--hx-space-4);
   align-items: start;
 }
 
-.panel,
-.tac-panel {
+.panel, .tac-panel {
   position: relative;
   grid-column: span 6;
   overflow: hidden;
   border: 1px solid var(--hx-border);
   border-radius: var(--hx-radius-lg);
-  background: linear-gradient(180deg, rgba(12, 21, 35, 0.95), rgba(7, 13, 24, 0.92));
+  background: linear-gradient(180deg, var(--hx-panel-strong), var(--hx-panel));
   box-shadow: var(--hx-shadow-glow);
   padding: var(--hx-space-5);
 }
 
-.panel::before,
-.tac-panel::before {
+.panel::before, .tac-panel::before {
   content: "";
   position: absolute;
   inset: 0 0 auto 0;
   height: 1px;
-  background: linear-gradient(90deg, transparent, rgba(147, 197, 253, 0.55), transparent);
+  background: linear-gradient(90deg, transparent, rgba(138, 184, 255, 0.3), transparent);
 }
 
 .panel-hero {
   grid-column: 1 / -1;
   background:
-    radial-gradient(circle at top right, rgba(45, 212, 191, 0.12), transparent 26%),
-    linear-gradient(140deg, rgba(104, 173, 255, 0.2), rgba(8, 14, 24, 0.95) 58%);
+    radial-gradient(circle at top right, rgba(45, 212, 191, 0.08), transparent 30%),
+    linear-gradient(135deg, rgba(99, 159, 245, 0.12), var(--hx-panel) 60%);
 }
 
-.panel-hero p:last-child {
-  max-width: 72ch;
-}
+.panel-hero p:last-child { max-width: 68ch; }
 
 .panel-header {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   justify-content: space-between;
   gap: var(--hx-space-4);
   margin-bottom: var(--hx-space-4);
   padding-bottom: var(--hx-space-3);
-  border-bottom: 1px solid rgba(104, 173, 255, 0.14);
+  border-bottom: 1px solid var(--hx-border-subtle);
 }
 
 .panel-title {
   color: var(--hx-accent-strong);
-  font-size: 0.78rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
 }
 
-.panel-toolbar,
-.command-row-head {
+.panel-toolbar, .command-row-head {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: var(--hx-space-3);
 }
 
-.panel-toolbar {
-  margin-bottom: var(--hx-space-4);
-}
+.panel-toolbar { margin-bottom: var(--hx-space-4); }
 
-.toolbar-actions,
-.command-list {
-  display: flex;
-  gap: var(--hx-space-3);
-}
+.toolbar-actions, .command-list { display: flex; gap: var(--hx-space-3); }
+.toolbar-actions { flex-wrap: wrap; align-items: center; justify-content: flex-end; }
+.command-list { flex-direction: column; }
 
-.toolbar-actions {
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-}
-
-.command-list {
-  flex-direction: column;
-}
-
-.panel-span-12,
-.span-12 {
-  grid-column: 1 / -1;
-}
-
-.panel-span-7 {
-  grid-column: span 7;
-}
-
-.panel-span-6,
-.span-6 {
-  grid-column: span 6;
-}
-
-.panel-span-5 {
-  grid-column: span 5;
-}
-
-.span-8 {
-  grid-column: span 8;
-}
-
-.panel-span-4,
-.span-4 {
-  grid-column: span 4;
-}
-
-.panel-span-3,
-.span-3 {
-  grid-column: span 3;
-}
+.panel-span-12, .span-12 { grid-column: 1 / -1; }
+.panel-span-7 { grid-column: span 7; }
+.panel-span-6, .span-6 { grid-column: span 6; }
+.panel-span-5 { grid-column: span 5; }
+.span-8 { grid-column: span 8; }
+.panel-span-4, .span-4 { grid-column: span 4; }
+.panel-span-3, .span-3 { grid-column: span 3; }
 
 .metrics-grid {
   display: grid;
@@ -689,47 +1750,37 @@ a {
   gap: var(--hx-space-3);
 }
 
-.metric-card,
-.data-block {
+.metric-card, .data-block {
   display: flex;
-  min-height: 112px;
+  min-height: 96px;
   flex-direction: column;
   justify-content: space-between;
-  gap: var(--hx-space-3);
-  border: 1px solid rgba(104, 173, 255, 0.14);
+  gap: var(--hx-space-2);
+  border: 1px solid var(--hx-border-subtle);
   border-radius: var(--hx-radius-md);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.02), rgba(3, 7, 13, 0.18));
-  padding: var(--hx-space-4);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.015), rgba(3, 7, 13, 0.2));
+  padding: var(--hx-space-3) var(--hx-space-4);
 }
 
-.metric-label,
-.d-label {
+.metric-label, .d-label {
   color: var(--hx-text-low);
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
-.metric-value,
-.d-value {
+.metric-value, .d-value {
   color: var(--hx-text);
   font-family: 'Space Grotesk', sans-serif;
-  font-size: clamp(1.6rem, 1.3rem + 0.9vw, 2.35rem);
+  font-size: clamp(1.5rem, 1.2rem + 0.8vw, 2.1rem);
   font-weight: 700;
   line-height: 1;
 }
 
-.d-value.highlight {
-  color: var(--hx-accent-strong);
-}
-
-.d-value.alert {
-  color: var(--hx-warn);
-}
-
-.d-value.danger {
-  color: var(--hx-danger);
-}
+.d-value.highlight { color: var(--hx-accent-strong); }
+.d-value.alert { color: var(--hx-warn); }
+.d-value.danger { color: var(--hx-danger); }
 
 .agent-grid {
   display: grid;
@@ -737,13 +1788,12 @@ a {
   gap: var(--hx-space-4);
 }
 
-.agent-card,
-.command-row {
+.agent-card, .command-row {
   display: flex;
   min-height: 100%;
   flex-direction: column;
   gap: var(--hx-space-3);
-  border: 1px solid rgba(104, 173, 255, 0.12);
+  border: 1px solid var(--hx-border-subtle);
   border-radius: var(--hx-radius-md);
   background: var(--hx-panel-soft);
   padding: var(--hx-space-4);
@@ -756,89 +1806,52 @@ a {
   gap: var(--hx-space-3);
 }
 
-.status-pill,
-.info-pill,
-.tag-chip,
-.command-inline {
+.status-pill, .info-pill, .tag-chip, .command-inline {
   display: inline-flex;
   max-width: 100%;
   align-items: center;
-  gap: var(--hx-space-2);
+  gap: var(--hx-space-1);
   border-radius: 999px;
-  padding: 6px 10px;
-  font-size: 0.76rem;
+  padding: 4px 10px;
+  font-size: 0.72rem;
   line-height: 1.2;
 }
 
 .status-pill {
-  border: 1px solid rgba(104, 173, 255, 0.16);
-  background: rgba(104, 173, 255, 0.08);
+  border: 1px solid var(--hx-border);
+  background: var(--hx-accent-soft);
   color: var(--hx-accent-strong);
   font-family: 'IBM Plex Mono', monospace;
   text-transform: uppercase;
+  letter-spacing: 0.03em;
 }
 
-.status-pill.ok {
-  border-color: rgba(34, 197, 94, 0.24);
-  background: rgba(34, 197, 94, 0.12);
-  color: #8ef3b0;
-}
+.status-pill.ok { border-color: rgba(52, 211, 153, 0.22); background: rgba(52, 211, 153, 0.1); color: #6ee7b7; }
+.status-pill.warn, .status-pill.warning { border-color: rgba(251, 191, 36, 0.22); background: rgba(251, 191, 36, 0.1); color: #fcd34d; }
+.status-pill.danger, .status-pill.alert { border-color: rgba(251, 113, 133, 0.22); background: rgba(251, 113, 133, 0.1); color: #fda4af; }
+.status-pill.info { border-color: rgba(45, 212, 191, 0.22); background: rgba(45, 212, 191, 0.1); color: #5eead4; }
 
-.status-pill.warn,
-.status-pill.warning {
-  border-color: rgba(245, 158, 11, 0.24);
-  background: rgba(245, 158, 11, 0.12);
-  color: #fcd34d;
-}
-
-.status-pill.danger,
-.status-pill.alert {
-  border-color: rgba(251, 113, 133, 0.24);
-  background: rgba(251, 113, 133, 0.12);
-  color: #fda4af;
-}
-
-.status-pill.info {
-  border-color: rgba(45, 212, 191, 0.24);
-  background: rgba(45, 212, 191, 0.12);
-  color: #7cebdc;
-}
-
-.info-pill,
-.tag-chip,
-.command-inline {
-  border: 1px solid rgba(104, 173, 255, 0.12);
-  background: rgba(104, 173, 255, 0.06);
+.info-pill, .tag-chip, .command-inline {
+  border: 1px solid var(--hx-border-subtle);
+  background: rgba(99, 159, 245, 0.04);
   color: var(--hx-text-mid);
-}
-
-.tag-chip {
-  background: rgba(45, 212, 191, 0.08);
-  color: #b8fff4;
 }
 
 .command-inline {
   width: fit-content;
   max-width: 100%;
-  border-radius: 12px;
+  border-radius: var(--hx-radius-sm);
   font-family: 'IBM Plex Mono', monospace;
   white-space: normal;
   word-break: break-word;
 }
 
-.pill-row,
-.button-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--hx-space-2);
-}
+.pill-row, .button-row { display: flex; flex-wrap: wrap; gap: var(--hx-space-2); }
 
-.stack-list,
-.command-stack,
-.tac-list {
+.stack-list, .command-stack, .tac-list {
   display: flex;
   flex-direction: column;
-  gap: var(--hx-space-3);
+  gap: var(--hx-space-2);
 }
 
 .tac-row {
@@ -846,38 +1859,18 @@ a {
   align-items: center;
   justify-content: space-between;
   gap: var(--hx-space-3);
-  border: 1px solid rgba(104, 173, 255, 0.1);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.02);
-  padding: 12px 14px;
+  border: 1px solid var(--hx-border-subtle);
+  border-radius: var(--hx-radius-sm);
+  background: rgba(255, 255, 255, 0.015);
+  padding: 10px 14px;
 }
 
-.tac-row.healthy {
-  border-left: 3px solid rgba(104, 173, 255, 0.24);
-}
+.tac-row.healthy { border-left: 3px solid rgba(99, 159, 245, 0.3); }
+.tac-row.warning, .tac-row.warn { border-left: 3px solid rgba(251, 191, 36, 0.5); background: linear-gradient(90deg, rgba(251, 191, 36, 0.06), transparent); }
+.tac-row.danger, .command-row.danger { border-left: 3px solid rgba(251, 113, 133, 0.6); background: linear-gradient(90deg, rgba(251, 113, 133, 0.06), transparent); }
 
-.tac-row.warning,
-.tac-row.warn {
-  border-left: 3px solid rgba(245, 158, 11, 0.6);
-  background: linear-gradient(90deg, rgba(245, 158, 11, 0.12), rgba(255, 255, 255, 0.02));
-}
-
-.tac-row.danger,
-.command-row.danger {
-  border-left: 3px solid rgba(251, 113, 133, 0.72);
-  background: linear-gradient(90deg, rgba(251, 113, 133, 0.12), rgba(255, 255, 255, 0.02));
-}
-
-.row-primary {
-  color: var(--hx-text);
-  font-size: 0.86rem;
-  font-weight: 600;
-}
-
-.row-secondary {
-  color: var(--hx-text-dim);
-  font-size: 0.78rem;
-}
+.row-primary { color: var(--hx-text); font-size: 0.88rem; font-weight: 500; }
+.row-secondary { color: var(--hx-text-dim); font-size: 0.78rem; }
 
 .form-grid {
   display: grid;
@@ -885,62 +1878,34 @@ a {
   gap: var(--hx-space-4);
 }
 
-.field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--hx-space-2);
-}
-
-.field-full {
-  grid-column: 1 / -1;
-}
+.field { display: flex; flex-direction: column; gap: var(--hx-space-2); }
+.field-full { grid-column: 1 / -1; }
 
 .field > span {
   color: var(--hx-text-dim);
   font-family: 'IBM Plex Mono', monospace;
-  font-size: 0.74rem;
-  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
 }
 
-.field input,
-.field select,
-.field textarea,
-.command-editor,
-.json-output,
-.tac-term {
+.field input, .field select, .field textarea, .command-editor, .json-output, .tac-term {
   width: 100%;
-  border: 1px solid rgba(104, 173, 255, 0.16);
+  border: 1px solid var(--hx-border);
   border-radius: var(--hx-radius-md);
-  background: rgba(5, 10, 18, 0.92);
+  background: rgba(4, 8, 16, 0.9);
   color: var(--hx-text);
-  padding: 12px 14px;
+  padding: 10px 14px;
+  font-size: 0.88rem;
 }
 
-.field input,
-.field select,
-.field textarea,
-.command-editor {
-  min-height: 48px;
-}
+.field input, .field select, .command-editor { min-height: 44px; }
+.field textarea, .command-editor { resize: vertical; }
+.field input::placeholder, .field textarea::placeholder, .command-editor::placeholder { color: var(--hx-text-low); }
 
-.field textarea,
-.command-editor {
-  resize: vertical;
-}
-
-.field input::placeholder,
-.field textarea::placeholder,
-.command-editor::placeholder {
-  color: var(--hx-text-low);
-}
-
-.field input:focus,
-.field select:focus,
-.field textarea:focus,
-.command-editor:focus {
-  border-color: rgba(104, 173, 255, 0.4);
-  box-shadow: 0 0 0 4px rgba(104, 173, 255, 0.12);
+.field input:focus, .field select:focus, .field textarea:focus, .command-editor:focus {
+  border-color: var(--hx-border-strong);
+  box-shadow: 0 0 0 3px rgba(99, 159, 245, 0.1);
   outline: none;
 }
 
@@ -948,62 +1913,65 @@ a {
   flex-direction: row;
   align-items: center;
   gap: var(--hx-space-3);
-  border: 1px solid rgba(104, 173, 255, 0.12);
+  border: 1px solid var(--hx-border-subtle);
   border-radius: var(--hx-radius-md);
-  background: rgba(9, 17, 29, 0.6);
+  background: var(--hx-panel-soft);
   padding: 0 var(--hx-space-4);
+  min-height: 48px;
 }
 
-.checkbox-field input {
-  width: 18px;
-  height: 18px;
-  accent-color: var(--hx-accent);
-}
+.checkbox-field input { width: 18px; height: 18px; accent-color: var(--hx-accent); }
+.checkbox-field span { color: var(--hx-text); }
 
-.checkbox-field span {
+.btn-primary, .btn-secondary, .tac-btn {
+  display: inline-flex;
+  min-height: 40px;
+  align-items: center;
+  justify-content: center;
+  gap: var(--hx-space-2);
+  padding: 0 var(--hx-space-4);
+  border: 1px solid var(--hx-border);
+  border-radius: var(--hx-radius-sm);
+  background: var(--hx-panel-soft);
   color: var(--hx-text);
+  font-family: 'Inter', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
 }
 
-.status-line,
-.panel-note,
-.mono-detail,
-.mono-label {
+.btn-primary, .tac-btn {
+  border-color: rgba(99, 159, 245, 0.3);
+  background: linear-gradient(180deg, rgba(99, 159, 245, 0.18), rgba(99, 159, 245, 0.06));
+  color: var(--hx-accent-strong);
+}
+
+.btn-secondary { background: var(--hx-panel-soft); color: var(--hx-text-mid); }
+
+.btn-primary:hover, .btn-secondary:hover, .tac-btn:hover {
+  border-color: var(--hx-border-strong);
+  box-shadow: var(--hx-shadow-sm);
+  transform: translateY(-1px);
+}
+
+.status-line, .panel-note, .mono-detail, .mono-label {
   color: var(--hx-text-dim);
 }
 
-.status-line,
-.panel-note,
-.mono-detail {
-  font-size: 0.82rem;
-  line-height: 1.55;
-}
-
-.mono-label,
-.mono-detail {
-  letter-spacing: 0.08em;
-}
+.status-line, .panel-note, .mono-detail { font-size: 0.82rem; line-height: 1.55; }
+.mono-label, .mono-detail { letter-spacing: 0.04em; font-family: 'IBM Plex Mono', monospace; }
 
 .mono-label {
   margin-bottom: var(--hx-space-2);
   color: var(--hx-accent-strong);
-  font-size: 0.72rem;
+  font-size: 0.68rem;
   text-transform: uppercase;
 }
 
-.mono-detail {
-  color: var(--hx-text-low);
-  text-transform: none;
-}
+.mono-detail { color: var(--hx-text-low); text-transform: none; }
 
-.command-stack {
-  overflow-wrap: anywhere;
-}
+.command-stack { overflow-wrap: anywhere; }
 
-.command-editor,
-.json-output,
-.json-block,
-.tac-term,
-.result-table {
+.command-editor, .json-output, .json-block, .tac-term, .result-table {
   font-family: 'IBM Plex Mono', monospace;
   font-size: 0.8rem;
 }
@@ -1011,9 +1979,9 @@ a {
 .json-block {
   overflow: auto;
   max-height: 220px;
-  border: 1px solid rgba(104, 173, 255, 0.12);
+  border: 1px solid var(--hx-border-subtle);
   border-radius: var(--hx-radius-md);
-  background: rgba(3, 7, 13, 0.42);
+  background: rgba(3, 7, 13, 0.5);
   color: var(--hx-text-mid);
   margin: 0;
   padding: var(--hx-space-3);
@@ -1021,23 +1989,14 @@ a {
   word-break: break-word;
 }
 
-.json-output,
-.tac-term {
-  overflow: auto;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
-
-.json-output {
-  max-height: 420px;
-  margin: 0;
-}
+.json-output, .tac-term { overflow: auto; white-space: pre-wrap; word-break: break-word; }
+.json-output { max-height: 420px; margin: 0; }
 
 .table-wrap {
   overflow: auto;
-  border: 1px solid rgba(104, 173, 255, 0.12);
+  border: 1px solid var(--hx-border-subtle);
   border-radius: var(--hx-radius-md);
-  background: rgba(5, 10, 18, 0.78);
+  background: rgba(4, 8, 16, 0.6);
 }
 
 .result-table {
@@ -1046,84 +2005,45 @@ a {
   border-collapse: collapse;
 }
 
-.result-table thead {
-  position: sticky;
-  top: 0;
-  z-index: 1;
-}
+.result-table thead { position: sticky; top: 0; z-index: 1; }
 
-.result-table th,
-.result-table td {
-  border-bottom: 1px solid rgba(104, 173, 255, 0.1);
-  padding: 10px 12px;
+.result-table th, .result-table td {
+  border-bottom: 1px solid var(--hx-border-subtle);
+  padding: 10px 14px;
   text-align: left;
   vertical-align: top;
 }
 
 .result-table th {
-  background: rgba(9, 17, 29, 0.98);
+  background: rgba(10, 16, 27, 0.98);
   color: var(--hx-accent-strong);
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
+  font-family: 'IBM Plex Mono', monospace;
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
+  font-weight: 500;
 }
 
-.result-table tbody tr:nth-child(even) {
-  background: rgba(255, 255, 255, 0.02);
-}
-
-.result-table tbody tr:hover {
-  background: rgba(104, 173, 255, 0.06);
-}
+.result-table tbody tr:nth-child(even) { background: rgba(255, 255, 255, 0.015); }
+.result-table tbody tr:hover { background: rgba(99, 159, 245, 0.04); }
 
 @media (max-width: 1180px) {
-  .panel,
-  .tac-panel,
-  .panel-span-7,
-  .panel-span-6,
-  .panel-span-5,
-  .panel-span-4,
-  .panel-span-3,
-  .span-8,
-  .span-6,
-  .span-4,
-  .span-3 {
+  .panel, .tac-panel,
+  .panel-span-7, .panel-span-6, .panel-span-5, .panel-span-4, .panel-span-3,
+  .span-8, .span-6, .span-4, .span-3 {
     grid-column: span 6;
   }
-
-  .panel-span-12,
-  .span-12,
-  .panel-hero {
-    grid-column: 1 / -1;
-  }
+  .panel-span-12, .span-12, .panel-hero { grid-column: 1 / -1; }
 }
 
 @media (max-width: 1024px) {
-  .tac-topbar {
-    padding: 0 var(--hx-space-4);
-  }
+  .tac-topbar { padding: 0 var(--hx-space-4); }
+  .topbar-menu { display: inline-flex; }
+  .topbar-collapse { display: none; }
+  .brand-version { display: none; }
+  .topbar-telemetry { gap: var(--hx-space-2); }
 
-  .topbar-menu {
-    display: inline-flex;
-  }
-
-  .topbar-collapse {
-    display: none;
-  }
-
-  .brand-version {
-    display: none;
-  }
-
-  .topbar-telemetry {
-    gap: var(--hx-space-2);
-  }
-
-  .tac-main-grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  .tac-main-grid.sidebar-collapsed {
+  .tac-main-grid, .tac-main-grid.sidebar-collapsed {
     grid-template-columns: minmax(0, 1fr);
   }
 
@@ -1132,16 +2052,14 @@ a {
     top: var(--hx-topbar-height);
     bottom: 0;
     left: 0;
-    width: min(84vw, 320px);
+    width: min(84vw, 300px);
     transform: translateX(-104%);
     transition: transform 220ms ease;
     z-index: 40;
     box-shadow: var(--hx-shadow);
   }
 
-  .tac-sidebar.is-open {
-    transform: translateX(0);
-  }
+  .tac-sidebar.is-open { transform: translateX(0); }
 
   .tac-sidebar.is-collapsed .group-label,
   .tac-sidebar.is-collapsed .nav-text,
@@ -1153,7 +2071,7 @@ a {
 
   .tac-sidebar.is-collapsed .tac-nav-link {
     justify-content: flex-start;
-    padding: 0 var(--hx-space-4);
+    padding: 0 var(--hx-space-3);
   }
 
   .sidebar-scrim {
@@ -1162,73 +2080,31 @@ a {
     inset: var(--hx-topbar-height) 0 0 0;
     z-index: 30;
     border: 0;
-    background: rgba(2, 6, 23, 0.52);
+    background: rgba(2, 6, 16, 0.5);
+    backdrop-filter: blur(2px);
   }
 
-  .tac-workspace {
-    padding: var(--hx-space-4);
-  }
-
-  .form-grid {
-    grid-template-columns: 1fr;
-  }
+  .tac-workspace { padding: var(--hx-space-4); }
+  .form-grid { grid-template-columns: 1fr; }
 }
 
 @media (max-width: 720px) {
-  .dashboard-grid,
-  .hud-grid {
-    grid-template-columns: 1fr;
-  }
+  .dashboard-grid, .hud-grid { grid-template-columns: 1fr; }
 
-  .panel,
-  .tac-panel,
-  .panel-span-12,
-  .panel-span-7,
-  .panel-span-6,
-  .panel-span-5,
-  .panel-span-4,
-  .panel-span-3,
+  .panel, .tac-panel,
+  .panel-span-12, .panel-span-7, .panel-span-6, .panel-span-5, .panel-span-4, .panel-span-3,
   .panel-hero,
-  .span-12,
-  .span-8,
-  .span-6,
-  .span-4,
-  .span-3 {
+  .span-12, .span-8, .span-6, .span-4, .span-3 {
     grid-column: 1 / -1;
   }
 
   .tac-topbar {
     align-items: flex-start;
-    padding-top: var(--hx-space-3);
-    padding-bottom: var(--hx-space-3);
+    padding-top: var(--hx-space-2);
+    padding-bottom: var(--hx-space-2);
   }
 
-  .topbar-brand,
-  .topbar-telemetry {
-    gap: var(--hx-space-2);
-  }
-
-  .agent-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .metric-card,
-  .data-block {
-    min-height: 92px;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  *,
-  *::before,
-  *::after {
-    animation-duration: 0.01ms !important;
-    animation-iteration-count: 1 !important;
-    transition-duration: 0.01ms !important;
-    scroll-behavior: auto !important;
-  }
-
-  .tac-scanlines {
-    opacity: 0.12;
-  }
+  .topbar-brand, .topbar-telemetry { gap: var(--hx-space-2); }
+  .agent-grid { grid-template-columns: 1fr; }
+  .metric-card, .data-block { min-height: 80px; }
 }


### PR DESCRIPTION
## Summary

Three major features building on each other:

### 1. Federation Layer (`49850e1`)
- New `helix-federation` crate: `PeerDesk`, `PeerRegistry`, `OutboundDispatcher`, `FederationEvent`, `DispatchLog`
- 6 API endpoints for peer CRUD, dispatch log, manual broadcast, and inbound receive
- Automatic dispatch hooks for evidence ingestion, watchlist hits, case escalation/opening
- `FederationPage.tsx` UI for peer management and dispatch monitoring
- 23 crate unit tests + 6 API integration tests

### 2. LLM Desk Operator (`23688b6`)
- New `helix-operator` crate: `DeskOperatorConfig`, `DeskContext`, `OperatorLoop`
- Observe-think-act loop with deterministic guardrails — the LLM proposes, the guard decides
- Two-gate evaluation: scope check (ObserveOnly/Intelligence/Policy/Full) + autopilot guard (Off/Assist/Auto)
- Proposal parser with fail-closed validation, action mapping for 6 action types
- Bounded activity log for audit
- 7 API endpoints: status, config GET/PUT, start/stop/pause, activity
- `OperatorPage.tsx` with config form, status dashboard, controls, activity log
- 38 crate unit tests + 9 API integration tests

### 3. CoPilot Mode (`a14f4ff`)
- Multi-participant collaboration: any number of humans + AI copilots on one desk
- `session.rs`: OperatorSession with SessionKind (human/ai), SessionRole (viewer/operator/admin), presence tracking
- `registry.rs`: thread-safe session registry with heartbeat and stale pruning
- `confirmation.rs`: ConfirmationQueue for assist-mode AI proposals awaiting human review
- `collaboration.rs`: CollaborationBroadcaster for real-time SSE event streaming
- Loop integration: assist-mode proposals route to confirmation queue, all events broadcast
- 8 new API endpoints: sessions CRUD, heartbeat, confirmations, SSE stream
- UI: join form, active participants table, confirmation queue with confirm/deny
- 30 crate unit tests + 11 API integration tests

#### Test plan
- [x] `cargo test --workspace` — all tests pass (0 failures)
- [x] `npm run build` (UI) — TypeScript + Vite build passes
- [x] Federation integration tests verify peer CRUD and dispatch
- [x] Operator tests verify guard enforcement across all modes
- [x] CoPilot tests verify session lifecycle, confirmation flow, and role permissions

Generated with [Devin](https://devin.ai)